### PR TITLE
Add '-std=c++11' if libsigc++ depends on it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,10 +278,10 @@ if (OPTION_OMP)
     endif (OPENMP_FOUND)
 endif (OPTION_OMP)
 
-if(USE_EXPERIMENTAL_LANG_VERSIONS)
+if(USE_EXPERIMENTAL_LANG_VERSIONS OR NOT (SIGC_VERSION VERSION_LESS 2.5.1))
 	SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu1x")
 	SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
-endif (USE_EXPERIMENTAL_LANG_VERSIONS)
+endif ()
 
 # find out whether we are building out of source
 get_filename_component(ABS_SOURCE_DIR "${PROJECT_SOURCE_DIR}" ABSOLUTE)


### PR DESCRIPTION
Turns out my comment on #2744 was not correct and `pkg-config --cflags sigc++-2.0` does not include the necessary language support compiler flags. However the [libsigc++ project](http://libsigc.sourceforge.net/) itself states that version 2.5.1 or later definitely depends on C++11 support and it seems does not build without it, at least on a current [Arch Linux](https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/rawtherapee). Hence I suggest this change to enable the necessary flag if explicitly requested or if such a version of libsigc++ is detected.