### PR TITLE
Mandate C++11 support and GCC version 4.9 or higher on the Gtk3 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,16 @@
-if (WIN32)
-  cmake_minimum_required(VERSION 2.8.4)
-else (WIN32)
-  cmake_minimum_required(VERSION 2.6)
-endif (WIN32)
+cmake_minimum_required(VERSION 3.1)
 
 PROJECT(RawTherapee)
+
+# set required C and C++ standards and check GCC version
+SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
+    message(WARNING "RawTherapee should be built using GCC version 4.9 or higher!")
+  endif()
+endif()
 
 # the default target is 'Debug'
 if (CMAKE_BUILD_TYPE STREQUAL "")
@@ -12,16 +18,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
 endif ()
 
 string (TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
-
-# assuming that Linux and Apple users will have gtk2 built by their installed gcc
-if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  if (GCC_VERSION VERSION_GREATER 5.0 OR GCC_VERSION VERSION_EQUAL 5.0)
-    #message(STATUS "Gcc Version >= 5.0 ; adding -D_GLIBCXX_USE_CXX11_ABI=0 to build with Gtk2")
-    #add_definitions (-D_GLIBCXX_USE_CXX11_ABI=0)
-	# see here : https://gcc.gnu.org/gcc-5/changes.html#libstdcxx
-  endif()
-endif()
 
 if (UPPER_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
   add_definitions (-D_DEBUG)
@@ -90,15 +86,14 @@ if (APPLE)
     endif ()
 endif (APPLE)
 
-option(USE_EXPERIMENTAL_LANG_VERSIONS "Build RT with -std=c++0x" OFF)
 option (BUILD_SHARED "Build rawtherapee with shared libraries" OFF)
 option (WITH_BZIP "Build with Bzip2 support" ON)
 option (WITH_MYFILE_MMAP "Build using memory mapped file" ON)
+option (WITH_LTO "Build with link-time optimizations" OFF)
 option (OPTION_OMP "Build with OpenMP support" ON)
 option (PROTECT_VECTORS "Protect critical vectors by custom R/W Mutex, recommanded even if your std::vector is thread safe" ON)
 option (STRICT_MUTEX "True (recommended): MyMutex will behave like POSIX Mutex; False: MyMutex will behave like POSIX RecMutex; Note: forced to ON for Debug builds" ON)
 option (TRACE_MYRWMUTEX "Trace RT's custom R/W Mutex (Debug builds only); redirecting std::out to a file is strongly recommended!" OFF)
-option (AUTO_GDK_FLUSH "Use gdk_flush on all gdk_thread_leave other than the GUI thread; set it ON if you experience X Server warning/errors" OFF)
 
 # set install directories
 if (WIN32 OR APPLE)
@@ -212,12 +207,6 @@ else (TRACE_MYRWMUTEX)
     add_definitions (-DTRACE_MYRWMUTEX=0)
 endif (TRACE_MYRWMUTEX)
 
-if (AUTO_GDK_FLUSH)
-    add_definitions (-DAUTO_GDK_FLUSH=1)
-else (AUTO_GDK_FLUSH)
-    add_definitions (-DAUTO_GDK_FLUSH=0)
-endif (AUTO_GDK_FLUSH)
-
 # check for libraries
 find_package(PkgConfig)
 pkg_check_modules (GTK     REQUIRED gtk+-3.0>=3.16)
@@ -271,17 +260,18 @@ if (WITH_MYFILE_MMAP)
 	add_definitions (-DMYFILE_MMAP)
 endif (WITH_MYFILE_MMAP)
 
+if (WITH_LTO)
+    SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto")
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+    SET (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto")
+endif (WITH_LTO)
+
 if (OPTION_OMP)
     find_package(OpenMP)
     if (OPENMP_FOUND)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -Werror=unknown-pragmas")
     endif (OPENMP_FOUND)
 endif (OPTION_OMP)
-
-if(USE_EXPERIMENTAL_LANG_VERSIONS OR NOT (SIGC_VERSION VERSION_LESS 2.5.1))
-	SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu1x")
-	SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
-endif ()
 
 # find out whether we are building out of source
 get_filename_component(ABS_SOURCE_DIR "${PROJECT_SOURCE_DIR}" ABSOLUTE)

--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -21,10 +21,6 @@
 #include <glib/gstdio.h>
 #include "safegtk.h"
 
-#ifndef GLIBMM_EXCEPTIONS_ENABLED
-#include <memory>
-#endif
-
 using namespace rtengine;
 
 extern "C" IptcData *iptc_data_new_from_jpeg_file (FILE* infile);

--- a/rtengine/safegtk.cc
+++ b/rtengine/safegtk.cc
@@ -83,7 +83,7 @@ Glib::RefPtr<Gio::FileInfo> safe_query_file_info (Glib::RefPtr<Gio::File> &file)
     } catch (...) {  }
 
 #else
-    std::auto_ptr<Glib::Error> error;
+    std::unique_ptr<Glib::Error> error;
     info = file->query_info("*", Gio::FILE_QUERY_INFO_NONE, error);
 #endif
     return info;
@@ -119,7 +119,7 @@ Glib::RefPtr<Gio::FileInfo> safe_next_file (Glib::RefPtr<Gio::FileEnumerator> &d
 
     do {
         retry = false;
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         Glib::RefPtr<Gio::Cancellable> cancellable;
         info = dirList->next_file(cancellable, error);
 
@@ -143,7 +143,7 @@ Glib::RefPtr<Gio::FileInfo> safe_next_file (Glib::RefPtr<Gio::FileEnumerator> &d
                 }}  catch (Glib::Exception& ex) {   printf ("%s\n", ex.what().c_str()); }}while(0)
 #else
 # define SAFE_ENUMERATOR_CODE_START \
-                do{std::auto_ptr<Glib::Error> error;    Glib::RefPtr<Gio::Cancellable> cancellable; \
+                do{std::unique_ptr<Glib::Error> error;    Glib::RefPtr<Gio::Cancellable> cancellable; \
                     if ((dirList = dir->enumerate_children (cancellable, "*", Gio::FILE_QUERY_INFO_NONE, error))) \
                         for (Glib::RefPtr<Gio::FileInfo> info = safe_next_file(dirList); info; info = safe_next_file(dirList)) {
 
@@ -287,7 +287,7 @@ Glib::ustring safe_filename_to_utf8 (const std::string& src)
 
 #else
     {
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         utf8_str = locale_to_utf8(src, error);
 
         if (error.get()) {
@@ -314,7 +314,7 @@ Glib::ustring safe_locale_to_utf8 (const std::string& src)
 
 #else
     {
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         utf8_str = locale_to_utf8(src, error);
 
         if (error.get()) {
@@ -338,7 +338,7 @@ std::string safe_locale_from_utf8 (const Glib::ustring& utf8_str)
 
 #else
     {
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         str = Glib::locale_from_utf8(utf8_str, error);
         /*if (error.get())
             {str = Glib::convert_with_fallback(utf8_str, "ISO-8859-1", "UTF-8", "?", error);}*/
@@ -363,7 +363,7 @@ bool safe_spawn_command_line_async (const Glib::ustring& cmd_utf8)
     }
 
 #else
-    std::auto_ptr<Glib::Error> error;
+    std::unique_ptr<Glib::Error> error;
     cmd = Glib::filename_from_utf8(cmd_utf8, error);
 
     if (!error.get())   {

--- a/rtengine/safekeyfile.h
+++ b/rtengine/safekeyfile.h
@@ -15,7 +15,7 @@ public :
                      return res; }while(0)
 #else
 #define SAFE_KEY_FILE_METHOD_CODE(method,method_err) \
-            do { std::auto_ptr<Glib::Error> error; \
+            do { std::unique_ptr<Glib::Error> error; \
                 res = Glib::KeyFile::method_err; \
                 if (error.get()){/* TODO */}; \
                 return res;} while(0)

--- a/rtgui/darkframe.h
+++ b/rtgui/darkframe.h
@@ -39,7 +39,7 @@ class DarkFrame : public ToolParamBlock, public FoldableToolPanel
 protected:
 
     MyFileChooserButton *darkFrameFile;
-    std::auto_ptr<FileChooserLastFolderPersister> darkFrameFilePersister;
+    std::unique_ptr<FileChooserLastFolderPersister> darkFrameFilePersister;
     Gtk::HBox *hbdf;
     Gtk::Button *btnReset;
     Gtk::Label *dfLabel;

--- a/rtgui/editwindow.cc
+++ b/rtgui/editwindow.cc
@@ -61,20 +61,12 @@ EditWindow::EditWindow (RTWindow* p) : parent(p) , isFullscreen(false)
     Glib::ustring fName = "rt-logo-tiny.png";
     Glib::ustring fullPath = RTImage::findIconAbsolutePath(fName);
 
-#ifdef GLIBMM_EXCEPTIONS_ENABLED
-
     try {
         set_default_icon_from_file (fullPath);
     } catch(Glib::Exception& ex) {
         printf ("%s\n", ex.what().c_str());
     }
 
-#else
-    {
-        std::unique_ptr<Glib::Error> error;
-        set_default_icon_from_file (fullPath, error);
-    }
-#endif //GLIBMM_EXCEPTIONS_ENABLED
     set_title_decorated("");
     set_modal(false);
     set_resizable(true);

--- a/rtgui/editwindow.cc
+++ b/rtgui/editwindow.cc
@@ -71,7 +71,7 @@ EditWindow::EditWindow (RTWindow* p) : parent(p) , isFullscreen(false)
 
 #else
     {
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         set_default_icon_from_file (fullPath, error);
     }
 #endif //GLIBMM_EXCEPTIONS_ENABLED

--- a/rtgui/flatfield.h
+++ b/rtgui/flatfield.h
@@ -41,7 +41,7 @@ class FlatField : public ToolParamBlock, public AdjusterListener, public Foldabl
 protected:
 
     MyFileChooserButton *flatFieldFile;
-    std::auto_ptr<FileChooserLastFolderPersister> flatFieldFilePersister;
+    std::unique_ptr<FileChooserLastFolderPersister> flatFieldFilePersister;
     Gtk::Label *ffLabel;
     Gtk::Label *ffInfo;
     Gtk::Button *flatFieldFileReset;

--- a/rtgui/icmpanel.h
+++ b/rtgui/icmpanel.h
@@ -82,7 +82,7 @@ private:
     Gtk::RadioButton*  ofromfile;
     Gtk::RadioButton*  iunchanged;
     MyFileChooserButton* ipDialog;
-    std::auto_ptr<FileChooserLastFolderPersister> ipDialogPersister;
+    std::unique_ptr<FileChooserLastFolderPersister> ipDialogPersister;
     Gtk::RadioButton::Group opts;
     Gtk::Button*        saveRef;
     sigc::connection   ipc;

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -67,7 +67,6 @@ bool simpleEditor;
 Glib::RefPtr<Gtk::CssProvider> cssBase;
 Glib::RefPtr<Gtk::CssProvider> cssForced;
 Glib::RefPtr<Gtk::CssProvider> cssRT;
-//Glib::Threads::Thread* mainThread;
 
 
 // This recursive mutex will be used by gdk_threads_enter/leave instead of a simple mutex
@@ -83,13 +82,6 @@ static void myGdkLockEnter()
 }
 static void myGdkLockLeave()
 {
-    // Automatic gdk_flush for non main tread
-#if AUTO_GDK_FLUSH
-    //if (Glib::Thread::self() != mainThread) {
-    //    gdk_flush();
-    //}
-
-#endif
     myGdkRecMutex.unlock();
 }
 

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -105,7 +105,7 @@ RTWindow::RTWindow ()
 
 #else
     {
-        std::auto_ptr<Glib::Error> error;
+        std::unique_ptr<Glib::Error> error;
         set_default_icon_from_file (fullPath, error);
     }
 #endif //GLIBMM_EXCEPTIONS_ENABLED

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -95,20 +95,11 @@ RTWindow::RTWindow ()
     Glib::ustring fName = "rt-logo-small.png";
     Glib::ustring fullPath = RTImage::findIconAbsolutePath(fName);
 
-#ifdef GLIBMM_EXCEPTIONS_ENABLED
-
     try {
         set_default_icon_from_file (fullPath);
     } catch(Glib::Exception& ex) {
         printf ("%s\n", ex.what().c_str());
     }
-
-#else
-    {
-        std::unique_ptr<Glib::Error> error;
-        set_default_icon_from_file (fullPath, error);
-    }
-#endif //GLIBMM_EXCEPTIONS_ENABLED
 
 #if defined(__APPLE__)
     {


### PR DESCRIPTION
This takes up @Hombre57's changes replacing `std::auto_ptr` by `std::unique_ptr` on the `gtk3` branch and adds mandating C++14 support via the build system. It also checks but for now only warns if the GCC version used is lower than 5.0. It also removes all references to `GLIBMM_EXCEPTIONS_ENABLED` as Glib version 3 does not seem to support to disabling exceptions anymore and will unconditionally define this. This actually removes most of our usage of `std::auto_ptr`. The other points of use are extended to make use of `std::make_unique`.