### PR TITLE
Remove double-checked locking pattern in the cache manager singleton

### DIFF
--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -30,18 +30,8 @@
 CacheManager*
 CacheManager::getInstance(void)
 {
-    static CacheManager* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new CacheManager();
-        }
-    }
-
-    return instance_;
+    static CacheManager instance_;
+    return &instance_;
 }
 
 void CacheManager::init ()


### PR DESCRIPTION
The cache manager and a lot of other lazily initialized singletons within the RT code base currently use the [double-checked locking (anti-)pattern](http://www.aristeia.com/Papers/DDJ_Jul_Aug_2004_revised.pdf) trying to minimize the cost of thread safe access to global state. Leaving aside whether some these singletons should not be global or could just as well be initialized greedily on program start, they currently do not use the necessary memory barriers to make this properly thread safe.

One of the benefits of the C++11 memory model is that lazy initialization of local static variables is now guaranteed to be thread safe, so using a conforming compiler the pattern can just be replaced by a local variable with static storage duration. And even when not in C++11 mode, GCC does this reliably since version 4.3 when not explicitly disabled via ``-fno-threadsafe-statics``. (Looking at the example changed in this thread, the mutex that protects the static local variable is itself a static local variable whose constructor would need concurrency control. Hence my guess is that the above GCC features is currently what actually makes the code work reliably. But then again, this implies that we currently do the locking twice which somewhat weakens the optimization.)

Personally, I would like to mandate C++11 support for the code base, possibly on the level of what is available in GCC 4.6, and modify all thread safe singletons as described in this change. Of course, initializing them at program start or fully removing the global might be a better solution in some places (like with the cache manager which actually seems to have a trivial constructor and could be initialized greedily).