### PR TITLE
Fix the number of files displayed in the file browser tab title being…

### DIFF
--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1721,6 +1721,11 @@ void FileCatalog::reparseDirectory ()
     for (size_t i = 0; i < fileNamesToDel.size(); i++) {
         delete fileBrowser->delEntry (fileNamesToDel[i]);
         cacheMgr->deleteEntry (fileNamesToDel[i]);
+        previewsLoaded--;
+    }
+
+    if (!fileNamesToDel.empty ()) {
+        _refreshProgressBar();
     }
 
     // check if a new file has been added


### PR DESCRIPTION
… wrong after removal of a file by an external actor.