### PR TITLE
Modified Preview Canvas

### DIFF
--- a/rtengine/CMakeLists.txt
+++ b/rtengine/CMakeLists.txt
@@ -11,7 +11,7 @@ set (RTENGINESOURCEFILES safegtk.cc colortemp.cc curves.cc flatcurves.cc diagona
     dfmanager.cc ffmanager.cc gauss.cc rawimage.cc image8.cc image16.cc imagefloat.cc imagedata.cc imageio.cc improcfun.cc init.cc dcrop.cc
     loadinitial.cc procparams.cc rawimagesource.cc demosaic_algos.cc shmap.cc simpleprocess.cc refreshmap.cc
     fast_demo.cc amaze_demosaic_RT.cc CA_correct_RT.cc cfa_linedn_RT.cc green_equil_RT.cc hilite_recon.cc expo_before_b.cc
-    stdimagesource.cc myfile.cc iccjpeg.cc hlmultipliers.cc improccoordinator.cc editbuffer.cc coord.cc
+    stdimagesource.cc myfile.cc iccjpeg.cc hlmultipliers.cc improccoordinator.cc pipettebuffer.cc coord.cc
     processingjob.cc rtthumbnail.cc utils.cc labimage.cc slicer.cc cieimage.cc
     iplab2rgb.cc ipsharpen.cc iptransform.cc ipresize.cc ipvibrance.cc
     imagedimensions.cc jpeg_memsrc.cc jdatasrc.cc iimage.cc

--- a/rtengine/coord.h
+++ b/rtengine/coord.h
@@ -187,23 +187,23 @@ public:
     {
         radius *= scale;
     }
-    PolarCoord operator+(PolarCoord & rhs)
+    PolarCoord operator+ (const PolarCoord& rhs) const
     {
+        PolarCoord result;
         Coord thisCoord, rhsCoord;
         thisCoord.setFromPolar(*this);
         rhsCoord.setFromPolar(rhs);
         thisCoord += rhsCoord;
-        PolarCoord result;
         result.setFromCartesian(thisCoord);
         return result;
     }
-    PolarCoord operator-(PolarCoord & rhs)
+    PolarCoord operator- (const PolarCoord& rhs) const
     {
+        PolarCoord result;
         Coord thisCoord, rhsCoord;
         thisCoord.setFromPolar(*this);
         rhsCoord.setFromPolar(rhs);
         thisCoord -= rhsCoord;
-        PolarCoord result;
         result.setFromCartesian(thisCoord);
         return result;
     }

--- a/rtengine/curves.h
+++ b/rtengine/curves.h
@@ -28,7 +28,7 @@
 #include "../rtgui/mydiagonalcurve.h"
 #include "color.h"
 #include "procparams.h"
-#include "editbuffer.h"
+#include "pipettebuffer.h"
 
 #include "LUT.h"
 

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1151,11 +1151,9 @@ bool Crop::setCropSizes (int rcx, int rcy, int rcw, int rch, int skip, bool inte
     }
 
     EditType editType = ET_PIPETTE;
-    EditDataProvider *editProvider = PipetteBuffer::getDataProvider();
-    if (editProvider) {
-        EditSubscriber *editSubscriber = editProvider->getCurrSubscriber();
-        if (editSubscriber) {
-            editType = editSubscriber->getEditingType();
+    if (const auto editProvider = PipetteBuffer::getDataProvider ()) {
+        if (const auto editSubscriber = editProvider->getCurrSubscriber ()) {
+            editType = editSubscriber->getEditingType ();
         }
     }
 
@@ -1241,12 +1239,7 @@ bool Crop::setCropSizes (int rcx, int rcy, int rcw, int rch, int skip, bool inte
     trafx = orx;
     trafy = ory;
 
-
     if (settings->verbose) {
-        if (changed) {
-            printf("new crop size:  cropx=%d, cropy=%d, cropw=%d, croph=%d   /   rqcropx=%d, rqcropy=%d, rqcropw=%d, rqcroph=%d   /   leftBorder=%d, upperBorder=%d\n",
-                    cropx, cropy, cropw, croph, rqcropx, rqcropy, rqcropw, rqcroph, leftBorder, upperBorder);
-        }
         printf ("setsizes ends\n");
     }
 

--- a/rtengine/dcrop.h
+++ b/rtengine/dcrop.h
@@ -92,7 +92,7 @@ public:
         return cropImageListener;
     }
     void update      (int todo);
-    void setWindow   (int cropX, int cropY, int cropW, int cropH, int canvasX, int canvasY, int canvasW, int canvasH, int skip)
+    void setWindow   (int cropX, int cropY, int cropW, int cropH, int skip)
     {
         setCropSizes (cropX, cropY, cropW, cropH, skip, false);
     }

--- a/rtengine/dcrop.h
+++ b/rtengine/dcrop.h
@@ -26,7 +26,7 @@
 #include "image16.h"
 #include "imagesource.h"
 #include "procevents.h"
-#include "editbuffer.h"
+#include "pipettebuffer.h"
 #include "../rtgui/threadutils.h"
 
 namespace rtengine
@@ -36,7 +36,7 @@ using namespace procparams;
 
 class ImProcCoordinator;
 
-class Crop : public DetailedCrop, public EditBuffer
+class Crop : public DetailedCrop, public PipetteBuffer
 {
 
 protected:
@@ -57,6 +57,7 @@ protected:
     bool updating;         /// Flag telling if an updater thread is currently processing
     bool newUpdatePending; /// Flag telling the updater thread that a new update is pending
     int skip;
+    int padding;           /// Minimum space allowed around image in the display area
     int cropx, cropy, cropw, croph;         /// size of the detail crop image ('skip' taken into account), with border
     int trafx, trafy, trafw, trafh;         /// the size and position to get from the imagesource that is transformed to the requested crop area
     int rqcropx, rqcropy, rqcropw, rqcroph; /// size of the requested detail crop image (the image might be smaller) (without border)
@@ -70,7 +71,7 @@ protected:
     ImProcCoordinator* parent;
     bool isDetailWindow;
     EditUniqueID getCurrEditID();
-    bool setCropSizes (int cx, int cy, int cw, int ch, int skip, bool internal);
+    bool setCropSizes (int cropX, int cropY, int cropW, int cropH, int skip, bool internal);
     void freeAll ();
 
 public:
@@ -91,9 +92,9 @@ public:
         return cropImageListener;
     }
     void update      (int todo);
-    void setWindow   (int cx, int cy, int cw, int ch, int skip)
+    void setWindow   (int cropX, int cropY, int cropW, int cropH, int canvasX, int canvasY, int canvasW, int canvasH, int skip)
     {
-        setCropSizes (cx, cy, cw, ch, skip, false);
+        setCropSizes (cropX, cropY, cropW, cropH, skip, false);
     }
 
     /** @brief Synchronously look out if a full update is necessary
@@ -108,6 +109,10 @@ public:
     int  get_skip       ()
     {
         return skip;
+    }
+    int getPadding      ()
+    {
+        return padding;
     }
     int  getLeftBorder  ()
     {

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -3106,15 +3106,15 @@ filmlike_clip(float *r, float *g, float *b)
     }
 }
 
-void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, EditBuffer *editBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
+void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer *pipetteBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
                                SHMap* shmap, int sat, LUTf & rCurve, LUTf & gCurve, LUTf & bCurve, float satLimit , float satLimitOpacity, const ColorGradientCurve & ctColorCurve, const OpacityCurve & ctOpacityCurve, bool opautili,  LUTf & clToningcurve, LUTf & cl2Toningcurve,
                                const ToneCurve & customToneCurve1, const ToneCurve & customToneCurve2, const ToneCurve & customToneCurvebw1, const ToneCurve & customToneCurvebw2, double &rrm, double &ggm, double &bbm, float &autor, float &autog, float &autob, DCPProfile *dcpProf )
 {
-    rgbProc (working, lab, editBuffer, hltonecurve, shtonecurve, tonecurve, shmap, sat, rCurve, gCurve, bCurve, satLimit , satLimitOpacity, ctColorCurve, ctOpacityCurve, opautili, clToningcurve, cl2Toningcurve, customToneCurve1, customToneCurve2,  customToneCurvebw1, customToneCurvebw2, rrm, ggm, bbm, autor, autog, autob, params->toneCurve.expcomp, params->toneCurve.hlcompr, params->toneCurve.hlcomprthresh, dcpProf);
+    rgbProc (working, lab, pipetteBuffer, hltonecurve, shtonecurve, tonecurve, shmap, sat, rCurve, gCurve, bCurve, satLimit , satLimitOpacity, ctColorCurve, ctOpacityCurve, opautili, clToningcurve, cl2Toningcurve, customToneCurve1, customToneCurve2,  customToneCurvebw1, customToneCurvebw2, rrm, ggm, bbm, autor, autog, autob, params->toneCurve.expcomp, params->toneCurve.hlcompr, params->toneCurve.hlcomprthresh, dcpProf);
 }
 
 // Process RGB image and convert to LAB space
-void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, EditBuffer *editBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
+void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer *pipetteBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
                                SHMap* shmap, int sat, LUTf & rCurve, LUTf & gCurve, LUTf & bCurve, float satLimit , float satLimitOpacity, const ColorGradientCurve & ctColorCurve, const OpacityCurve & ctOpacityCurve, bool opautili, LUTf & clToningcurve, LUTf & cl2Toningcurve,
                                const ToneCurve & customToneCurve1, const ToneCurve & customToneCurve2,  const ToneCurve & customToneCurvebw1, const ToneCurve & customToneCurvebw2, double &rrm, double &ggm, double &bbm, float &autor, float &autog, float &autob, double expcomp, int hlcompr, int hlcomprthresh, DCPProfile *dcpProf)
 {
@@ -3125,20 +3125,20 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, EditBuffer *e
     Imagefloat* editImgFloat = NULL;
     LabImage* editLab = NULL;
     PlanarWhateverData<float>* editWhatever = NULL;
-    EditUniqueID editID = editBuffer ? editBuffer->getEditID() : EUID_None;
+    EditUniqueID editID = pipetteBuffer ? pipetteBuffer->getEditID() : EUID_None;
 
     if (editID != EUID_None) {
-        switch  (editBuffer->getDataProvider()->getCurrSubscriber()->getEditBufferType()) {
+        switch  (pipetteBuffer->getDataProvider()->getCurrSubscriber()->getPipetteBufferType()) {
         case (BT_IMAGEFLOAT):
-            editImgFloat = editBuffer->getImgFloatBuffer();
+            editImgFloat = pipetteBuffer->getImgFloatBuffer();
             break;
 
         case (BT_LABIMAGE):
-            editLab = editBuffer->getLabBuffer();
+            editLab = pipetteBuffer->getLabBuffer();
             break;
 
         case (BT_SINGLEPLANE_FLOAT):
-            editWhatever = editBuffer->getSinglePlaneBuffer();
+            editWhatever = pipetteBuffer->getSinglePlaneBuffer();
             break;
         }
     }
@@ -3447,7 +3447,7 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, EditBuffer *e
         int tW;
         int tH;
 
-        // Allocating buffer for the EditBuffer
+        // Allocating buffer for the PipetteBuffer
         float *editIFloatTmpR, *editIFloatTmpG, *editIFloatTmpB, *editWhateverTmp;
 
         if (editImgFloat) {
@@ -5552,7 +5552,7 @@ void ImProcFunctions::luminanceCurve (LabImage* lold, LabImage* lnew, LUTf & cur
 
 
 
-SSEFUNCTION void ImProcFunctions::chromiLuminanceCurve (EditBuffer *editBuffer, int pW, LabImage* lold, LabImage* lnew, LUTf & acurve, LUTf & bcurve, LUTf & satcurve, LUTf & lhskcurve, LUTf & clcurve, LUTf & curve, bool utili, bool autili, bool butili, bool ccutili, bool cclutili, bool clcutili, LUTu &histCCurve, LUTu &histCLurve, LUTu &histLLCurve, LUTu &histLCurve)
+SSEFUNCTION void ImProcFunctions::chromiLuminanceCurve (PipetteBuffer *pipetteBuffer, int pW, LabImage* lold, LabImage* lnew, LUTf & acurve, LUTf & bcurve, LUTf & satcurve, LUTf & lhskcurve, LUTf & clcurve, LUTf & curve, bool utili, bool autili, bool butili, bool ccutili, bool cclutili, bool clcutili, LUTu &histCCurve, LUTu &histCLurve, LUTu &histLLCurve, LUTu &histLCurve)
 {
     int W = lold->W;
     int H = lold->H;
@@ -5566,23 +5566,23 @@ SSEFUNCTION void ImProcFunctions::chromiLuminanceCurve (EditBuffer *editBuffer, 
     EditUniqueID editID = EUID_None;
     bool editPipette = false;
 
-    if (editBuffer) {
-        editID = editBuffer->getEditID();
+    if (pipetteBuffer) {
+        editID = pipetteBuffer->getEditID();
 
         if (editID != EUID_None) {
             editPipette = true;
 
-            switch  (editBuffer->getDataProvider()->getCurrSubscriber()->getEditBufferType()) {
+            switch  (pipetteBuffer->getDataProvider()->getCurrSubscriber()->getPipetteBufferType()) {
             case (BT_IMAGEFLOAT):
-                editImgFloat = editBuffer->getImgFloatBuffer();
+                editImgFloat = pipetteBuffer->getImgFloatBuffer();
                 break;
 
             case (BT_LABIMAGE):
-                editLab = editBuffer->getLabBuffer();
+                editLab = pipetteBuffer->getLabBuffer();
                 break;
 
             case (BT_SINGLEPLANE_FLOAT):
-                editWhatever = editBuffer->getSinglePlaneBuffer();
+                editWhatever = pipetteBuffer->getSinglePlaneBuffer();
                 break;
             }
         }

--- a/rtengine/improcfun.h
+++ b/rtengine/improcfun.h
@@ -33,7 +33,7 @@
 #include "dcp.h"
 #include "curves.h"
 #include "cplx_wavelet_dec.h"
-#include "editbuffer.h"
+#include "pipettebuffer.h"
 
 #define PIX_SORT(a,b) { if ((a)>(b)) {temp=(a);(a)=(b);(b)=temp;} }
 
@@ -235,10 +235,10 @@ public:
 
     void firstAnalysis    (Imagefloat* working, const ProcParams* params, LUTu & vhist16);
     void updateColorProfiles (const ColorManagementParams& icm, const Glib::ustring& monitorProfile, RenderingIntent monitorIntent);
-    void rgbProc          (Imagefloat* working, LabImage* lab, EditBuffer *editBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
+    void rgbProc          (Imagefloat* working, LabImage* lab, PipetteBuffer *pipetteBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
                            SHMap* shmap, int sat, LUTf & rCurve, LUTf & gCurve, LUTf & bCurve, float satLimit , float satLimitOpacity, const ColorGradientCurve & ctColorCurve, const OpacityCurve & ctOpacityCurve, bool opautili, LUTf & clcurve, LUTf & cl2curve, const ToneCurve & customToneCurve1, const ToneCurve & customToneCurve2,
                            const ToneCurve & customToneCurvebw1, const ToneCurve & customToneCurvebw2, double &rrm, double &ggm, double &bbm, float &autor, float &autog, float &autob, DCPProfile *dcpProf);
-    void rgbProc          (Imagefloat* working, LabImage* lab, EditBuffer *editBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
+    void rgbProc          (Imagefloat* working, LabImage* lab, PipetteBuffer *pipetteBuffer, LUTf & hltonecurve, LUTf & shtonecurve, LUTf & tonecurve,
                            SHMap* shmap, int sat, LUTf & rCurve, LUTf & gCurve, LUTf & bCurve, float satLimit , float satLimitOpacity, const ColorGradientCurve & ctColorCurve, const OpacityCurve & ctOpacityCurve, bool opautili, LUTf & clcurve, LUTf & cl2curve, const ToneCurve & customToneCurve1, const ToneCurve & customToneCurve2,
                            const ToneCurve & customToneCurvebw1, const ToneCurve & customToneCurvebw2, double &rrm, double &ggm, double &bbm, float &autor, float &autog, float &autob,
                            double expcomp, int hlcompr, int hlcomprthresh, DCPProfile *dcpProf);
@@ -259,7 +259,7 @@ public:
     void ciecam_02        (CieImage* ncie, double adap, int begh, int endh,  int pW, int pwb, LabImage* lab, const ProcParams* params,
                            const ColorAppearance & customColCurve1, const ColorAppearance & customColCurve, const ColorAppearance & customColCurve3,
                            LUTu &histLCAM, LUTu &histCCAM, LUTf & CAMBrightCurveJ, LUTf & CAMBrightCurveQ, float &mean, int Iterates, int scale, bool execsharp, double &d, int scalecd, int rtt);
-    void chromiLuminanceCurve (EditBuffer *editBuffer, int pW, LabImage* lold, LabImage* lnew, LUTf &acurve, LUTf &bcurve, LUTf & satcurve, LUTf & satclcurve, LUTf &clcurve, LUTf &curve, bool utili, bool autili, bool butili, bool ccutili, bool cclutili, bool clcutili, LUTu &histCCurve, LUTu &histCLurve, LUTu &histLCurve, LUTu &histLurve);
+    void chromiLuminanceCurve (PipetteBuffer *pipetteBuffer, int pW, LabImage* lold, LabImage* lnew, LUTf &acurve, LUTf &bcurve, LUTf & satcurve, LUTf & satclcurve, LUTf &clcurve, LUTf &curve, bool utili, bool autili, bool butili, bool ccutili, bool cclutili, bool clcutili, LUTu &histCCurve, LUTu &histCLurve, LUTu &histLCurve, LUTu &histLurve);
     void vibrance         (LabImage* lab);//Jacques' vibrance
     void colorCurve       (LabImage* lold, LabImage* lnew);
     void sharpening       (LabImage* lab, float** buffer, SharpeningParams &sharpenParam);

--- a/rtengine/pipettebuffer.h
+++ b/rtengine/pipettebuffer.h
@@ -16,8 +16,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef _EDITBUFFER_H_
-#define _EDITBUFFER_H_
+#ifndef _PIPETTEBUFFER_H_
+#define _PIPETTEBUFFER_H_
 
 #include "../rtgui/edit.h"
 #include "array2D.h"
@@ -28,16 +28,8 @@ namespace rtengine
 {
 
 /// @brief Structure that contains information about and pointers to the Edit buffer
-class EditBuffer
+class PipetteBuffer
 {
-private:
-
-    // Used to draw the objects where the color correspond to the object's ID, in order to find the correct object when hovering
-    Cairo::RefPtr<Cairo::ImageSurface> objectMap;
-    // If more than 254 objects has to be handled, objectMap2 contains the "upper part" of the 16 bit int value. objectMap2 will be NULL otherwise.
-    Cairo::RefPtr<Cairo::ImageSurface> objectMap2;
-    ObjectMode objectMode;
-
 protected:
 
     // To avoid duplicated information, we points to a EditDataProvider that contains the current EditSubscriber
@@ -52,39 +44,38 @@ protected:
 
     bool ready;  // flag that indicates if the _pipette_ buffer is ready
 
-    void                       createBuffer(int width, int height);
-    void                       resize(int newWidth, int newHeight, EditSubscriber* newSubscriber);
-    void                       resize(int newWidth, int newHeight);
-    void                       flush();
+    void createBuffer(int width, int height);
+    void resize(int newWidth, int newHeight, EditSubscriber* newSubscriber);
+    void resize(int newWidth, int newHeight);
+    void flush();
 
 public:
-    EditBuffer(::EditDataProvider *dataProvider);
-    ~EditBuffer();
+    PipetteBuffer(::EditDataProvider *dataProvider);
+    ~PipetteBuffer();
 
     /** @brief Getter to know if the pipette buffer is correctly filled */
-    bool                       isReady()
+    bool isReady()
     {
         return ready;
     }
 
     /** @brief Setter to tell that the pipette buffer is correctly filled
      *  You have to use this method once the pipette is filled, so it can be read. */
-    void                       setReady()
+    void setReady()
     {
         ready = true;
     }
 
-    void                       setObjectMode(ObjectMode newType);
-    ::EditDataProvider*        getDataProvider()
+    ::EditDataProvider* getDataProvider()
     {
         return dataProvider;
     }
-    EditUniqueID               getEditID();
-    Imagefloat*                getImgFloatBuffer()
+    EditUniqueID getEditID();
+    Imagefloat* getImgFloatBuffer()
     {
         return imgFloatBuffer;
     }
-    LabImage*                  getLabBuffer()
+    LabImage* getLabBuffer()
     {
         return LabBuffer;
     }
@@ -92,26 +83,12 @@ public:
     {
         return &singlePlaneBuffer;
     }
-    ObjectMode                 getObjectMode()
-    {
-        return objectMode;
-    }
-
-    Cairo::RefPtr<Cairo::ImageSurface> &getObjectMap ()
-    {
-        return objectMap;
-    }
-    Cairo::RefPtr<Cairo::ImageSurface> &getObjectMap2()
-    {
-        return objectMap2;
-    }
 
     // return true if the buffer has been allocated
-    bool                       bufferCreated();
+    bool bufferCreated();
 
-    int                        getObjectID(const Coord& location);
     // get the pipette values
-    void                       getPipetteData(float* v, int x, int y, int squareSize);
+    void getPipetteData(float* v, int x, int y, int squareSize);
 };
 
 }

--- a/rtengine/rt_math.h
+++ b/rtengine/rt_math.h
@@ -80,12 +80,31 @@ inline const _Tp& max(const _Tp& a, const _Tp& b, const _Tp& c, const _Tp& d)
 }
 
 template<typename _Tp>
