### PR TITLE
Fixed 'LensModel' not extracted for Sony cameras

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -269,6 +269,9 @@ void ImageData::extractInfo ()
                 lens = exif->getTag ("LensModel")->valueToString ();
             }
         } else if(!make.compare (0, 4, "SONY")) {
+            if(exif->getTag ("LensModel")) {
+                lens = exif->getTag ("LensModel")->valueToString ();
+            }
             if (iso_speed == 65535 || iso_speed == 0) {
                 rtexif::Tag* isoTag = exif->getTag ("RecommendedExposureIndex");
                 if(isoTag)


### PR DESCRIPTION
When extracting Exif data from a RAW file shot with a Sony camera the lens name/type was not extracted and displayed even though it was set.

Original:
![bug](https://cloud.githubusercontent.com/assets/9962967/13143781/8d744226-d646-11e5-83d7-7eec9f476840.png)


Fixed:
![fixed](https://cloud.githubusercontent.com/assets/9962967/13143783/914e7e02-d646-11e5-9764-2084e1dca2f3.png)
