### PR TITLE
Fix #3113 by changing the destruction order in the batch queue

### DIFF
--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -39,46 +39,45 @@
 using namespace std;
 using namespace rtengine;
 
-BatchQueue::BatchQueue (FileCatalog* aFileCatalog) : processing(NULL), fileCatalog(aFileCatalog), sequence(0), listener(NULL),
-    pmenu (new Gtk::Menu ())
+BatchQueue::BatchQueue (FileCatalog* aFileCatalog) : processing(NULL), fileCatalog(aFileCatalog), sequence(0), listener(NULL)
 {
 
     location = THLOC_BATCHQUEUE;
 
     int p = 0;
 
-    pmenu->attach (*Gtk::manage(open = new Gtk::MenuItem (M("FILEBROWSER_POPUPOPENINEDITOR"))), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(open = new Gtk::MenuItem (M("FILEBROWSER_POPUPOPENINEDITOR"))), 0, 1, p, p + 1);
     p++;
-    pmenu->attach (*Gtk::manage(selall = new Gtk::MenuItem (M("FILEBROWSER_POPUPSELECTALL"))), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(selall = new Gtk::MenuItem (M("FILEBROWSER_POPUPSELECTALL"))), 0, 1, p, p + 1);
     p++;
-    pmenu->attach (*Gtk::manage(new Gtk::SeparatorMenuItem ()), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(new Gtk::SeparatorMenuItem ()), 0, 1, p, p + 1);
     p++;
 
-    pmenu->attach (*Gtk::manage(head = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPMOVEHEAD"))), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(head = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPMOVEHEAD"))), 0, 1, p, p + 1);
     p++;
     head->set_image(*Gtk::manage(new RTImage ("toleftend.png")));
 
-    pmenu->attach (*Gtk::manage(tail = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPMOVEEND"))), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(tail = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPMOVEEND"))), 0, 1, p, p + 1);
     p++;
     tail->set_image(*Gtk::manage(new RTImage ("torightend.png")));
 
-    pmenu->attach (*Gtk::manage(new Gtk::SeparatorMenuItem ()), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(new Gtk::SeparatorMenuItem ()), 0, 1, p, p + 1);
     p++;
 
-    pmenu->attach (*Gtk::manage(cancel = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPCANCELJOB"))), 0, 1, p, p + 1);
+    pmenu.attach (*Gtk::manage(cancel = new Gtk::ImageMenuItem (M("FILEBROWSER_POPUPCANCELJOB"))), 0, 1, p, p + 1);
     p++;
     cancel->set_image(*Gtk::manage(new RTImage ("gtk-close.png")));
 
-    pmenu->show_all ();
+    pmenu.show_all ();
 
     // Accelerators
     pmaccelgroup = Gtk::AccelGroup::create ();
-    pmenu->set_accel_group (pmaccelgroup);
-    open->add_accelerator ("activate", pmenu->get_accel_group(), GDK_e, Gdk::CONTROL_MASK, Gtk::ACCEL_VISIBLE);
-    selall->add_accelerator ("activate", pmenu->get_accel_group(), GDK_a, Gdk::CONTROL_MASK, Gtk::ACCEL_VISIBLE);
-    head->add_accelerator ("activate", pmenu->get_accel_group(), GDK_Home, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
-    tail->add_accelerator ("activate", pmenu->get_accel_group(), GDK_End, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
-    cancel->add_accelerator ("activate", pmenu->get_accel_group(), GDK_Delete, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
+    pmenu.set_accel_group (pmaccelgroup);
+    open->add_accelerator ("activate", pmaccelgroup, GDK_e, Gdk::CONTROL_MASK, Gtk::ACCEL_VISIBLE);
+    selall->add_accelerator ("activate", pmaccelgroup, GDK_a, Gdk::CONTROL_MASK, Gtk::ACCEL_VISIBLE);
+    head->add_accelerator ("activate", pmaccelgroup, GDK_Home, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
+    tail->add_accelerator ("activate", pmaccelgroup, GDK_End, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
+    cancel->add_accelerator ("activate", pmaccelgroup, GDK_Delete, (Gdk::ModifierType)0, Gtk::ACCEL_VISIBLE);
 
     open->signal_activate().connect(sigc::mem_fun(*this, &BatchQueue::openLastSelectedItemInEditor));
     cancel->signal_activate().connect (std::bind (&BatchQueue::cancelItems, this, std::ref (selected)));
@@ -141,8 +140,7 @@ int BatchQueue::getThumbnailHeight ()
 
 void BatchQueue::rightClicked (ThumbBrowserEntryBase* entry)
 {
-
-    pmenu->popup (3, this->eventTime);
+    pmenu.popup (3, this->eventTime);
 }
 
 void BatchQueue::doubleClicked(ThumbBrowserEntryBase* entry)

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -57,9 +57,8 @@ protected:
     Gtk::ImageMenuItem* tail;
     Gtk::MenuItem* selall;
     Gtk::MenuItem* open;
-    std::unique_ptr<Gtk::Menu> pmenu;
-
     Glib::RefPtr<Gtk::AccelGroup> pmaccelgroup;
+    Gtk::Menu pmenu;
 
     BatchQueueListener* listener;
 


### PR DESCRIPTION
The Gtk+ RTTI warnings described in #3113 seem to be caused by the (reference-counted pointer to the) menu accelerator group being destroyed before the menu to which it is attached. This was introduced by PR #3040 by using a `std::unique_ptr` to reliably destruct the menu itself instead of manually deleting it. This PR reverses the declaration and hence the destruction order. It also removes the unnecessary indirectly allocation and makes the menu a full member of the batch queue widget itself.