-inline const _Tp intp(const _Tp a, const _Tp b, const _Tp c) {
+inline const _Tp intp(const _Tp a, const _Tp b, const _Tp c)
+{
     // calculate a * b + (1 - a) * c
     // following is valid:
     // intp(a, b+x, c+x) = intp(a, b, c) + x
     // intp(a, b*x, c*x) = intp(a, b, c) * x
     return a * (b-c) + c;
+}
+
+template<typename T>
+T norm1(const T& x, const T& y)
+{
+    return std::abs(x) + std::abs(y);
+}
+
+template<typename T>
+T norm2(const T& x, const T& y)
+{
+    return std::sqrt(x * x + y * y);
+}
+
+template< typename T >
+T norminf(const T& x, const T& y)
+{
+    return std::max(std::abs(x), std::abs(y));
 }
 
 }

--- a/rtgui/crophandler.cc
+++ b/rtgui/crophandler.cc
@@ -24,13 +24,16 @@
 #include "cropwindow.h"
 #include "../rtengine/dcrop.h"
 #include "../rtengine/refreshmap.h"
+#include "../rtengine/rt_math.h"
 
 using namespace rtengine;
 
 CropHandler::CropHandler ()
-    : zoom(10), ww(0), wh(0), cx(0), cy(0), cw(0), ch(0),
-      cropX(0), cropY(0), cropW(0), cropH(0), enabled(false),
-      cropimg(NULL), cropimgtrue(NULL), ipc(NULL), crop(NULL), listener(NULL), isLowUpdatePriority(false)
+    : zoom(10), ww(0), wh(0), imx(-1), imy(-1), imw(0), imh(0), cax(-1), cay(-1),
+      cx(0), cy(0), cw(0), ch(0), cropX(0), cropY(0), cropW(0), cropH(0), enabled(false),
+      cropimg(NULL), cropimgtrue(NULL), cropimg_width(0), cropimg_height(0),
+      initial(false), isLowUpdatePriority(false), ipc(NULL), crop(NULL),
+      displayHandler(NULL)
 {
 
     chi = new CropHandlerIdleHelper;
@@ -82,7 +85,7 @@ void CropHandler::newImage (StagedImageProcessor* ipc_, bool isDetailWindow)
     }
 
     EditDataProvider *editDataProvider = NULL;
