### PR TITLE
Add explicit type conversions to satisfy C++11 requirements.

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -1937,9 +1937,11 @@ void CLASS hasselblad_correct()
         const ushort corners_shift[9] = { 2, 1, 2, 1, 0, 1, 2, 1, 2 };
         for (row = 0; row < bh; row++) {
             const ushort maxdist = bw < bh ? bw/2-1 : bh/2-1;
-            const unsigned corners[9][2] = {{0,0},   {0,bw/2},   {0,bw-1},
-                                            {bh/2,0},{bh/2,bw/2},{bh/2,bw-1},
-                                            {bh-1,0},{bh-1,bw/2},{bh-1,bw-1}};
+            const unsigned bwu = (unsigned)bw;
+            const unsigned bhu = (unsigned)bh;
+            const unsigned corners[9][2] = {{0,0},    {0,bwu/2},    {0,bwu-1},
+                                            {bhu/2,0},{bhu/2,bwu/2},{bhu/2,bwu-1},
+                                            {bhu-1,0},{bhu-1,bwu/2},{bhu-1,bwu-1}};
             for (col = 0; col < bw; col++) {
                 for (i = 0; i < 9; i++) {
                     ushort dist = (ushort)sqrt(abs(corners[i][0] - row) * abs(corners[i][0] - row) + abs(corners[i][1] - col) * abs(corners[i][1] - col));

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2004,9 +2004,9 @@ void ImProcFunctions::ciecam_02float (CieImage* ncie, float adap, int begh, int 
         //matrix for current working space
         TMatrix wiprof = iccStore->workingSpaceInverseMatrix (params->icm.working);
         const float wip[3][3] = {
-            {wiprof[0][0], wiprof[0][1], wiprof[0][2]},
-            {wiprof[1][0], wiprof[1][1], wiprof[1][2]},
-            {wiprof[2][0], wiprof[2][1], wiprof[2][2]}
+            {(float)wiprof[0][0], (float)wiprof[0][1], (float)wiprof[0][2]},
+            {(float)wiprof[1][0], (float)wiprof[1][1], (float)wiprof[1][2]},
+            {(float)wiprof[2][0], (float)wiprof[2][1], (float)wiprof[2][2]}
         };
 
 #ifdef __SSE2__

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -2744,7 +2744,9 @@ void RawImageSource::processFlatField(const RAWParams &raw, RawImage *riFlatFile
  */
 void RawImageSource::copyOriginalPixels(const RAWParams &raw, RawImage *src, RawImage *riDark, RawImage *riFlatFile )
 {
-    unsigned short black[4] = {ri->get_cblack(0), ri->get_cblack(1), ri->get_cblack(2), ri->get_cblack(3)};
+    unsigned short black[4] = {
+            (unsigned short)ri->get_cblack(0), (unsigned short)ri->get_cblack(1),
+            (unsigned short)ri->get_cblack(2), (unsigned short)ri->get_cblack(3)};
 
     if (ri->getSensorType() == ST_BAYER || ri->getSensorType() == ST_FUJI_XTRANS) {
         if (!rawData) {
@@ -4217,7 +4219,10 @@ void RawImageSource::getRAWHistogram (LUTu & histRedRaw, LUTu & histGreenRaw, LU
     histRedRaw.clear();
     histGreenRaw.clear();
     histBlueRaw.clear();
-    const float mult[4] = { 65535.0 / ri->get_white(0), 65535.0 / ri->get_white(1), 65535.0 / ri->get_white(2), 65535.0 / ri->get_white(3) };
+    const float mult[4] = { 65535.0f / ri->get_white(0),
+                            65535.0f / ri->get_white(1),
+                            65535.0f / ri->get_white(2),
+                            65535.0f / ri->get_white(3) };
 
 #ifdef _OPENMP
     int numThreads;


### PR DESCRIPTION
Follow up on https://github.com/Beep6581/RawTherapee/pull/2960 but split out from the Halide work.

Seems to be in the same vein as https://github.com/Beep6581/RawTherapee/pull/2935.

Summary of motivation:

 `glibmm` 2.4 and `sigc++` 2.6.1 (a `glibmm` dependency) both use C++11 features in their header files. Without the `-std=c++1y` flag on compilation, RawTherapee fails to compile, at least using Clang (the following example is a small snippet) but likely with `g++` as well:

```
/usr/local/Cellar/libsigc++/2.6.1/include/sigc++-2.0/sigc++/functors/slot.h:737:21: error: expected ';' at end of declaration list
  slot3(slot3&& src) noexcept
                    ^
                    ;
/usr/local/Cellar/libsigc++/2.6.1/include/sigc++-2.0/sigc++/functors/slot.h:835:14: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
  slot4(slot4&& src) noexcept
```

On the other hand, C++11 doesn't allow implicit narrowing conversions, which RT makes (limited) use of, so RT fails to compile _with_ the `-std=c++1y` flag a well. This commit simply makes the conversions explicit so that RT is C++11 compatible.

All the \*mm projects and `sigc++` [have moved to C++ 11](http://www.murrayc.com/permalink/2015/07/31/gtkmm-now-uses-c11/) so fixing these things seems necessary, if not now then at some point in the future.