### PR TITLE
Fix some of the leaks found by starting with GCC's leak sanitizer

### DIFF
--- a/rtexif/rtexif.h
+++ b/rtexif/rtexif.h
@@ -306,8 +306,6 @@ public:
 class ExifManager
 {
 
-    static std::vector<Tag*> defTags;
-
     static Tag* saveCIFFMNTag (FILE* f, TagDirectory* root, int len, const char* name);
 public:
     static TagDirectory* parse (FILE*f, int base, bool skipIgnored = true);
@@ -316,7 +314,10 @@ public:
     static TagDirectory* parseCIFF (FILE* f, int base, int length);
     static void          parseCIFF (FILE* f, int base, int length, TagDirectory* root);
 
-    static const std::vector<Tag*>& getDefaultTIFFTags (TagDirectory* forthis);
+    /// @brief Get default tag for TIFF
+    /// @param forthis The byte order will be taken from the given directory.
+    /// @return The ownership of the return tags is passed to the caller.
+    static std::vector<Tag*> getDefaultTIFFTags (TagDirectory* forthis);
     static int    createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char* buffer);
     static int    createTIFFHeader (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, int bps, const char* profiledata, int profilelen, const char* iptcdata, int iptclen, unsigned char* buffer);
 };

--- a/rtgui/coordinateadjuster.cc
+++ b/rtgui/coordinateadjuster.cc
@@ -103,6 +103,12 @@ CoordinateAdjuster::CoordinateAdjuster(CoordinateProvider *provider, CurveEditor
     createWidgets(defaultAxis);
 }
 
+CoordinateAdjuster::~CoordinateAdjuster()
+{
+    for (std::vector<AxisAdjuster*>::iterator iterator = axisAdjusters.begin(); iterator != axisAdjusters.end(); ++iterator)
+        delete *iterator;
+}
+
 void CoordinateAdjuster::createWidgets(const std::vector<Axis> &axis)
 {
     unsigned int count = axis.size();

--- a/rtgui/coordinateadjuster.h
+++ b/rtgui/coordinateadjuster.h
@@ -136,7 +136,7 @@ public:
     /// For more complex adjuster
     CoordinateAdjuster(CoordinateProvider *provider, CurveEditorSubGroup *parent, const std::vector<Axis> &axis);
 
-    virtual ~CoordinateAdjuster() {}
+    virtual ~CoordinateAdjuster();
 
     // Update the Axis list, e.g. on Curve change, but MUST have the same axis count
     void setAxis(const std::vector<Axis> &axis);

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -516,7 +516,6 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     lastSaveAsFileName = removeExtension (Glib::path_get_basename (fname));
 
     previewHandler = new PreviewHandler ();
-    previewHandler2 = new PreviewHandler ();
 
     this->isrc = isrc;
     ipc = rtengine::StagedImageProcessor::create (isrc);

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -87,7 +87,6 @@ protected:
     ImageAreaPanel* iareapanel;
     PreviewHandler* previewHandler;
     PreviewHandler* beforePreviewHandler;   // for the before-after view
-    PreviewHandler* previewHandler2;
     Navigator* navigator;
     ImageAreaPanel* beforeIarea;    // for the before-after view
     Gtk::VBox* beforeBox;

--- a/rtgui/exifpanel.cc
+++ b/rtgui/exifpanel.cc
@@ -156,14 +156,17 @@ void ExifPanel::setImageData (const ImageMetaData* id)
     idata = id;
     exifTreeModel->clear ();
 
-    const std::vector<Tag*>& defTags = ExifManager::getDefaultTIFFTags (NULL);
+    const std::vector<Tag*> defTags = ExifManager::getDefaultTIFFTags (NULL);
 
-    for (size_t i = 0; i < defTags.size(); i++)
-        if (defTags[i]->nameToString() == "ImageWidth" || defTags[i]->nameToString() == "ImageHeight" || defTags[i]->nameToString() == "BitsPerSample") {
-            addTag (exifTreeModel->children(), defTags[i]->nameToString(), "?", AC_SYSTEM, false);
+    for (size_t i = 0; i < defTags.size(); i++) {
+        Tag* defTag = defTags[i];
+        if (defTag->nameToString() == "ImageWidth" || defTag->nameToString() == "ImageHeight" || defTag->nameToString() == "BitsPerSample") {
+            addTag (exifTreeModel->children(), defTag->nameToString(), "?", AC_SYSTEM, false);
         } else {
-            addTag (exifTreeModel->children(), defTags[i]->nameToString(), defTags[i]->valueToString(), AC_SYSTEM, false);
+            addTag (exifTreeModel->children(), defTag->nameToString(), defTag->valueToString(), AC_SYSTEM, false);
         }
+        delete defTag;
+    }
 
     if (id && id->getExifData ()) {
 //        id->getExifData ()->printAll ();


### PR DESCRIPTION
Starting, opening a folder in file browser, then an image in editor and closing RT will produce a rather lengthy log when linking with `-fsanitize=leak` which will intercept calls to `malloc` and `free` as explained in the [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#index-fsanitize_003dleak-684).

This PR tries to fix three of the reported leaks as they at least seemed to be the most straight-forward:
* The leak in the coordinate adjuster looks genuine.
* The leaked `previewHandler2` looks like an unused variable.
* The leak in `getDefaultTIFFTags` is probably just due to using a static instance of `std::vector<Tag*>` to do a manual return-value-optimization. But since the content of this collection is newly created for each call, the time to copy these 12 pointers is surely dwarfed by time to actually allocate those objects. Hence I opted to to replace the global state by passing the vector by value using named-return-value-optimization.

The cursors allocated in `CursorManager::init` are also reported leaked which could probably prevented by explicitly deleting them in a destructor or using reference-counted managed pointers. But this is probably just a question of style since this looks like explicit global state. The other leaks reported either seem to be rooted in external libraries or involve more complicated object life cycle issues.