### PR TITLE
Solving issue #3088 : "Filebrowser's History panel broken"

### DIFF
--- a/rtgui/history.cc
+++ b/rtgui/history.cc
@@ -155,10 +155,9 @@ History::History (bool bookmarkSupport) : blistener(NULL), tpc (NULL), bmnum (1)
 void History::initHistory ()
 {
 
-    selchangehist.block(true);
+    ConnectionBlocker selBlocker(selchangehist);
     historyModel->clear ();
     bookmarkModel->clear ();
-    selchangehist.block(false);
 }
 
 void History::clearParamChanges ()

--- a/rtgui/history.cc
+++ b/rtgui/history.cc
@@ -155,8 +155,10 @@ History::History (bool bookmarkSupport) : blistener(NULL), tpc (NULL), bmnum (1)
 void History::initHistory ()
 {
 
+    selchangehist.block(true);
     historyModel->clear ();
     bookmarkModel->clear ();
+    selchangehist.block(false);
 }
 
 void History::clearParamChanges ()


### PR DESCRIPTION
The `clean` method does throw a `selection_change` event, which was not the case with Gtk2.