### PR TITLE
Optionally enable link-time optimizations in the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ if (APPLE)
 endif (APPLE)
 
 option(USE_EXPERIMENTAL_LANG_VERSIONS "Build RT with -std=c++0x" OFF)
+option(USE_EXPERIMENTAL_OPTIMIZATIONS "Build RT with -flto" OFF)
 option (BUILD_SHARED "Build rawtherapee with shared libraries" OFF)
 option (WITH_BZIP "Build with Bzip2 support" ON)
 option (WITH_MYFILE_MMAP "Build using memory mapped file" ON)
@@ -281,6 +282,12 @@ endif (OPTION_OMP)
 if(USE_EXPERIMENTAL_LANG_VERSIONS OR NOT (SIGC_VERSION VERSION_LESS 2.5.1))
 	SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu1x")
 	SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
+endif ()
+
+if(USE_EXPERIMENTAL_OPTIMIZATIONS)
+        SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
+        SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+        SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
 endif ()
 
 # find out whether we are building out of source


### PR DESCRIPTION
I do not know if any experience with [LTO](https://gcc.gnu.org/onlinedocs/gccint/LTO.html) does exist for the RT code base, but as any complex C++ application it should benefit significantly from LTO due to the importance of inlining. (It also allows one to write better encapsulated code, as one is not as pressed to expose implementation details in the headers for inlining purposes.)
Doing a debug build and running them program yields no immediate crashes, but highly optimized code like that of `rtengine` might show regressions after enabling this, so I put it behind a build-time flag. I also did a release build and developed a DNG using the neutral profile without obvious problems.
Of course, this also depends on a rather recent version of GCC (I tested using version 5.2.0) and it does add quite a bit of non-parallelizable build-time (on my machine, a full debug build goes from 6 to 7 minutes and full release build takes 12 minutes with more than half of that spent for finally linking the executable), but since compiler optimizations are almost free from a developer's perspective, it should be worth it.