-    CropWindow *cropWin = listener ? static_cast<CropWindow*>(listener) : NULL;
+    CropWindow *cropWin = displayHandler ? static_cast<CropWindow*>(displayHandler) : NULL;
 
     if (cropWin) {
         editDataProvider = cropWin->getImageArea();
@@ -126,16 +129,28 @@ double CropHandler::getFitZoom ()
 
 void CropHandler::setZoom (int z, int centerx, int centery)
 {
+    assert (ipc);
 
-    int x = cx + cw / 2;
-    int y = cy + ch / 2;
+    float oldScale = zoom >= 1000 ? float(zoom / 1000) : 1.f / float(zoom);
+    float newScale = z >= 1000 ? float(z / 1000) : 1.f / float(z);
 
-    if (centerx >= 0) {
-        x = centerx;
+    int oldcax = cax;
+    int oldcay = cay;
+
+    if (centerx == -1) {
+        cax = ipc->getFullWidth () / 2;
+    } else {
+        float distToAnchor = float(cax - centerx);
+        distToAnchor = distToAnchor / newScale * oldScale;
+        cax = centerx + int(distToAnchor);
     }
 
-    if (centery >= 0) {
-        y = centery;
+    if (centery == -1) {
+        cay = ipc->getFullHeight () / 2;
+    } else {
+        float distToAnchor = float(cay - centery);
+        distToAnchor = distToAnchor / newScale * oldScale;
+        cay = centery + int(distToAnchor);
     }
 
     // maybe demosaic etc. if we cross the border to >100%
@@ -151,12 +166,18 @@ void CropHandler::setZoom (int z, int centerx, int centery)
         ch = wh * zoom;
     }
 
-    cx = x - cw / 2;
-    cy = y - ch / 2;
+    cx = cax - cw / 2;
+    cy = cay - ch / 2;
+
+
+    int oldCropX = cropX;
+    int oldCropY = cropY;
+    int oldCropW = cropW;
+    int oldCropH = cropH;
 
     compDim ();
 
-    if (enabled) {
+    if (enabled && (oldcax != cax || oldcay != cay || oldCropX != cropX || oldCropY != cropY || oldCropW != cropW || oldCropH != cropH)) {
         if (needsFullRefresh) {
             ipc->startProcessing(M_HIGHQUAL);
         } else {
@@ -194,11 +215,44 @@ void CropHandler::getWSize (int& w, int &h)
     h = wh;
 }
 
-void CropHandler::setPosition (int x, int y, bool update_)
+void CropHandler::getAnchorPosition (int& x, int& y)
 {
+    x = cax;
+    y = cay;
+}
 
-    cx = x;
-    cy = y;
+void CropHandler::setAnchorPosition (int x, int y, bool update_)
+{
+    cax = x;
+    cay = y;
+
+    compDim ();
+
+    if (enabled && update_) {
+        update ();
+    }
+}
+
+void CropHandler::moveAnchor (int deltaX, int deltaY, bool update_)
+{
+    cax += deltaX;
+    cay += deltaY;
+
+    compDim ();
+
+    if (enabled && update_) {
+        update ();
+    }
+}
+
+void CropHandler::centerAnchor (bool update_)
+{
+    assert (ipc);
+
+    // Computes the crop's size and position given the anchor's position and display size
+
+    cax = ipc->getFullWidth() / 2;
+    cay = ipc->getFullHeight() / 2;
 
     compDim ();
 
@@ -280,11 +334,11 @@ int createpixbufs (void* data)
 
     ch->cimg.unlock ();
 
-    if (ch->listener) {
-        ch->listener->cropImageUpdated ();
+    if (ch->displayHandler) {
+        ch->displayHandler->cropImageUpdated ();
 
         if (ch->initial) {
-            ch->listener->initialImageArrived ();
+            ch->displayHandler->initialImageArrived ();
             ch->initial = false;
         }
     }
@@ -365,7 +419,7 @@ bool CropHandler::getWindow (int& cwx, int& cwy, int& cww, int& cwh, int& cskip)
 void CropHandler::update ()
 {
 
-    if (crop) {
+    if (crop && enabled) {
 //        crop->setWindow (cropX, cropY, cropW, cropH, zoom>=1000 ? 1 : zoom); --> we use the "getWindow" hook instead of setting the size before
         crop->setListener (this);
         cropPixbuf.clear ();
@@ -428,41 +482,78 @@ void CropHandler::getFullImageSize (int& w, int& h)
 
 void CropHandler::compDim ()
 {
+    assert (ipc && displayHandler);
 
-    cropX = cx;
-    cropY = cy;
-    cropW = cw;
-    cropH = ch;
+    // Computes the crop's size and position given the anchor's position and display size
 
-    cutRectToImgBounds (cropX, cropY, cropW, cropH);
-}
+    int fullW = ipc->getFullWidth();
+    int fullH = ipc->getFullHeight();
+    int imgX = -1, imgY = -1;
+    //int scaledFullW, scaledFullH;
+    int scaledCAX, scaledCAY;
+    int wwImgSpace;
+    int whImgSpace;
 
-void CropHandler::cutRectToImgBounds (int& x, int& y, int& w, int& h)
-{
+    cax = rtengine::LIM(cax, 0, fullW-1);
+    cay = rtengine::LIM(cay, 0, fullH-1);
 
-    if (ipc) {
-        if (w > ipc->getFullWidth()) {
-            w = ipc->getFullWidth();
-        }
-
-        if (h > ipc->getFullHeight()) {
-            h = ipc->getFullHeight();
-        }
-
-        if (x < 0) {
-            x = 0;
-        }
-
-        if (y < 0) {
-            y = 0;
-        }
-
-        if (x + w >= ipc->getFullWidth()) {
-            x = ipc->getFullWidth() - w;
-        }
-
-        if (y + h >= ipc->getFullHeight()) {
-            y = ipc->getFullHeight() - h;
-        }
+    if (zoom >= 1000) {
+        wwImgSpace = int(float(ww) / float(zoom/1000) + 0.5f);
+        whImgSpace = int(float(wh) / float(zoom/1000) + 0.5f);
+        //scaledFullW = fullW * (zoom/1000);
+        //scaledFullH = fullH * (zoom/1000);
+        scaledCAX = cax * (zoom/1000);
+        scaledCAY = cay * (zoom/1000);
+    } else {
+        wwImgSpace = int(float(ww) * float(zoom) + 0.5f);
+        whImgSpace = int(float(wh) * float(zoom) + 0.5f);
+        //scaledFullW = fullW / zoom;
+        //scaledFullH = fullH / zoom;
+        scaledCAX = cax / zoom;
+        scaledCAY = cay / zoom;
     }
+
+    imgX = ww / 2 - scaledCAX;
+    if (imgX < 0) {
+        imgX = 0;
+    }
+    imgY = wh / 2 - scaledCAY;
+    if (imgY < 0) {
+        imgY = 0;
+    }
+
+    cropX = cax - (wwImgSpace/2);
+    cropY = cay - (whImgSpace/2);
+    cropW = wwImgSpace;
+    cropH = whImgSpace;
+
+    if (cropX + cropW > fullW) {
+        cropW = fullW - cropX;
+    }
+
+    if (cropY + cropH > fullH) {
+        cropH = fullH - cropY;
+    }
+
+    if (cropX < 0) {
+        cropW += cropX;
+        cropX = 0;
+    }
+
+    if (cropY < 0) {
+        cropH += cropY;
+        cropY = 0;
+    }
+
+    // Should be good already, but this will correct eventual rounding error
+
+    if (cropW > fullW) {
+        cropW = fullW;
+    }
+
+    if (cropH > fullH) {
+        cropH = fullH;
+    }
+
+    displayHandler->setDisplayPosition(imgX, imgY);
 }

--- a/rtgui/cropwindow.h
+++ b/rtgui/cropwindow.h
@@ -28,6 +28,7 @@
 #include <list>
 #include "cropguilistener.h"
 #include "pointermotionlistener.h"
+#include "edit.h"
 
 class CropWindow;
 class CropWindowListener
@@ -42,12 +43,13 @@ public:
 };
 
 class ImageArea;
-class CropWindow : public LWButtonListener, public CropHandlerListener, public EditCoordSystem
+class CropWindow : public LWButtonListener, public CropDisplayHandler, public EditCoordSystem, public ObjectMOBuffer
 {
 
     // state management
-    ImgEditState state;                  // current state of user (see enum State)
-    int action_x, action_y, press_x, press_y;
+    ImgEditState state;                 // current state of user (see enum State)
+    int press_x, press_y;               // position of the cursor in the GUI space on button press
+    int action_x, action_y;             // parameter that will evolve during a pan or drag action
     double rot_deg;
     bool onResizeArea;
     bool deleted;
@@ -85,7 +87,7 @@ class CropWindow : public LWButtonListener, public CropHandlerListener, public E
     PointerMotionListener* pmhlistener;
     std::list<CropWindowListener*> listeners;
 
-    CropWindow* observedCropWin;
+    CropWindow* observedCropWin;  // Pointer to the currently active detail CropWindow
     rtengine::StagedImageProcessor* ipc;
 
     bool onArea                    (CursorArea a, int x, int y);
@@ -95,7 +97,9 @@ class CropWindow : public LWButtonListener, public CropHandlerListener, public E
     void drawScaledSpotRectangle   (Cairo::RefPtr<Cairo::Context> cr, int rectSize);
     void drawUnscaledSpotRectangle (Cairo::RefPtr<Cairo::Context> cr, int rectSize);
     void drawObservedFrame         (Cairo::RefPtr<Cairo::Context> cr, int rw = 0, int rh = 0);
-    void changeZoom                (int zoom, bool notify = true, int centerx = -1, int centery = -1, bool skipZoomIfUnchanged = true);
+    void changeZoom                (int zoom, bool notify = true, int centerx = -1, int centery = -1);
+
+    // Used by the mainCropWindow only
     void getObservedFrameArea      (int& x, int& y, int& w, int& h, int rw = 0, int rh = 0);
 
 public:
@@ -117,15 +121,16 @@ public:
 
     void screenCoordToCropBuffer (int phyx, int phyy, int& cropx, int& cropy);
     void screenCoordToImage (int phyx, int phyy, int& imgx, int& imgy);
-    void screenCoordToPreview (int phyx, int phyy, int& prevx, int& prevy);
+    void screenCoordToCropCanvas (int phyx, int phyy, int& prevx, int& prevy);
+    void imageCoordToCropCanvas (int imgx, int imgy, int& phyx, int& phyy);
     void imageCoordToScreen (int imgx, int imgy, int& phyx, int& phyy);
     void imageCoordToCropBuffer (int imgx, int imgy, int& phyx, int& phyy);
     int scaleValueToImage (int value);
     float scaleValueToImage (float value);
     double scaleValueToImage (double value);
-    int scaleValueToScreen (int value);
-    float scaleValueToScreen (float value);
-    double scaleValueToScreen (double value);
+    int scaleValueToCanvas (int value);
+    float scaleValueToCanvas (float value);
+    double scaleValueToCanvas (double value);
     double getZoomFitVal ();
     void setPosition (int x, int y);
     void getPosition (int& x, int& y);
@@ -140,14 +145,13 @@ public:
     void zoomIn      (bool toCursor = false, int cursorX = -1, int cursorY = -1);
     void zoomOut     (bool toCursor = false, int cursorX = -1, int cursorY = -1);
     void zoom11      ();
-    void zoomFit     (bool skipZoomIfUnchanged = true);
+    void zoomFit     ();
     void zoomFitCrop ();
     double getZoom   ();
     bool isMinZoom   ();
     bool isMaxZoom   ();
     void setZoom     (double zoom);
 
-    void findCenter  (int deltaZoom, int& x, int& y);
     bool isInside    (int x, int y);
 
 
@@ -157,15 +161,20 @@ public:
 
     void expose        (Cairo::RefPtr<Cairo::Context> cr);
 
+    void setEditSubscriber (EditSubscriber* newSubscriber);
+
     // interface lwbuttonlistener
     void buttonPressed (LWButton* button, int actionCode, void* actionData);
     void redrawNeeded  (LWButton* button);
 
     // crop handling
-    void getCropRectangle (int& x, int& y, int& w, int& h);
-    void getCropPosition  (int& x, int& y);
-    void setCropPosition  (int x, int y, bool update = true);
-    void getCropSize      (int& w, int& h);
+    void getCropRectangle      (int& x, int& y, int& w, int& h);
+    void getCropPosition       (int& x, int& y);
+    void setCropPosition       (int x, int y, bool update = true);
+    void centerCrop            (bool update = true);
+    void getCropSize           (int& w, int& h);
+    void getCropAnchorPosition (int& w, int& h);
+    void setCropAnchorPosition (int& w, int& h);
 
     // listeners
     void setCropGUIListener       (CropGUIListener* cgl)
@@ -192,6 +201,7 @@ public:
     void cropImageUpdated ();
     void cropWindowChanged ();
     void initialImageArrived ();
+    void setDisplayPosition (int x, int y);
 
     void remoteMove      (int deltaX, int deltaY);
     void remoteMoveReady ();

--- a/rtgui/edit.h
+++ b/rtgui/edit.h
@@ -153,8 +153,6 @@ private:
 
     // Used to draw the objects where the color correspond to the object's ID, in order to find the correct object when hovering
     Cairo::RefPtr<Cairo::ImageSurface> objectMap;
-    // If more than 254 objects has to be handled, objectMap2 contains the "upper part" of the 16 bit int value. objectMap2 will be NULL otherwise.
-    Cairo::RefPtr<Cairo::ImageSurface> objectMap2;
     ObjectMode objectMode;
 
 protected:
@@ -164,32 +162,19 @@ protected:
     EditDataProvider* dataProvider;
 
     void createBuffer(int width, int height);
-    void resize(int newWidth, int newHeight, EditSubscriber* newSubscriber);
+    void resize(int newWidth, int newHeight);
     void flush();
     EditSubscriber *getEditSubscriber ();
 
 public:
-    ObjectMOBuffer(EditDataProvider *dataProvider);
+    explicit ObjectMOBuffer (EditDataProvider *dataProvider);
     ~ObjectMOBuffer();
 
-    EditDataProvider* getDataProvider()
-    {
-        return dataProvider;
-    }
-    void setObjectMode(ObjectMode newType);
-    ObjectMode getObjectMode()
-    {
-        return objectMode;
-    }
+    EditDataProvider* getDataProvider ();
+    void setObjectMode (ObjectMode newType);
+    ObjectMode getObjectMode ();
 
-    Cairo::RefPtr<Cairo::ImageSurface> &getObjectMap ()
-    {
-        return objectMap;
-    }
-    Cairo::RefPtr<Cairo::ImageSurface> &getObjectMap2()
-    {
-        return objectMap2;
-    }
+    Cairo::RefPtr<Cairo::ImageSurface>& getObjectMap ();
 
     // return true if the buffer has been allocated
     bool bufferCreated();
@@ -238,36 +223,16 @@ class RGBColor
     double b;
 
 public:
-    RGBColor () : r(0.), g(0.), b(0.) {}
-    explicit RGBColor (double r, double g, double b) : r(r), g(g), b(b) {}
-    explicit RGBColor (char r, char g, char b) : r(double(r) / 255.), g(double(g) / 255.), b(double(b) / 255.) {}
+    RGBColor ();
+    explicit RGBColor (double r, double g, double b);
+    explicit RGBColor (char r, char g, char b);
 
-    void setColor(double r, double g, double b)
-    {
-        this->r = r;
-        this->g = g;
-        this->b = b;
-    }
+    void setColor (double r, double g, double b);
+    void setColor (char r, char g, char b);
 
-    void setColor(char r, char g, char b)
-    {
-        this->r = double(r) / 255.;
-        this->g = double(g) / 255.;
-        this->b = double(b) / 255.;
-    }
-
-    double getR()
-    {
-        return r;
-    }
-    double getG()
-    {
-        return g;
-    }
-    double getB()
-    {
-        return b;
-    }
+    double getR ();
+    double getG ();
+    double getB ();
 };
 
 class RGBAColor : public RGBColor
@@ -275,26 +240,14 @@ class RGBAColor : public RGBColor
     double a;
 
 public:
-    RGBAColor () : RGBColor(0., 0., 0.), a(0.) {}
-    explicit RGBAColor (double r, double g, double b, double a) : RGBColor(r, g, b), a(a) {}
-    explicit RGBAColor (char r, char g, char b, char a) : RGBColor(r, g, b), a(double(a) / 255.) {}
+    RGBAColor ();
+    explicit RGBAColor (double r, double g, double b, double a);
+    explicit RGBAColor (char r, char g, char b, char a);
 
-    void setColor(double r, double g, double b, double a)
-    {
-        RGBColor::setColor(r, g, b);
-        this->a = a;
-    }
+    void setColor (double r, double g, double b, double a);
+    void setColor (char r, char g, char b, char a);
 
-    void setColor(char r, char g, char b, char a)
-    {
-        RGBColor::setColor(r, g, b);
-        this->a = double(a) / 255.;
-    }
-
-    double getA()
-    {
-        return a;
-    }
+    double getA ();
 };
 
 /// @brief Displayable and MouseOver geometry base class
@@ -345,85 +298,29 @@ public:
     Datum datum;
     State state;  // set by the Subscriber
 
-    Geometry () : innerLineColor(char(255), char(255), char(255)), outerLineColor(char(0), char(0), char(0)), flags(F_VISIBLE | F_HOVERABLE | F_AUTO_COLOR), innerLineWidth(1.5f), datum(IMAGE), state(NORMAL) {}
+    Geometry ();
     virtual ~Geometry() {}
 
-    void     setInnerLineColor     (double r, double g, double b)
-    {
-        innerLineColor.setColor(r, g, b);
-        flags &= ~F_AUTO_COLOR;
-    }
-    void     setInnerLineColor     (char   r, char   g, char   b)
-    {
-        innerLineColor.setColor(r, g, b);
-        flags &= ~F_AUTO_COLOR;
-    }
-    RGBColor getInnerLineColor     ();
-    void     setOuterLineColor     (double r, double g, double b)
-    {
-        outerLineColor.setColor(r, g, b);
-        flags &= ~F_AUTO_COLOR;
-    }
-    void     setOuterLineColor     (char   r, char   g, char   b)
-    {
-        outerLineColor.setColor(r, g, b);
-        flags &= ~F_AUTO_COLOR;
-    }
-    RGBColor getOuterLineColor     ();
-    double   getOuterLineWidth     ()
-    {
-        return double(innerLineWidth) + 2.;
-    }
-    double   getMouseOverLineWidth ()
-    {
-        return getOuterLineWidth() + 2.;
-    }
-    void     setAutoColor          (bool aColor)
-    {
-        if (aColor) {
-            flags |= F_AUTO_COLOR;
-        } else {
-            flags &= ~F_AUTO_COLOR;
-        }
-    }
-    bool     isVisible             ()
-    {
-        return flags & F_VISIBLE;
-    }
-    void     setVisible            (bool visible)
-    {
-        if (visible) {
-            flags |= F_VISIBLE;
-        } else {
-            flags &= ~F_VISIBLE;
-        }
-    }
-    bool     isHoverable           ()
-    {
-        return flags & F_HOVERABLE;
-    }
-    void     setHoverable          (bool visible)
-    {
-        if (visible) {
-            flags |= F_HOVERABLE;
-        } else {
-            flags &= ~F_HOVERABLE;
-        }
-    }
+    void setInnerLineColor (double r, double g, double b);
+    void setInnerLineColor (char r, char g, char b);
+    RGBColor getInnerLineColor ();
+    void setOuterLineColor (double r, double g, double b);
+    void setOuterLineColor (char r, char g, char b);
+    RGBColor getOuterLineColor ();
+    double getOuterLineWidth ();
+    double getMouseOverLineWidth ();
+    void setAutoColor (bool aColor);
+    bool isVisible ();
+    void setVisible (bool visible);
+    bool isHoverable ();
+    void setHoverable (bool visible);
 
     // setActive will enable/disable the visible and hoverable flags in one shot!
-    void     setActive             (bool active)
-    {
-        if (active) {
-            flags |= (F_VISIBLE | F_HOVERABLE);
-        } else {
-            flags &= ~(F_VISIBLE | F_HOVERABLE);
-        }
-    }
+    void setActive (bool active);
 
     virtual void drawOuterGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *parent, EditCoordSystem &coordSystem) = 0;
     virtual void drawInnerGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *parent, EditCoordSystem &coordSystem) = 0;
-    virtual void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, Cairo::RefPtr<Cairo::Context> &cr2, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem) = 0;
+    virtual void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem) = 0;
 };
 
 class Circle : public Geometry
@@ -434,13 +331,13 @@ public:
     bool filled;
     bool radiusInImageSpace; /// If true, the radius depend on the image scale; if false, it is a fixed 'screen' size
 
-    Circle () : center(100, 100), radius(10), filled(false), radiusInImageSpace(false) {}
-    Circle (rtengine::Coord &center, int radius, bool filled = false, bool radiusInImageSpace = false) : center(center), radius(radius), filled(filled), radiusInImageSpace(radiusInImageSpace) {}
-    Circle (int centerX, int centerY, int radius, bool filled = false, bool radiusInImageSpace = false) : center(centerX, centerY), radius(radius), filled(filled), radiusInImageSpace(radiusInImageSpace) {}
+    Circle ();
+    Circle (rtengine::Coord& center, int radius, bool filled = false, bool radiusInImageSpace = false);
+    Circle (int centerX, int centerY, int radius, bool filled = false, bool radiusInImageSpace = false);
 
     void drawOuterGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
     void drawInnerGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
-    void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, Cairo::RefPtr<Cairo::Context> &cr2, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
+    void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
 };
 
 class Line : public Geometry
@@ -449,13 +346,13 @@ public:
     rtengine::Coord begin;
     rtengine::Coord end;
 
-    Line () : begin(10, 10), end(100, 100) {}
-    Line (rtengine::Coord &begin, rtengine::Coord &end) : begin(begin), end(end) {}
-    Line (int beginX, int beginY, int endX, int endY) : begin(beginX, beginY), end(endX, endY) {}
+    Line ();
+    Line (rtengine::Coord& begin, rtengine::Coord& end);
+    Line (int beginX, int beginY, int endX, int endY);
 
     void drawOuterGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
     void drawInnerGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
-    void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, Cairo::RefPtr<Cairo::Context> &cr2, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
+    void drawToMOChannel   (Cairo::RefPtr<Cairo::Context> &cr, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
 };
 
 class Polyline : public Geometry
@@ -464,11 +361,11 @@ public:
     std::vector<rtengine::Coord> points;
     bool filled;
 
-    Polyline() : filled(false) {}
+    Polyline ();
 
     void drawOuterGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
     void drawInnerGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
-    void drawToMOChannel (Cairo::RefPtr<Cairo::Context> &cr, Cairo::RefPtr<Cairo::Context> &cr2, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
+    void drawToMOChannel (Cairo::RefPtr<Cairo::Context> &cr, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
 };
 
 class Rectangle : public Geometry
@@ -478,7 +375,7 @@ public:
     rtengine::Coord bottomRight;
     bool filled;
 
-    Rectangle() : topLeft(0, 0), bottomRight(10, 10), filled(false) {}
+    Rectangle ();
 
     void setXYWH(int left, int top, int width, int height);
     void setXYXY(int left, int top, int right, int bottom);
@@ -486,7 +383,7 @@ public:
     void setXYXY(rtengine::Coord topLeft, rtengine::Coord bottomRight);
     void drawOuterGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
     void drawInnerGeometry (Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
-    void drawToMOChannel (Cairo::RefPtr<Cairo::Context> &cr, Cairo::RefPtr<Cairo::Context> &cr2, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
+    void drawToMOChannel (Cairo::RefPtr<Cairo::Context> &cr, unsigned short id, ObjectMOBuffer *pipetteBuffer, EditCoordSystem &coordSystem);
 };
 
 /// @brief Method for client tools needing Edit information
@@ -511,10 +408,7 @@ public:
     virtual ~EditSubscriber () {}
 
     void              setEditProvider(EditDataProvider *provider);
-    EditDataProvider* getEditProvider()
-    {
-        return provider;
-    }
+    EditDataProvider* getEditProvider ();
     void              setEditID(EditUniqueID ID, BufferType buffType);
     bool              isCurrentSubscriber();
     virtual void      subscribe();
@@ -527,103 +421,64 @@ public:
 
     /** @brief Get the cursor to be displayed when above handles
     @param objectID object currently "hovered" */
-    virtual CursorShape getCursor(int objectID)
-    {
-        return CSOpenHand;
-    }
+    virtual CursorShape getCursor (int objectID);
 
     /** @brief Triggered when the mouse is moving over an object
     This method is also triggered when the cursor is moving over the image in ET_PIPETTE mode
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool mouseOver(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool mouseOver (int modifierKey);
 
     /** @brief Triggered when mouse button 1 is pressed, together with the CTRL modifier key if the subscriber is of type ET_PIPETTE
     Once the key is pressed, RT will enter in drag1 mode on subsequent mouse movements
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button1Pressed(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool button1Pressed (int modifierKey);
 
     /** @brief Triggered when mouse button 1 is released
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button1Released()
-    {
-        return false;
-    }
+    virtual bool button1Released ();
 
     /** @brief Triggered when mouse button 2 is pressed (middle button)
     Once the key is pressed, RT will enter in drag2 mode on subsequent mouse movements
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button2Pressed(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool button2Pressed (int modifierKey);
 
     /** @brief Triggered when mouse button 2 is released (middle button)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button2Released()
-    {
-        return false;
-    }
+    virtual bool button2Released ();
 
     /** @brief Triggered when mouse button 3 is pressed (right button)
     Once the key is pressed, RT will enter in drag3 mode on subsequent mouse movements
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button3Pressed(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool button3Pressed (int modifierKey);
 
     /** @brief Triggered when mouse button 3 is released (right button)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool button3Released()
-    {
-        return false;
-    }
+    virtual bool button3Released ();
 
     /** @brief Triggered when the user is moving while holding down mouse button 1
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool drag1(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool drag1 (int modifierKey);
 
     /** @brief Triggered when the user is moving while holding down mouse button 2
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool drag2(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool drag2 (int modifierKey);
 
     /** @brief Triggered when the user is moving while holding down mouse button 3
     @param modifierKey Gtk's event modifier key (GDK_CONTROL_MASK | GDK_SHIFT_MASK | ...)
     @return true if the preview has to be redrawn, false otherwise */
-    virtual bool drag3(int modifierKey)
-    {
-        return false;
-    }
+    virtual bool drag3 (int modifierKey);
 
     /** @brief Get the geometry to be shown to the user */
-    const std::vector<Geometry*> & getVisibleGeometry()
-    {
-        return visibleGeometry;
-    }
+    const std::vector<Geometry*>& getVisibleGeometry ();
 
     /** @brief Get the geometry to be drawn in the "mouse over" channel, hidden from the user */
-    const std::vector<Geometry*> & getMouseOverGeometry()
-    {
-        return mouseOverGeometry;
-    }
+    const std::vector<Geometry*>& getMouseOverGeometry ();
 };
 
 /** @brief Class to handle the furniture of data to the subscribers.
@@ -655,12 +510,255 @@ public:
     virtual void        unsubscribe();         /// Occurs when the subscriber has been switched off first
     virtual void        switchOffEditMode ();  /// Occurs when the user want to stop the editing mode
     virtual CursorShape getCursor(int objectID);
-    int                 getPipetteRectSize()
-    {
-        return 8;    // TODO: make a GUI
-    }
+    int                 getPipetteRectSize ();
     EditSubscriber*     getCurrSubscriber();
     virtual void        getImageSize (int &w, int&h) = 0;
 };
+
+inline EditDataProvider* ObjectMOBuffer::getDataProvider () {
+    return dataProvider;
+}
+
+inline ObjectMode ObjectMOBuffer::getObjectMode () {
+    return objectMode;
+}
+
+inline Cairo::RefPtr<Cairo::ImageSurface>& ObjectMOBuffer::getObjectMap () {
+    return objectMap;
+}
+
+inline void RGBColor::setColor (double r, double g, double b) {
+    this->r = r;
+    this->g = g;
+    this->b = b;
+}
+
+inline void RGBColor::setColor (char r, char g, char b) {
+    this->r = double (r) / 255.;
+    this->g = double (g) / 255.;
+    this->b = double (b) / 255.;
+}
+
+inline double RGBColor::getR () {
+    return r;
+}
+
+inline double RGBColor::getG () {
+    return g;
+}
+
+inline double RGBColor::getB () {
+    return b;
+}
+
+inline void RGBAColor::setColor (double r, double g, double b, double a) {
+    RGBColor::setColor (r, g, b);
+    this->a = a;
+}
+
+inline void RGBAColor::setColor (char r, char g, char b, char a) {
+    RGBColor::setColor (r, g, b);
+    this->a = double (a) / 255.;
+}
+
+inline double RGBAColor::getA () {
+    return a;
+}
+
+inline void Geometry::setInnerLineColor (double r, double g, double b) {
+    innerLineColor.setColor (r, g, b);
+    flags &= ~F_AUTO_COLOR;
+}
+
+inline void Geometry::setInnerLineColor (char r, char g, char b) {
+    innerLineColor.setColor (r, g, b);
+    flags &= ~F_AUTO_COLOR;
+}
+
+inline void Geometry::setOuterLineColor (double r, double g, double b) {
+    outerLineColor.setColor (r, g, b);
+    flags &= ~F_AUTO_COLOR;
+}
+
+inline double Geometry::getOuterLineWidth () {
+    return double (innerLineWidth) + 2.;
+}
+
+inline void Geometry::setOuterLineColor (char r, char g, char b) {
+    outerLineColor.setColor (r, g, b);
+    flags &= ~F_AUTO_COLOR;
+}
+
+inline double Geometry::getMouseOverLineWidth () {
+    return getOuterLineWidth () + 2.;
+}
+
+inline void Geometry::setAutoColor (bool aColor) {
+    if (aColor) {
+        flags |= F_AUTO_COLOR;
+    } else {
+        flags &= ~F_AUTO_COLOR;
+    }
+}
+
+inline bool Geometry::isVisible () {
+    return flags & F_VISIBLE;
+}
+
+inline void Geometry::setVisible (bool visible) {
+    if (visible) {
+        flags |= F_VISIBLE;
+    } else {
+        flags &= ~F_VISIBLE;
+    }
+}
+
+inline bool Geometry::isHoverable () {
+    return flags & F_HOVERABLE;
+}
+
+inline void Geometry::setHoverable (bool visible) {
+    if (visible) {
+        flags |= F_HOVERABLE;
+    } else {
+        flags &= ~F_HOVERABLE;
+    }
+}
+
+inline void Geometry::setActive (bool active) {
+    if (active) {
+        flags |= (F_VISIBLE | F_HOVERABLE);
+    } else {
+        flags &= ~(F_VISIBLE | F_HOVERABLE);
+    }
+}
+
+inline EditDataProvider* EditSubscriber::getEditProvider () {
+    return provider;
+}
+
+inline CursorShape EditSubscriber::getCursor (int objectID) {
+    return CSOpenHand;
+}
+
+inline bool EditSubscriber::mouseOver (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::button1Pressed (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::button1Released () {
+    return false;
+}
+
+inline bool EditSubscriber::button2Pressed (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::button2Released () {
+    return false;
+}
+
+inline bool EditSubscriber::button3Pressed (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::button3Released () {
+    return false;
+}
+
+inline bool EditSubscriber::drag1 (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::drag2 (int modifierKey) {
+    return false;
+}
+
+inline bool EditSubscriber::drag3 (int modifierKey) {
+    return false;
+}
+
+inline const std::vector<Geometry*>& EditSubscriber::getVisibleGeometry () {
+    return visibleGeometry;
+}
+
+inline const std::vector<Geometry*>& EditSubscriber::getMouseOverGeometry () {
+    return mouseOverGeometry;
+}
+
+inline int EditDataProvider::getPipetteRectSize () {
+    return 8; // TODO: make a GUI
+}
+
+inline Geometry::Geometry () :
+        innerLineColor (char (255), char (255), char (255)), outerLineColor (
+                char (0), char (0), char (0)), flags (
+                F_VISIBLE | F_HOVERABLE | F_AUTO_COLOR), innerLineWidth (1.5f), datum (
+                IMAGE), state (NORMAL) {
+}
+
+inline Circle::Circle () :
+        center (100, 100), radius (10), filled (false), radiusInImageSpace (
+                false) {
+}
+
+inline Rectangle::Rectangle () :
+        topLeft (0, 0), bottomRight (10, 10), filled (false) {
+}
+
+inline Polyline::Polyline () :
+        filled (false) {
+}
+
+inline Line::Line () :
+        begin (10, 10), end (100, 100) {
+}
+
+inline RGBAColor::RGBAColor () :
+        RGBColor (0., 0., 0.), a (0.) {
+}
+
+inline RGBColor::RGBColor () :
+        r (0.), g (0.), b (0.) {
+}
+
+inline RGBColor::RGBColor (double r, double g, double b) :
+        r (r), g (g), b (b) {
+}
+
+inline RGBColor::RGBColor (char r, char g, char b) :
+        r (double (r) / 255.), g (double (g) / 255.), b (double (b) / 255.) {
+}
+
+inline RGBAColor::RGBAColor (double r, double g, double b, double a) :
+        RGBColor (r, g, b), a (a) {
+}
+
+inline RGBAColor::RGBAColor (char r, char g, char b, char a) :
+        RGBColor (r, g, b), a (double (a) / 255.) {
+}
+
+inline Circle::Circle (rtengine::Coord& center, int radius, bool filled,
+        bool radiusInImageSpace) :
+        center (center), radius (radius), filled (filled), radiusInImageSpace (
+                radiusInImageSpace) {
+}
+
+inline Circle::Circle (int centerX, int centerY, int radius, bool filled,
+        bool radiusInImageSpace) :
+        center (centerX, centerY), radius (radius), filled (filled), radiusInImageSpace (
+                radiusInImageSpace) {
+}
+
+inline Line::Line (rtengine::Coord& begin, rtengine::Coord& end) :
+        begin (begin), end (end) {
+}
+
+inline Line::Line (int beginX, int beginY, int endX, int endY) :
+        begin (beginX, beginY), end (endX, endY) {
+}
 
 #endif

--- a/rtgui/gradient.cc
+++ b/rtgui/gradient.cc
@@ -136,88 +136,99 @@ void Gradient::read (const ProcParams* pp, const ParamsEdited* pedited)
     enableListener ();
 }
 
-void Gradient::updateGeometry(int centerX_, int centerY_, double feather_, double degree_)
+void Gradient::updateGeometry(const int centerX_, const int centerY_, const double feather_, const double degree_, const int fullWidth, const int fullHeight)
 {
     EditDataProvider* dataProvider = getEditProvider();
 
-    if (dataProvider) {
-        int imW, imH;
-        PolarCoord polCoord1, polCoord2;
-        dataProvider->getImageSize(imW, imH);
-        double decay = feather_ * sqrt(double(imW) * double(imW) + double(imH) * double(imH)) / 200.;
-
-        rtengine::Coord origin(imW / 2 + centerX_ * imW / 200.f, imH / 2 + centerY_ * imH / 200.f);
-
-        Line *currLine;
-        Circle *currCircle;
-        // update horizontal line
-        currLine = static_cast<Line*>(visibleGeometry.at(0));
-        polCoord1.set(1500.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1);
-        currLine->begin += origin;
-        polCoord1.set(1500.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1);
-        currLine->end   += origin;
-        currLine = static_cast<Line*>(mouseOverGeometry.at(0));
-        polCoord1.set(1500.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1);
-        currLine->begin += origin;
-        polCoord1.set(1500.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1);
-        currLine->end   += origin;
-        // update vertical line
-        currLine = static_cast<Line*>(visibleGeometry.at(1));
-        polCoord1.set( 700.f, float(-degree_ + 90 ));
-        currLine->begin.setFromPolar(polCoord1);
-        currLine->begin += origin;
-        polCoord1.set( 700.f, float(-degree_ + 270));
-        currLine->end.setFromPolar  (polCoord1);
-        currLine->end   += origin;
-        currLine = static_cast<Line*>(mouseOverGeometry.at(1));
-        polCoord1.set( 700.f, float(-degree_ + 90 ));
-        currLine->begin.setFromPolar(polCoord1);
-        currLine->begin += origin;
-        polCoord1.set( 700.f, float(-degree_ + 270));
-        currLine->end.setFromPolar  (polCoord1);
-        currLine->end   += origin;
-        // update upper feather line
-        currLine = static_cast<Line*>(visibleGeometry.at(2));
-        polCoord2.set(decay, float(-degree_ + 270));
-        polCoord1.set(350.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1 + polCoord2);
-        currLine->begin += origin;
-        polCoord1.set(350.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1 + polCoord2);
-        currLine->end   += origin;
-        currLine = static_cast<Line*>(mouseOverGeometry.at(2));
-        polCoord1.set(350.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1 + polCoord2);
-        currLine->begin += origin;
-        polCoord1.set(350.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1 + polCoord2);
-        currLine->end   += origin;
-        // update lower feather line
-        currLine = static_cast<Line*>(visibleGeometry.at(3));
-        polCoord2.set(decay, float(-degree_ + 90));
-        polCoord1.set(350.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1 + polCoord2);
-        currLine->begin += origin;
-        polCoord1.set(350.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1 + polCoord2);
-        currLine->end   += origin;
-        currLine = static_cast<Line*>(mouseOverGeometry.at(3));
-        polCoord1.set(350.f, float(-degree_ + 180));
-        currLine->begin.setFromPolar(polCoord1 + polCoord2);
-        currLine->begin += origin;
-        polCoord1.set(350.f, float(-degree_    ));
-        currLine->end.setFromPolar  (polCoord1 + polCoord2);
-        currLine->end   += origin;
-        // update circle's position
-        currCircle = static_cast<Circle*>(visibleGeometry.at(4));
-        currCircle->center = origin;
-        currCircle = static_cast<Circle*>(mouseOverGeometry.at(4));
-        currCircle->center = origin;
+    if (!dataProvider) {
+        return;
     }
+
+    int imW, imH;
+    if (fullWidth != -1 && fullHeight != -1) {
+        imW = fullWidth;
+        imH = fullHeight;
+    } else {
+        dataProvider->getImageSize(imW, imH);
+        if (!imW || !imH) {
+            return;
+        }
+    }
+
+    PolarCoord polCoord1, polCoord2;
+    double decay = feather_ * sqrt(double(imW) * double(imW) + double(imH) * double(imH)) / 200.;
+
+    rtengine::Coord origin(imW / 2 + centerX_ * imW / 200.f, imH / 2 + centerY_ * imH / 200.f);
+
+    Line *currLine;
+    Circle *currCircle;
+    // update horizontal line
+    currLine = static_cast<Line*>(visibleGeometry.at(0));
+    polCoord1.set(1500.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1);
+    currLine->begin += origin;
+    polCoord1.set(1500.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1);
+    currLine->end   += origin;
+    currLine = static_cast<Line*>(mouseOverGeometry.at(0));
+    polCoord1.set(1500.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1);
+    currLine->begin += origin;
+    polCoord1.set(1500.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1);
+    currLine->end   += origin;
+    // update vertical line
+    currLine = static_cast<Line*>(visibleGeometry.at(1));
+    polCoord1.set( 700.f, float(-degree_ + 90 ));
+    currLine->begin.setFromPolar(polCoord1);
+    currLine->begin += origin;
+    polCoord1.set( 700.f, float(-degree_ + 270));
+    currLine->end.setFromPolar  (polCoord1);
+    currLine->end   += origin;
+    currLine = static_cast<Line*>(mouseOverGeometry.at(1));
+    polCoord1.set( 700.f, float(-degree_ + 90 ));
+    currLine->begin.setFromPolar(polCoord1);
+    currLine->begin += origin;
+    polCoord1.set( 700.f, float(-degree_ + 270));
+    currLine->end.setFromPolar  (polCoord1);
+    currLine->end   += origin;
+    // update upper feather line
+    currLine = static_cast<Line*>(visibleGeometry.at(2));
+    polCoord2.set(decay, float(-degree_ + 270));
+    polCoord1.set(350.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1 + polCoord2);
+    currLine->begin += origin;
+    polCoord1.set(350.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1 + polCoord2);
+    currLine->end   += origin;
+    currLine = static_cast<Line*>(mouseOverGeometry.at(2));
+    polCoord1.set(350.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1 + polCoord2);
+    currLine->begin += origin;
+    polCoord1.set(350.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1 + polCoord2);
+    currLine->end   += origin;
+    // update lower feather line
+    currLine = static_cast<Line*>(visibleGeometry.at(3));
+    polCoord2.set(decay, float(-degree_ + 90));
+    polCoord1.set(350.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1 + polCoord2);
+    currLine->begin += origin;
+    polCoord1.set(350.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1 + polCoord2);
+    currLine->end   += origin;
+    currLine = static_cast<Line*>(mouseOverGeometry.at(3));
+    polCoord1.set(350.f, float(-degree_ + 180));
+    currLine->begin.setFromPolar(polCoord1 + polCoord2);
+    currLine->begin += origin;
+    polCoord1.set(350.f, float(-degree_    ));
+    currLine->end.setFromPolar  (polCoord1 + polCoord2);
+    currLine->end   += origin;
+    // update circle's position
+    currCircle = static_cast<Circle*>(visibleGeometry.at(4));
+    currCircle->center = origin;
+    currCircle = static_cast<Circle*>(mouseOverGeometry.at(4));
+    currCircle->center = origin;
 }
 
 void Gradient::write (ProcParams* pp, ParamsEdited* pedited)
@@ -399,7 +410,7 @@ bool Gradient::button1Pressed(int modifierKey)
 {
     EditDataProvider *provider = getEditProvider();
 
-    if (!(modifierKey & GDK_CONTROL_MASK)) {
+    if (!(modifierKey & GDK_CONTROL_MASK) && lastObject > -1) {
         // button press is valid (no modifier key)
         PolarCoord pCoord;
         int imW, imH;
@@ -447,20 +458,20 @@ bool Gradient::button1Pressed(int modifierKey)
 
         EditSubscriber::dragging = true;
         return false;
-    } else {
+    } else if (lastObject > -1) { // should theoretically always be true
         // this will let this class ignore further drag events
-        if (lastObject > -1) { // should theoretically always be true
-            if (lastObject == 2 || lastObject == 3) {
-                EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
-                EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
-            } else {
-                EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
-            }
+        if (lastObject == 2 || lastObject == 3) {
+            EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
+            EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
+        } else {
+            EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
         }
 
         lastObject = -1;
         return true;
     }
+
+    return false;
 }
 
 bool Gradient::button1Released()

--- a/rtgui/gradient.cc
+++ b/rtgui/gradient.cc
@@ -136,7 +136,7 @@ void Gradient::read (const ProcParams* pp, const ParamsEdited* pedited)
     enableListener ();
 }
 
-void Gradient::updateGeometry(const int centerX_, const int centerY_, const double feather_, const double degree_, const int fullWidth, const int fullHeight)
+void Gradient::updateGeometry(const int centerX, const int centerY, const double feather, const double degree, const int fullWidth, const int fullHeight)
 {
     EditDataProvider* dataProvider = getEditProvider();
 
@@ -144,7 +144,8 @@ void Gradient::updateGeometry(const int centerX_, const int centerY_, const doub
         return;
     }
 
-    int imW, imH;
+    int imW=0;
+    int imH=0;
     if (fullWidth != -1 && fullHeight != -1) {
         imW = fullWidth;
         imH = fullHeight;
@@ -156,79 +157,56 @@ void Gradient::updateGeometry(const int centerX_, const int centerY_, const doub
     }
 
     PolarCoord polCoord1, polCoord2;
-    double decay = feather_ * sqrt(double(imW) * double(imW) + double(imH) * double(imH)) / 200.;
+    double decay = feather * rtengine::norm2<double>(imW, imH) / 200.;
 
-    rtengine::Coord origin(imW / 2 + centerX_ * imW / 200.f, imH / 2 + centerY_ * imH / 200.f);
+    rtengine::Coord origin(imW / 2 + centerX * imW / 200, imH / 2 + centerY * imH / 200);
 
     Line *currLine;
     Circle *currCircle;
+
+    const auto updateLine = [&](Geometry* geometry, const float radius, const float begin, const float end)
+    {
+        const auto line = static_cast<Line*>(geometry);
+        line->begin.setFromPolar(PolarCoord(radius, -degree + begin));
+        line->begin += origin;
+        line->end.setFromPolar(PolarCoord(radius, -degree + end));
+        line->end += origin;
+    };
+
+    const auto updateLineWithDecay = [&](Geometry* geometry, const float radius, const float offSetAngle)
+    {
+        const auto line = static_cast<Line*>(geometry);
+        line->begin.setFromPolar(PolarCoord(radius, -degree + 180.) + PolarCoord(decay, -degree + offSetAngle));
+        line->begin += origin;
+        line->end.setFromPolar(PolarCoord(radius, -degree) + PolarCoord(decay, -degree + offSetAngle));
+        line->end += origin;
+    };
+
+    const auto updateCircle = [&](Geometry* geometry)
+    {
+        const auto circle = static_cast<Circle*>(geometry);
+        circle->center = origin;
+    };
+
     // update horizontal line
-    currLine = static_cast<Line*>(visibleGeometry.at(0));
-    polCoord1.set(1500.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1);
-    currLine->begin += origin;
-    polCoord1.set(1500.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1);
-    currLine->end   += origin;
-    currLine = static_cast<Line*>(mouseOverGeometry.at(0));
-    polCoord1.set(1500.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1);
-    currLine->begin += origin;
-    polCoord1.set(1500.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1);
-    currLine->end   += origin;
+    updateLine (visibleGeometry.at(0), 1500., 0., 180.);
+    updateLine (mouseOverGeometry.at(0), 1500., 0., 180.);
+
     // update vertical line
-    currLine = static_cast<Line*>(visibleGeometry.at(1));
-    polCoord1.set( 700.f, float(-degree_ + 90 ));
-    currLine->begin.setFromPolar(polCoord1);
-    currLine->begin += origin;
-    polCoord1.set( 700.f, float(-degree_ + 270));
-    currLine->end.setFromPolar  (polCoord1);
-    currLine->end   += origin;
-    currLine = static_cast<Line*>(mouseOverGeometry.at(1));
-    polCoord1.set( 700.f, float(-degree_ + 90 ));
-    currLine->begin.setFromPolar(polCoord1);
-    currLine->begin += origin;
-    polCoord1.set( 700.f, float(-degree_ + 270));
-    currLine->end.setFromPolar  (polCoord1);
-    currLine->end   += origin;
+    updateLine (visibleGeometry.at(1), 700., 90., 270.);
+    updateLine (mouseOverGeometry.at(1), 700., 90., 270.);
+
     // update upper feather line
-    currLine = static_cast<Line*>(visibleGeometry.at(2));
-    polCoord2.set(decay, float(-degree_ + 270));
-    polCoord1.set(350.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1 + polCoord2);
-    currLine->begin += origin;
-    polCoord1.set(350.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1 + polCoord2);
-    currLine->end   += origin;
-    currLine = static_cast<Line*>(mouseOverGeometry.at(2));
-    polCoord1.set(350.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1 + polCoord2);
-    currLine->begin += origin;
-    polCoord1.set(350.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1 + polCoord2);
-    currLine->end   += origin;
+    updateLineWithDecay (visibleGeometry.at(2), 350., 270.);
+    updateLineWithDecay (mouseOverGeometry.at(2), 350., 270.);
+
     // update lower feather line
-    currLine = static_cast<Line*>(visibleGeometry.at(3));
-    polCoord2.set(decay, float(-degree_ + 90));
-    polCoord1.set(350.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1 + polCoord2);
-    currLine->begin += origin;
-    polCoord1.set(350.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1 + polCoord2);
-    currLine->end   += origin;
-    currLine = static_cast<Line*>(mouseOverGeometry.at(3));
-    polCoord1.set(350.f, float(-degree_ + 180));
-    currLine->begin.setFromPolar(polCoord1 + polCoord2);
-    currLine->begin += origin;
-    polCoord1.set(350.f, float(-degree_    ));
-    currLine->end.setFromPolar  (polCoord1 + polCoord2);
-    currLine->end   += origin;
+    updateLineWithDecay (visibleGeometry.at(3), 350., 90.);
+    updateLineWithDecay (mouseOverGeometry.at(3), 350., 90.);
+
     // update circle's position
-    currCircle = static_cast<Circle*>(visibleGeometry.at(4));
-    currCircle->center = origin;
-    currCircle = static_cast<Circle*>(mouseOverGeometry.at(4));
-    currCircle->center = origin;
+    updateCircle (visibleGeometry.at(4));
+    updateCircle (mouseOverGeometry.at(4));
 }
 
 void Gradient::write (ProcParams* pp, ParamsEdited* pedited)
@@ -408,9 +386,13 @@ bool Gradient::mouseOver(int modifierKey)
 
 bool Gradient::button1Pressed(int modifierKey)
 {
+    if (lastObject < 0) {
+        return false;
+    }
+
     EditDataProvider *provider = getEditProvider();
 
-    if (!(modifierKey & GDK_CONTROL_MASK) && lastObject > -1) {
+    if (!(modifierKey & GDK_CONTROL_MASK)) {
         // button press is valid (no modifier key)
         PolarCoord pCoord;
         int imW, imH;
@@ -458,7 +440,7 @@ bool Gradient::button1Pressed(int modifierKey)
 
         EditSubscriber::dragging = true;
         return false;
-    } else if (lastObject > -1) { // should theoretically always be true
+    } else { // should theoretically always be true
         // this will let this class ignore further drag events
         if (lastObject == 2 || lastObject == 3) {
             EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;

--- a/rtgui/gradient.h
+++ b/rtgui/gradient.h
@@ -46,7 +46,7 @@ public:
     void enabledChanged  ();
     void setAdjusterBehavior (bool degreeadd, bool featheradd, bool strengthadd, bool centeradd);
     void trimValues          (rtengine::procparams::ProcParams* pp);
-    void updateGeometry  (const int centerX_, const int centerY_, const double feather_, const double degree_, const int fullWidth=-1, const int fullHeight=-1);
+    void updateGeometry  (const int centerX, const int centerY, const double feather, const double degree, const int fullWidth=-1, const int fullHeight=-1);
 
     void setEditProvider (EditDataProvider* provider);
 

--- a/rtgui/gradient.h
+++ b/rtgui/gradient.h
@@ -42,12 +42,11 @@ public:
     void setDefaults    (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = NULL);
     void setBatchMode   (bool batchMode);
 
-    void updateGeometry (int centerX_, int centerY_, double feather_, double degree_);
-
     void adjusterChanged (Adjuster* a, double newval);
     void enabledChanged  ();
     void setAdjusterBehavior (bool degreeadd, bool featheradd, bool strengthadd, bool centeradd);
     void trimValues          (rtengine::procparams::ProcParams* pp);
+    void updateGeometry  (const int centerX_, const int centerY_, const double feather_, const double degree_, const int fullWidth=-1, const int fullHeight=-1);
 
     void setEditProvider (EditDataProvider* provider);
 

--- a/rtgui/imagearea.cc
+++ b/rtgui/imagearea.cc
@@ -96,10 +96,10 @@ void ImageArea::on_resized (Gtk::Allocation& req)
             mainCropWindow->setPointerMotionListener (pmlistener);
             mainCropWindow->setPointerMotionHListener (pmhlistener);
             mainCropWindow->setPosition (0, 0);
-            mainCropWindow->setSize (get_width(), get_height(), false);  // this execute the refresh itself
+            mainCropWindow->setSize (get_width(), get_height());  // this execute the refresh itself
             mainCropWindow->enable();  // start processing !
         } else {
-            mainCropWindow->setSize (get_width(), get_height());
+            mainCropWindow->setSize (get_width(), get_height());  // this execute the refresh itself
         }
 
         parent->syncBeforeAfterViews();
@@ -326,13 +326,12 @@ bool ImageArea::on_leave_notify_event  (GdkEventCrossing* event)
 
 void ImageArea::subscribe(EditSubscriber *subscriber)
 {
-    mainCropWindow->setEditSubscriber(subscriber);
+    EditDataProvider::subscribe(subscriber);
 
+    mainCropWindow->setEditSubscriber(subscriber);
     for (auto cropWin : cropWins) {
         cropWin->setEditSubscriber(subscriber);
     }
-
-    EditDataProvider::subscribe(subscriber);
 
     if (listener && listener->getToolBar()) {
         listener->getToolBar()->startEditMode ();
@@ -354,11 +353,11 @@ void ImageArea::unsubscribe()
     }
 
     EditDataProvider::unsubscribe();
-    // Ask the Crops to free-up edit mode buffers
-    mainCropWindow->cropHandler.setEditSubscriber(NULL);
 
+    // Ask the Crops to free-up edit mode buffers
+    mainCropWindow->setEditSubscriber(NULL);
     for (auto cropWin : cropWins) {
-        cropWin->cropHandler.setEditSubscriber(NULL);
+        cropWin->setEditSubscriber(NULL);
     }
 
     setToolHand();
@@ -619,10 +618,7 @@ void ImageArea::initialImageArrived (CropWindow* cw)
             mainCropWindow->cropHandler.getFullImageSize(w, h);
 
             if(w != fullImageWidth || h != fullImageHeight) {
-                printf("zoomFit !\n");
                 mainCropWindow->zoomFit ();
-            } else {
-                printf("no-zoomFit\n");
             }
 
             fullImageWidth = w;

--- a/rtgui/imageareapanel.cc
+++ b/rtgui/imageareapanel.cc
@@ -84,9 +84,7 @@ void ImageAreaPanel::synchronize ()
         after->imageArea->getScrollPosition (x, y);
 
         if (imgw > 0 && imgh > 0) {
-            int bimgw, bimgh;
-            imageArea->getScrollImageSize (bimgw, bimgh);
-            imageArea->setScrollPosition (x * bimgw / imgw, y * bimgh / imgh);
+            imageArea->setScrollPosition (x, y);
             imageArea->queue_draw ();
         }
     } else if (before && this == after) {
@@ -95,9 +93,7 @@ void ImageAreaPanel::synchronize ()
         before->imageArea->getScrollPosition (x, y);
 
         if (imgw > 0 && imgh > 0) {
-            int bimgw, bimgh;
-            imageArea->getScrollImageSize (bimgw, bimgh);
-            imageArea->setScrollPosition (x * bimgw / imgw, y * bimgh / imgh);
+            imageArea->setScrollPosition (x, y);
             imageArea->queue_draw ();
         }
     }

--- a/rtgui/previewhandler.cc
+++ b/rtgui/previewhandler.cc
@@ -204,27 +204,19 @@ Glib::RefPtr<Gdk::Pixbuf> PreviewHandler::getRoughImage (int x, int y, int w, in
             h = image->getHeight() * totalZoom;
         }
 
-        int ix = x * zoom;
-        int iy = y * zoom;
+        x *= zoom;
+        y *= zoom;
 
-        if (ix < 0) {
-            ix = 0;
+        if ((x + w) / totalZoom > previewImg->get_width()) {
+            w = previewImg->get_width() * totalZoom - x;
         }
 
-        if (iy < 0) {
-            iy = 0;
-        }
-
-        if ((ix + w) / totalZoom > previewImg->get_width()) {
-            ix = previewImg->get_width() * totalZoom - w;
-        }
-
-        if ((iy + h) / totalZoom > previewImg->get_height()) {
-            iy = previewImg->get_height() * totalZoom - h;
+        if ((y + h) / totalZoom > previewImg->get_height()) {
+            h = previewImg->get_height() * totalZoom - y;
         }
 
         resPixbuf = Gdk::Pixbuf::create (Gdk::COLORSPACE_RGB, false, 8, w, h);
-        previewImg->scale (resPixbuf, 0, 0, w, h, -ix, -iy, totalZoom, totalZoom, Gdk::INTERP_NEAREST);
+        previewImg->scale (resPixbuf, 0, 0, w, h, -x, -y, totalZoom, totalZoom, Gdk::INTERP_NEAREST);
     }
 
     return resPixbuf;

--- a/rtgui/previewhandler.cc
+++ b/rtgui/previewhandler.cc
@@ -207,13 +207,8 @@ Glib::RefPtr<Gdk::Pixbuf> PreviewHandler::getRoughImage (int x, int y, int w, in
         x *= zoom;
         y *= zoom;
 
-        if ((x + w) / totalZoom > previewImg->get_width()) {
-            w = previewImg->get_width() * totalZoom - x;
-        }
-
-        if ((y + h) / totalZoom > previewImg->get_height()) {
-            h = previewImg->get_height() * totalZoom - y;
-        }
+        w = rtengine::LIM<int>(w, 0, int(previewImg->get_width() * totalZoom) - x);
+        h = rtengine::LIM<int>(h, 0, int(previewImg->get_height() * totalZoom) - y);
 
         resPixbuf = Gdk::Pixbuf::create (Gdk::COLORSPACE_RGB, false, 8, w, h);
         previewImg->scale (resPixbuf, 0, 0, w, h, -x, -y, totalZoom, totalZoom, Gdk::INTERP_NEAREST);

--- a/rtgui/previewwindow.cc
+++ b/rtgui/previewwindow.cc
@@ -100,48 +100,50 @@ void PreviewWindow::on_resized (Gtk::Allocation& req)
 bool PreviewWindow::on_expose_event (GdkEventExpose* event)
 {
 
-    if (backBuffer) {
-        Glib::RefPtr<Gdk::Window> window = get_window();
+    if (!backBuffer) {
+        return true;
+    }
 
-        int bufferW, bufferH;
-        backBuffer->get_size (bufferW, bufferH);
+    Glib::RefPtr<Gdk::Window> window = get_window();
 
-        if (!mainCropWin && imageArea) {
-            mainCropWin = imageArea->getMainCropWindow ();
+    int bufferW, bufferH;
+    backBuffer->get_size (bufferW, bufferH);
 
-            if (mainCropWin) {
-                mainCropWin->addCropWindowListener (this);
-            }
+    if (!mainCropWin && imageArea) {
+        mainCropWin = imageArea->getMainCropWindow ();
+
+        if (mainCropWin) {
+            mainCropWin->addCropWindowListener (this);
         }
+    }
 
-        if ((get_width() != bufferW && get_height() != bufferH) || needsUpdate) {
-            needsUpdate = false;
-            updatePreviewImage ();
-        }
+    if ((get_width() != bufferW && get_height() != bufferH) || needsUpdate) {
+        needsUpdate = false;
+        updatePreviewImage ();
+    }
 
-        window->draw_drawable (get_style()->get_base_gc(Gtk::STATE_NORMAL), backBuffer, 0, 0, 0, 0, -1, -1);
+    window->draw_drawable (get_style()->get_base_gc(Gtk::STATE_NORMAL), backBuffer, 0, 0, 0, 0, -1, -1);
 
-        if (mainCropWin && zoom > 0.0) {
-            if(mainCropWin->getZoom() > mainCropWin->cropHandler.getFitZoom()) {
-                Cairo::RefPtr<Cairo::Context> cr = get_window()->create_cairo_context();
-                int x, y, w, h;
-                getObservedFrameArea (x, y, w, h);
-                double rectX = x + 0.5;
-                double rectY = y + 0.5;
-                double rectW = std::min(w, (int)(imgW - (x - imgX) - 1));
-                double rectH = std::min(h, (int)(imgH - (y - imgY) - 1));
+    if (mainCropWin && zoom > 0.0) {
+        Cairo::RefPtr<Cairo::Context> cr = get_window()->create_cairo_context();
+        int x, y, w, h;
+        getObservedFrameArea (x, y, w, h);
+        if (x>imgX || y>imgY || w < imgW || h < imgH) {
+            double rectX = x + 0.5;
+            double rectY = y + 0.5;
+            double rectW = std::min(w, (int)(imgW - (x - imgX) - 1));
+            double rectH = std::min(h, (int)(imgH - (y - imgY) - 1));
 
-                // draw a black "shadow" line
-                cr->set_source_rgba (0.0, 0.0, 0.0, 0.65);
-                cr->set_line_width (1);
-                cr->rectangle (rectX + 1., rectY + 1, rectW, rectH);
-                cr->stroke ();
+            // draw a black "shadow" line
+            cr->set_source_rgba (0.0, 0.0, 0.0, 0.65);
+            cr->set_line_width (1);
+            cr->rectangle (rectX + 1., rectY + 1, rectW, rectH);
+            cr->stroke ();
 
-                // draw a "frame" line. Color of frame line can be set in preferences
-                cr->set_source_rgba(options.navGuideBrush[0], options.navGuideBrush[1], options.navGuideBrush[2], options.navGuideBrush[3]); //( 1.0, 1.0, 1.0, 1.0);
-                cr->rectangle (rectX, rectY, rectW, rectH);
-                cr->stroke ();
-            }
+            // draw a "frame" line. Color of frame line can be set in preferences
+            cr->set_source_rgba(options.navGuideBrush[0], options.navGuideBrush[1], options.navGuideBrush[2], options.navGuideBrush[3]); //( 1.0, 1.0, 1.0, 1.0);
+            cr->rectangle (rectX, rectY, rectW, rectH);
+            cr->stroke ();
         }
     }
 
@@ -191,9 +193,9 @@ bool PreviewWindow::on_motion_notify_event (GdkEventMotion* event)
         return true;
     }
 
-    if(mainCropWin->getZoom() > mainCropWin->cropHandler.getFitZoom()) {
-        int x, y, w, h;
-        getObservedFrameArea (x, y, w, h);
+    int x, y, w, h;
+    getObservedFrameArea (x, y, w, h);
+    if (x>imgX || y>imgY || w < imgW || h < imgH) {
         bool inside = event->x > x - 6 && event->x < x + w - 1 + 6 && event->y > y - 6 && event->y < y + h - 1 + 6;
         bool moreInside = event->x > x + 6 && event->x < x + w - 1 - 6 && event->y > y + 6 && event->y < y + h - 1 - 6;
 
@@ -207,7 +209,7 @@ bool PreviewWindow::on_motion_notify_event (GdkEventMotion* event)
             cursorManager.setCursor (get_window(), CSArrow);
         }
     }
-
+    
     return true;
 }
 
@@ -218,9 +220,9 @@ bool PreviewWindow::on_button_press_event (GdkEventButton* event)
         return true;
     }
 
-    if(mainCropWin->getZoom() > mainCropWin->cropHandler.getFitZoom()) {
-        int x, y, w, h;
-        getObservedFrameArea (x, y, w, h);
+    int x, y, w, h;
+    getObservedFrameArea (x, y, w, h);
+    if (x>imgX || y>imgY || w < imgW || h < imgH) {
         bool inside = event->x > x - 6 && event->x < x + w - 1 + 6 && event->y > y - 6 && event->y < y + h - 1 + 6;
         bool moreInside = event->x > x + 6 && event->x < x + w - 1 - 6 && event->y > y + 6 && event->y < y + h - 1 - 6;
 

--- a/rtgui/previewwindow.cc
+++ b/rtgui/previewwindow.cc
@@ -199,6 +199,8 @@ bool PreviewWindow::on_motion_notify_event (GdkEventMotion* event)
 
         if (isMoving) {
             mainCropWin->remoteMove ((event->x - press_x) / zoom, (event->y - press_y) / zoom);
+            press_x = event->x;
+            press_y = event->y;
         } else if (inside && !moreInside) {
             cursorManager.setCursor (get_window(), CSClosedHand);
         } else {

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -349,8 +349,7 @@ void ToolPanelCoordinator::panelChanged (rtengine::ProcEvent event, const Glib::
     if (event == rtengine::EvPhotoLoaded || event == rtengine::EvProfileChanged || event == rtengine::EvHistoryBrowsed || event == rtengine::EvCTRotate) {
         // updating the "on preview" geometry
         int fw, fh;
-        rtengine::ImageSource *ii = (rtengine::ImageSource*)ipc->getInitialImage();
-        ii->getFullSize (fw, fh, tr);
+        ipc->getInitialImage()->getImageSource()->getFullSize (fw, fh, tr);
         gradient->updateGeometry (params->gradient.centerX, params->gradient.centerY, params->gradient.feather, params->gradient.degree, fw, fh);
     }
 
@@ -430,8 +429,7 @@ void ToolPanelCoordinator::profileChange  (const PartialProfile *nparams, rtengi
     }
 
     // trimming overflowing cropped area
-    rtengine::ImageSource *ii = (rtengine::ImageSource*)ipc->getInitialImage();
-    ii->getFullSize (fw, fh, tr);
+    ipc->getInitialImage()->getImageSource()->getFullSize (fw, fh, tr);
     crop->trim(params, fw, fh);
 
     // updating the GUI with updated values

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -269,8 +269,8 @@ ToolPanelCoordinator::ToolPanelCoordinator () : ipc(NULL)
     toolPanelNotebook->set_scrollable ();
     toolPanelNotebook->show_all ();
 
-    for (size_t i = 0; i < toolPanels.size(); i++) {
-        toolPanels[i]->setListener (this);
+    for (auto toolPanel : toolPanels) {
+        toolPanel->setListener (this);
     }
 
     whitebalance->setWBProvider (this);
@@ -323,8 +323,8 @@ void ToolPanelCoordinator::panelChanged (rtengine::ProcEvent event, const Glib::
 
     ProcParams* params = ipc->beginUpdateParams ();
 
-    for (size_t i = 0; i < toolPanels.size(); i++) {
-        toolPanels[i]->write (params);
+    for (auto toolPanel : toolPanels) {
+        toolPanel->write (params);
     }
 
     // Compensate rotation on flip
@@ -334,6 +334,24 @@ void ToolPanelCoordinator::panelChanged (rtengine::ProcEvent event, const Glib::
             changeFlags |= refreshmap[(int)rtengine::EvROTDegree];
             rotate->read (params);
         }
+    }
+
+    int tr = TR_NONE;
+    if (params->coarse.rotate == 90) {
+        tr = TR_R90;
+    } else if (params->coarse.rotate == 180) {
+        tr = TR_R180;
+    } else if (params->coarse.rotate == 270) {
+        tr = TR_R270;
+    }
+
+    // Update "on preview" geometry
+    if (event == rtengine::EvPhotoLoaded || event == rtengine::EvProfileChanged || event == rtengine::EvHistoryBrowsed || event == rtengine::EvCTRotate) {
+        // updating the "on preview" geometry
+        int fw, fh;
+        rtengine::ImageSource *ii = (rtengine::ImageSource*)ipc->getInitialImage();
+        ii->getFullSize (fw, fh, tr);
+        gradient->updateGeometry (params->gradient.centerX, params->gradient.centerY, params->gradient.feather, params->gradient.degree, fw, fh);
     }
 
     // some transformations make the crop change for convenience
@@ -357,8 +375,8 @@ void ToolPanelCoordinator::panelChanged (rtengine::ProcEvent event, const Glib::
 
     hasChanged = true;
 
-    for (size_t i = 0; i < paramcListeners.size(); i++) {
-        paramcListeners[i]->procParamsChanged (params, event, descr);
+    for (auto paramcListener : paramcListeners) {
+        paramcListener->procParamsChanged (params, event, descr);
     }
 }
 
@@ -403,17 +421,12 @@ void ToolPanelCoordinator::profileChange  (const PartialProfile *nparams, rtengi
     delete mergedParams;
 
     tr = TR_NONE;
-
     if (params->coarse.rotate == 90) {
-        tr |= TR_R90;
-    }
-
-    if (params->coarse.rotate == 180) {
-        tr |= TR_R180;
-    }
-
-    if (params->coarse.rotate == 270) {
-        tr |= TR_R270;
+        tr = TR_R90;
+    } else if (params->coarse.rotate == 180) {
+        tr = TR_R180;
+    } else if (params->coarse.rotate == 270) {
+        tr = TR_R270;
     }
 
     // trimming overflowing cropped area
@@ -422,12 +435,17 @@ void ToolPanelCoordinator::profileChange  (const PartialProfile *nparams, rtengi
     crop->trim(params, fw, fh);
 
     // updating the GUI with updated values
-    for (unsigned int i = 0; i < toolPanels.size(); i++) {
-        toolPanels[i]->read (params);
+    for (auto toolPanel : toolPanels) {
+        toolPanel->read (params);
 
         if (event == rtengine::EvPhotoLoaded || event == rtengine::EvProfileChanged) {
-            toolPanels[i]->autoOpenCurve();
+            toolPanel->autoOpenCurve();
         }
+    }
+
+    if (event == rtengine::EvPhotoLoaded || event == rtengine::EvProfileChanged || event == rtengine::EvHistoryBrowsed || event == rtengine::EvCTRotate) {
+        // updating the "on preview" geometry
+        gradient->updateGeometry (params->gradient.centerX, params->gradient.centerY, params->gradient.feather, params->gradient.degree, fw, fh);
     }
 
     // start the IPC processing
@@ -439,8 +457,8 @@ void ToolPanelCoordinator::profileChange  (const PartialProfile *nparams, rtengi
 
     hasChanged = event != rtengine::EvProfileChangeNotification;
 
-    for (size_t i = 0; i < paramcListeners.size(); i++) {
-        paramcListeners[i]->procParamsChanged (params, event, descr);
+    for (auto paramcListener : paramcListeners) {
+        paramcListener->procParamsChanged (params, event, descr);
     }
 }
 
@@ -448,8 +466,8 @@ void ToolPanelCoordinator::setDefaults (ProcParams* defparams)
 {
 
     if (defparams)
-        for (size_t i = 0; i < toolPanels.size(); i++) {
-            toolPanels[i]->setDefaults (defparams);
+        for (auto toolPanel : toolPanels) {
+            toolPanel->setDefaults (defparams);
         }
 }
 
@@ -746,9 +764,9 @@ void ToolPanelCoordinator::updateCurveBackgroundHistogram (LUTu & histToneCurve,
 void ToolPanelCoordinator::foldAllButOne (Gtk::Box* parent, FoldableToolPanel* openedSection)
 {
 
-    for (size_t i = 0; i < toolPanels.size(); i++) {
-        if (toolPanels[i]->getParent() != NULL) {
-            ToolPanel* currentTP = toolPanels[i];
+    for (auto toolPanel : toolPanels) {
+        if (toolPanel->getParent() != NULL) {
+            ToolPanel* currentTP = toolPanel;
 
             if (currentTP->getParent() == parent) {
                 // Section in the same tab, we unfold it if it's not the one that has been clicked

--- a/tools/coordinate_system.svg
+++ b/tools/coordinate_system.svg
@@ -13,10 +13,38 @@
    height="1052.3622047"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="coordinate_system.svg">
   <defs
      id="defs4">
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4672"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#969696;stroke-width:1pt;stroke-opacity:1;fill:#969696;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path4674" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker4626"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#969696;stroke-width:1pt;stroke-opacity:1;fill:#969696;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path4628" />
+    </marker>
     <marker
        inkscape:stockid="Arrow1Lstart"
        orient="auto"
@@ -57,6 +85,19 @@
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4878"
+       x="-0.033017408"
+       width="1.0660348"
+       y="-0.32826923"
+       height="1.6565385">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="10.058594"
+         id="feGaussianBlur4880" />
+    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -65,16 +106,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.70710678"
-     inkscape:cx="299.66147"
-     inkscape:cy="714.81018"
+     inkscape:zoom="0.5"
+     inkscape:cx="452.14874"
+     inkscape:cy="827.47718"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="991"
-     inkscape:window-height="915"
-     inkscape:window-x="738"
-     inkscape:window-y="60"
+     inkscape:window-width="1665"
+     inkscape:window-height="920"
+     inkscape:window-x="168"
+     inkscape:window-y="40"
      inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true" />
@@ -94,6 +135,27 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1">
+    <rect
+       y="-293.04019"
+       x="-78.267029"
+       height="73.539108"
+       width="731.14844"
+       id="rect4800"
+       style="opacity:0.5;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4878)" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4798"
+       width="731.14844"
+       height="73.539108"
+       x="-86.267029"
+       y="-301.04019" />
+    <rect
+       y="271.4635"
+       x="-69.296463"
+       height="527.3504"
+       width="885.09576"
+       id="rect3410"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
        style="opacity:1;fill:#aaaaaa;fill-opacity:1;stroke:none"
        id="rect2993"
@@ -117,54 +179,49 @@
        y="271.4635" />
     <text
        xml:space="preserve"
-       style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="724.4317"
-       y="1097.9205"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       x="393.50574"
+       y="1104.9916"
        id="text3804"
        sodipodi:linespacing="125%"><tspan
          sodipodi:role="line"
          id="tspan3806"
-         x="724.4317"
-         y="1097.9205">imgAreaW</tspan></text>
+         x="393.50574"
+         y="1104.9916">imgAreaW</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="-969.88525"
-       y="783.78394"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       x="-931.88525"
+       y="925.78394"
        id="text3808"
        sodipodi:linespacing="125%"
        transform="matrix(0,-1,1,0,0,0)"><tspan
          sodipodi:role="line"
          id="tspan3810"
-         x="-969.88525"
-         y="783.78394">imgAreaH</tspan></text>
+         x="-931.88525"
+         y="925.78394">imgAreaH</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 630.33519,1073.6769 c 81.82235,0 117.17769,0 117.17769,0"
+       style="fill:none;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       d="m 1.8732037,1119.6769 c 517.6606863,0 741.3412663,0 741.3412663,0"
        id="path3812"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 760.64487,954.37739 0,97.98481"
+       style="fill:none;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 940.64484,664.46366 0,387.00414"
        id="path3814"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 780.84792,1052.3622 -35.35534,0 0,35.3553"
-       id="path3816"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="3.2830606"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       x="163.28305"
        y="200.49203"
        id="text3804-1"
        sodipodi:linespacing="125%"><tspan
          sodipodi:role="line"
-         x="3.2830606"
+         x="163.28305"
          y="200.49203"
          id="tspan5224"
-         style="font-size:14px">leftBorder</tspan></text>
+         style="font-size:14px">cropHandler.getCrop()-&gt;getLeftBorder()</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
        d="m -20.712438,227.69388 c 15.3477121,0 21.9794413,0 21.9794413,0"
@@ -192,17 +249,17 @@
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="-239.34459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       x="-221.34459"
        y="-85.32505"
        id="text5604"
        sodipodi:linespacing="125%"
        transform="matrix(0,-1,1,0,0,0)"><tspan
          sodipodi:role="line"
          id="tspan5606"
-         x="-239.34459"
+         x="-221.34459"
          y="-85.32505"
-         style="font-size:14px">upperBorder</tspan></text>
+         style="font-size:14px">cropHandler.getCrop()-&gt;getUpperBorder()</tspan></text>
     <rect
        y="182.76044"
        x="1010.2919"
@@ -277,17 +334,17 @@
     <path
        inkscape:connector-curvature="0"
        id="path5630"
-       d="m -151.14286,272.55957 0,-271.4238"
-       style="fill:#0000ff;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart);fill-opacity:1"
+       d="m -211.14286,272.55957 0,-271.4238"
+       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
        sodipodi:nodetypes="cc" />
     <path
        inkscape:connector-curvature="0"
        id="path5632"
-       d="m -107.42857,270.93361 -48.57143,0"
+       d="m -107.42857,270.93361 -117.16079,0"
        style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m -3.9596642,1.2452264 -156.5142958,0"
+       d="m -3.9596643,1.2452265 -222.2752357,0"
        id="path5634"
        inkscape:connector-curvature="0" />
     <path
@@ -326,16 +383,16 @@
          style="font-size:14px">imgX</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none"
        x="-134.76872"
-       y="-163.5605"
+       y="-223.5605"
        id="text6020"
        sodipodi:linespacing="125%"
        transform="matrix(0,-1,1,0,0,0)"><tspan
          sodipodi:role="line"
          id="tspan6022"
          x="-134.76872"
-         y="-163.5605"
+         y="-223.5605"
          style="font-size:14px">imgY</tspan></text>
     <rect
        y="108.29912"
@@ -350,10 +407,10 @@
        height="230.92076"
        width="273.14529"
        id="rect6028"
-       style="fill:#aaaaaa;fill-opacity:1;stroke:none" />
+       style="fill:#ffffff;fill-opacity:1;stroke:none" />
     <path
-       style="fill:none;stroke:#00d500;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
-       d="m -1.7638416,-138.20953 348.7074816,0"
+       style="fill:none;stroke:#00d500;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       d="m 1.7050376,-138.20953 342.7697224,0"
        id="path6030"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -377,19 +434,19 @@
          style="font-size:14px">xpos</tspan></text>
     <path
        sodipodi:nodetypes="cc"
-       style="fill:#0101ff;fill-opacity:1;stroke:#00d500;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
-       d="m 345.91779,42.117984 0,-189.631354"
+       style="fill:#0101ff;fill-opacity:1;stroke:#00d500;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 345.91781,104.11799 0,-251.63137"
        id="path6038"
        inkscape:connector-curvature="0" />
     <path
        sodipodi:nodetypes="cc"
-       style="fill:#0000ff;fill-opacity:1;stroke:#00d500;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
-       d="m -43.14286,115.27439 0,-121.8534376"
+       style="fill:#0000ff;fill-opacity:1;stroke:#00d500;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       d="m -43.14286,106.70337 0,-104.461397"
        id="path6040"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#00d500;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 279.23572,108.93361 -341.400037,0"
+       style="fill:none;stroke:#00d500;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 335.23571,108.9336 -397.400024,0"
        id="path6042"
        inkscape:connector-curvature="0" />
     <text
@@ -408,43 +465,37 @@
          y="-61.683151"
          style="font-size:14px">ypos</tspan></text>
     <path
-       style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
-       d="m 343.23616,54.290469 13.70748,0"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
+       d="m 343.23616,-45.709531 13.70748,0"
        id="path6048"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path6050"
-       d="m 345.85714,103.75231 0,-60.735258"
-       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
        sodipodi:nodetypes="cc" />
     <text
        sodipodi:linespacing="125%"
        id="text6052"
-       y="34.583218"
-       x="349.59616"
-       style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
+       y="-54.916779"
+       x="379.59616"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
-         y="34.583218"
-         x="349.59616"
+         y="-54.916779"
+         x="379.59616"
          id="tspan6054"
-         sodipodi:role="line">imgX</tspan></text>
+         sodipodi:role="line">imgAreaX</tspan></text>
     <path
        sodipodi:nodetypes="cc"
-       style="fill:#0000ff;fill-opacity:1;stroke:#0101ff;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
-       d="m 353.85714,146.29539 0,-102.821417"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 353.85713,146.29539 0,-204.821419"
        id="path6056"
        inkscape:connector-curvature="0" />
     <path
        sodipodi:nodetypes="cc"
-       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
-       d="m 294.39329,156.93092 0,-59.258382"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lend-0);marker-end:url(#Arrow1Lstart)"
+       d="m 294.39329,159.35722 0,-50.11098"
        id="path6058"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 345.95545,156.93361 -59.83945,0"
+       style="fill:none;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 345.95544,156.9336 -129.84302,0"
        id="path6060"
        inkscape:connector-curvature="0" />
     <path
@@ -455,25 +506,20 @@
        sodipodi:cy="287.11218"
        sodipodi:cx="15.25"
        id="path6062"
-       style="fill:#0000ff;fill-opacity:1;stroke:none"
+       style="fill:#000000;fill-opacity:1;stroke:none"
        sodipodi:type="arc" />
     <text
        transform="matrix(0,-1,1,0,0,0)"
        sodipodi:linespacing="125%"
        id="text6064"
-       y="280.43951"
-       x="-147.26872"
-       style="font-size:14px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
+       y="283.43951"
+       x="-88.268723"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
-         y="280.43951"
-         x="-147.26872"
+         y="283.43951"
+         x="-88.268723"
          id="tspan6066"
-         sodipodi:role="line">imgY</tspan></text>
-    <path
-       inkscape:connector-curvature="0"
-       id="path6068"
-       d="m 337.95545,108.93361 -59.83945,0"
-       style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         sodipodi:role="line">imgAreaY</tspan></text>
     <rect
        y="132.46352"
        x="330.78668"
@@ -501,25 +547,336 @@
          y="31.362183" /></text>
     <text
        xml:space="preserve"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
-       x="479.60809"
-       y="-14.880458"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       x="10.089189"
+       y="-4.9809637"
        id="text6082"
        sodipodi:linespacing="125%"><tspan
          sodipodi:role="line"
          id="tspan6084"
-         x="479.60809"
-         y="-14.880458">CropWindow  (mainCropWindow)</tspan></text>
+         x="10.089189"
+         y="-4.9809637">CropWindow  (mainCropWindow)</tspan></text>
     <text
        sodipodi:linespacing="125%"
        id="text6086"
-       y="100.36218"
-       x="532"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Sans"
+       y="103.7764"
+       x="432.70352"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
-         y="100.36218"
-         x="532"
+         y="103.7764"
+         x="432.70352"
          id="tspan6088"
-         sodipodi:role="line">CropWindow</tspan></text>
+         sodipodi:role="line">CropWindow (detail)</tspan></text>
+    <text
+       inkscape:transform-center-y="-8"
+       inkscape:transform-center-x="8.5"
+       sodipodi:linespacing="125%"
+       id="text4240"
+       y="425.70987"
+       x="1114.1865"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="425.70987"
+         x="1114.1865"
+         id="tspan4242"
+         sodipodi:role="line">Scaled full image</tspan></text>
+    <rect
+       style="fill:none;stroke:#969696;stroke-width:1.99999988;stroke-miterlimit:4;stroke-dasharray:3.99999995, 3.99999994999999990;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4244"
+       width="1065.0957"
+       height="715.3504"
+       x="-159.29646"
+       y="177.4635" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       x="1113.7354"
+       y="494.30157"
+       id="text4246"
+       sodipodi:linespacing="125%"
+       inkscape:transform-center-x="8.5"
+       inkscape:transform-center-y="-8"><tspan
+         sodipodi:role="line"
+         id="tspan4248"
+         x="1113.7354"
+         y="494.30157">Editing canvas = Full image + padding, Scaled</tspan></text>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#969696;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend);fill-opacity:1"
+       d="m 816,653.36218 89,0"
+       id="path4250"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:14px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#969696;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="954"
+       y="641.36218"
+       id="text4608"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4610"
+         x="954"
+         y="641.36218">cropHandler.getCrop()-&gt;getPadding()</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4624"
+       d="m 895.99996,653.36208 319.00004,0"
+       style="fill:none;fill-rule:evenodd;stroke:#969696;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:4,4;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4790"
+       width="82.92926"
+       height="44.350399"
+       x="1010.7867"
+       y="400.4635" />
+    <rect
+       y="468.4635"
+       x="1010.7867"
+       height="44.350399"
+       width="82.92926"
+       id="rect4792"
+       style="fill:none;stroke:#969696;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:4, 4;stroke-dashoffset:0;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="-69.296463"
+       y="-255.78535"
+       id="text4794"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4796"
+         x="-69.296463"
+         y="-255.78535"
+         style="font-size:35px">CropWindow class, geometry explained</tspan></text>
+    <rect
+       style="fill:#aaaaaa;fill-opacity:1;stroke:none"
+       id="rect4278"
+       width="222.23361"
+       height="185.66592"
+       x="404.46506"
+       y="201.20769" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4280"
+       d="m 353.46717,64.290469 49.74544,0"
+       style="fill:none;stroke:#0000ff;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none"
+       x="361.09616"
+       y="46.083218"
+       id="text4282"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4284"
+         x="361.09616"
+         y="46.083218">imgX</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4286"
+       d="m 403.85714,190.29539 0,-135.321416"
+       style="fill:#0000ff;fill-opacity:1;stroke:#0101ff;stroke-width:1.51763952px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <circle
+       style="fill:#0000ff;fill-opacity:1;stroke:none"
+       id="path4288"
+       cx="403.75"
+       cy="202.61218"
+       r="3.75" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4290"
+       d="m 230.39329,198.88275 0,-41.0199"
+       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4292"
+       d="m 393.95546,200.93361 -171.83946,0"
+       style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none"
+       x="-191.26872"
+       y="216.43951"
+       id="text4294"
+       sodipodi:linespacing="125%"
+       transform="matrix(0,-1,1,0,0,0)"><tspan
+         sodipodi:role="line"
+         id="tspan4296"
+         x="-191.26872"
+         y="216.43951">imgY</tspan></text>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4298"
+       y="459.92047"
+       x="524.4317"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="459.92047"
+         x="524.4317"
+         id="tspan4300"
+         sodipodi:role="line">imgAreaW</tspan></text>
+    <text
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4302"
+       y="697.78394"
+       x="-287.88525"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:end;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="697.78394"
+         x="-287.88525"
+         id="tspan4304"
+         sodipodi:role="line">imgAreaH</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4306"
+       d="m 355.1635,467.67688 c 188.54914,0 270.02102,0 270.02102,0"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4308"
+       d="m 704.64487,158.81238 0,225.11483"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       id="path4312"
+       cx="626.75"
+       cy="386.36218"
+       r="3.75" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4314"
+       d="m 353.85715,478.86394 0,-91.88996"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 626.85715,478.36394 0,-81.38996"
+       id="path4316"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4318"
+       d="m 715.55213,386.66896 -81.38996,0"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4320"
+       d="m 717.45546,156.93361 -85.33945,0"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#0000ff;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       d="m 403.45131,64.290469 222.64262,0"
+       id="path4322"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       sodipodi:linespacing="125%"
+       id="text4324"
+       y="46.583218"
+       x="489.59619"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="46.583218"
+         x="489.59619"
+         id="tspan4326"
+         sodipodi:role="line">imgW</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#0000ff;fill-opacity:1;stroke:#0101ff;stroke-width:1.51763952px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 625.85714,196.00755 0,-138.533577"
+       id="path4328"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4456"
+       d="m 294.35713,100.29539 0,-75.82142"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 447.45546,-45.56639 -85.33945,0"
+       id="path4458"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4460"
+       d="m 744.85715,1133.3639 0,-72.3899"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 961.41712,1052.669 -207.25496,0"
+       id="path4462"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       d="m 0.85715,1133.3639 0,-72.3899"
+       id="path4464"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4466"
+       d="m 940.64485,643.28784 0,-641.8377393"
+       style="fill:none;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4468"
+       d="m 961.41712,0.669 -207.25496,0"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4470"
+       d="m 345.75602,-138.20953 290.99366,0"
+       style="fill:none;stroke:#00d500;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#00d500;fill-opacity:1;stroke:none"
+       x="476.66547"
+       y="-156.65942"
+       id="text4472"
+       sodipodi:linespacing="125%"><tspan
+         style="font-size:14px"
+         sodipodi:role="line"
+         id="tspan4474"
+         x="476.66547"
+         y="-156.65942">width</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4476"
+       d="m 637.91781,104.11799 0,-251.63137"
+       style="fill:#0101ff;fill-opacity:1;stroke:#00d500;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:none;marker-end:none"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
+       d="m 230.39328,385.66718 0,-183.38169"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#0000ff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 393.95546,386.93361 -171.83946,0"
+       id="path4480"
+       inkscape:connector-curvature="0" />
+    <text
+       transform="matrix(0,-1,1,0,0,0)"
+       sodipodi:linespacing="125%"
+       id="text4482"
+       y="216.43951"
+       x="-337.26874"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#0000ff;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="216.43951"
+         x="-337.26874"
+         id="tspan4484"
+         sodipodi:role="line">height</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
- Now the Preview can show free space around the image (the image's
corner will coincide with the center of the preview area)
- Editing objects can now be manipulated in this free space
- The editing mechanism has been split : it was completely handled in
rtengine before, now rtengine still handle the pipette's data provider,
but rtgui now handle the objects data provider.
- Bugfix: when using coarse rotate in the Editor panel, the Gradient
widgets are now correctly displayed