### PR TITLE
Prevent treeview background color from being changed by the system theme

### DIFF
--- a/rtdata/themes/09-Gray-Orange.gtkrc
+++ b/rtdata/themes/09-Gray-Orange.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/17-Gray-Red.gtkrc
+++ b/rtdata/themes/17-Gray-Red.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/21-Gray-Gray.gtkrc
+++ b/rtdata/themes/21-Gray-Gray.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 1
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/21-Gray-Orange.gtkrc
+++ b/rtdata/themes/21-Gray-Orange.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 1
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/21-Gray-Purple.gtkrc
+++ b/rtdata/themes/21-Gray-Purple.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 1
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/21-Gray-Red.gtkrc
+++ b/rtdata/themes/21-Gray-Red.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 1
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/25-Gray-Gray.gtkrc
+++ b/rtdata/themes/25-Gray-Gray.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/25-Gray-Purple.gtkrc
+++ b/rtdata/themes/25-Gray-Purple.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/25-Gray-Red.gtkrc
+++ b/rtdata/themes/25-Gray-Red.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/37-Gray-Red-Textured.gtkrc
+++ b/rtdata/themes/37-Gray-Red-Textured.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/37-Gray-Red.gtkrc
+++ b/rtdata/themes/37-Gray-Red.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/63-Gray-Cyan.gtkrc
+++ b/rtdata/themes/63-Gray-Cyan.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0

--- a/rtdata/themes/92-Beige-DarkCyan.gtkrc
+++ b/rtdata/themes/92-Beige-DarkCyan.gtkrc
@@ -53,6 +53,8 @@ style "clearlooks-default" {
 	GtkToolbar::internal-padding = 1
 	GtkTreeView::expander-size = 12
 	GtkTreeView::vertical-separator = 0
+	GtkTreeView::even_row_color = shade(0.97, @rt_base_color)
+	GtkTreeView::odd_row_color = shade(0.9, @rt_base_color)
 
 	GtkMenu::horizontal-padding = 0
 	GtkMenu::vertical-padding = 0


### PR DESCRIPTION
This fixes the issue outlined in https://github.com/Beep6581/RawTherapee/issues/3100 by setting `GtkTreeView::even_row_color` and `GtkTreeView::odd_row_color`.
This prevents the system's default theme from overwriting these values.