### PR TITLE
Continue to simplify and improve singletons

### DIFF
--- a/rtengine/camconst.cc
+++ b/rtengine/camconst.cc
@@ -683,29 +683,22 @@ CameraConstantsStore::CameraConstantsStore()
 {
 }
 
-static CameraConstantsStore *global_instance;
-
-void CameraConstantsStore::initCameraConstants(Glib::ustring baseDir, Glib::ustring userSettingsDir)
+void CameraConstantsStore::init(Glib::ustring baseDir, Glib::ustring userSettingsDir)
 {
-    if (global_instance) {
-        // should only be called once during init.
-        abort();
-    }
-
-    global_instance = new CameraConstantsStore();
-    global_instance->parse_camera_constants_file(Glib::build_filename(baseDir, "camconst.json"));
+    parse_camera_constants_file(Glib::build_filename(baseDir, "camconst.json"));
 
     Glib::ustring userFile(Glib::build_filename(userSettingsDir, "camconst.json"));
 
     if (safe_file_test(userFile, Glib::FILE_TEST_EXISTS)) {
-        global_instance->parse_camera_constants_file(userFile);
+        parse_camera_constants_file(userFile);
     }
 }
 
 CameraConstantsStore *
 CameraConstantsStore::getInstance(void)
 {
-    return global_instance;
+    static CameraConstantsStore instance_;
+    return &instance_;
 }
 
 CameraConst *

--- a/rtengine/camconst.h
+++ b/rtengine/camconst.h
@@ -54,7 +54,7 @@ private:
     bool parse_camera_constants_file(Glib::ustring filename);
 
 public:
-    static void initCameraConstants(Glib::ustring baseDir, Glib::ustring userSettingsDir);
+    void init(Glib::ustring baseDir, Glib::ustring userSettingsDir);
     static CameraConstantsStore *getInstance(void);
     CameraConst *get(const char make[], const char model[]);
 };

--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -1691,18 +1691,8 @@ void DCPProfile::step2ApplyTile(float *rc, float *gc, float *bc, int width, int 
 // Generates as singleton
 DCPStore* DCPStore::getInstance()
 {
-    static DCPStore* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new DCPStore();
-        }
-    }
-
-    return instance_;
+    static DCPStore instance_;
+    return &instance_;
 }
 
 // Reads all profiles from the given profiles dir

--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -192,18 +192,8 @@ ICCStore::makeStdGammaProfile(cmsHPROFILE iprof)
 ICCStore*
 ICCStore::getInstance(void)
 {
-    static ICCStore* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new ICCStore();
-        }
-    }
-
-    return instance_;
+    static ICCStore instance_;
+    return &instance_;
 }
 
 ICCStore::ICCStore ()

--- a/rtengine/init.cc
+++ b/rtengine/init.cc
@@ -46,7 +46,7 @@ int init (const Settings* s, Glib::ustring baseDir, Glib::ustring userSettingsDi
 
     dcpStore->init (baseDir + "/dcpprofiles");
 
-    CameraConstantsStore::initCameraConstants (baseDir, userSettingsDir);
+    CameraConstantsStore::getInstance ()->init (baseDir, userSettingsDir);
     profileStore.init ();
     ProcParams::init ();
     Color::init ();

--- a/rtengine/lcp.cc
+++ b/rtengine/lcp.cc
@@ -781,18 +781,8 @@ void XMLCALL LCPProfile::XmlEndHandler(void *pLCPProfile, const char *el)
 // Generates as singleton
 LCPStore* LCPStore::getInstance()
 {
-    static LCPStore* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new LCPStore();
-        }
-    }
-
-    return instance_;
+    static LCPStore instance_;
+    return &instance_;
 }
 
 LCPProfile* LCPStore::getProfile (Glib::ustring filename)

--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -30,18 +30,8 @@
 CacheManager*
 CacheManager::getInstance(void)
 {
-    static CacheManager* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new CacheManager();
-        }
-    }
-
-    return instance_;
+    static CacheManager instance_;
+    return &instance_;
 }
 
 void CacheManager::init ()

--- a/rtgui/extprog.cc
+++ b/rtgui/extprog.cc
@@ -74,18 +74,8 @@ bool ExtProgAction::Execute(std::vector<Glib::ustring> fileNames)
 // Generates as singleton
 ExtProgStore* ExtProgStore::getInstance()
 {
-    static ExtProgStore* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == 0 ) {
-            instance_ = new ExtProgStore();
-        }
-    }
-
-    return instance_;
+    static ExtProgStore instance_;
+    return &instance_;
 }
 
 ExtProgStore::~ExtProgStore()

--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -168,19 +168,8 @@ PreviewLoader::PreviewLoader():
 
 PreviewLoader* PreviewLoader::getInstance(void)
 {
-    // this will not be deleted...
-    static PreviewLoader* instance_ = NULL;
-
-    if ( instance_ == NULL ) {
-        static MyMutex smutex_;
-        MyMutex::MyLock lock(smutex_);
-
-        if ( instance_ == NULL ) {
-            instance_ = new PreviewLoader();
-        }
-    }
-
-    return instance_;
+    static PreviewLoader instance_;
+    return &instance_;
 }
 
 void PreviewLoader::add(int dir_id, const Glib::ustring& dir_entry, PreviewLoaderListener* l)

--- a/rtgui/thumbimageupdater.cc
+++ b/rtgui/thumbimageupdater.cc
@@ -192,14 +192,8 @@ public:
 ThumbImageUpdater*
 ThumbImageUpdater::getInstance(void)
 {
-    // this will not be deleted...
-    static ThumbImageUpdater* instance_ = 0;
-
-    if ( instance_ == 0 ) {
-        instance_ = new ThumbImageUpdater();
-    }
-
-    return instance_;
+    static ThumbImageUpdater instance_;
+    return &instance_;
 }
 
 ThumbImageUpdater::ThumbImageUpdater():


### PR DESCRIPTION
Based on PR #2975, this change tries to apply the same changes to other singletons found by searching for methods named `getInstance`. Most simplifications are as straight-forward as the cache manager.

For the editor window, it is probably debatable whether the `EditWindowInstance` type is really necessary or whether the monitor selection logic should just be folded into the constructor of `EditWindow`.

The commit concerning the camera constant should probably be considered optional as initialization is just handled differently from the other singletons and the commit only regularizes this but does not really fix anything (except if one considers the fact that `getInstance` could return a null pointer a problem which also seems to be based on the fact that uninitialized static variables are zero'ed when the program is loaded instead of explicit initialization).