### PR TITLE
Save 8 bit b/w images using PseudoGrey Plus

### DIFF
--- a/rtengine/iimage.cc
+++ b/rtengine/iimage.cc
@@ -44,3 +44,80 @@ int rtengine::getCoarseBitMask( const procparams::CoarseTransformParams &coarse)
 
     return tr;
 }
+
+void rtengine::ImageDatas::allocate(int W, int H)
+{
+}
+
+void rtengine::ImageDatas::rotate(int deg)
+{
+}
+void rtengine::ImageDatas::flushData()
+{
+    allocate(0, 0);
+}
+
+void rtengine::ImageDatas::hflip()
+{
+}
+
+void rtengine::ImageDatas::vflip()
+{
+}
+
+void rtengine::ImageDatas::readData(FILE *fh)
+{
+}
+
+void rtengine::ImageDatas::writeData(FILE *fh)
+{
+}
+
+void rtengine::ImageDatas::normalizeInt(int srcMinVal, int srcMaxVal)
+{
+}
+
+void rtengine::ImageDatas::normalizeFloat(float srcMinVal, float srcMaxVal)
+{
+}
+
+void rtengine::ImageDatas::computeHistogramAutoWB(
+    double &avg_r,
+    double &avg_g,
+    double &avg_b,
+    int &n,
+    LUTu &histogram,
+    int compression
+)
+{
+}
+
+void rtengine::ImageDatas::getSpotWBData(
+    double &reds,
+    double &greens,
+    double &blues,
+    int &rn,
+    int &gn,
+    int &bn,
+    std::vector<Coord2D> &red,
+    std::vector<Coord2D> &green,
+    std::vector<Coord2D> &blue,
+    int tran
+)
+{
+}
+
+void rtengine::ImageDatas::getAutoWBMultipliers(double &rm, double &gm, double &bm)
+{
+    rm = gm = bm = 1.0;
+}
+
+const char* rtengine::ImageDatas::getType() const
+{
+    return "unknown";
+}
+
+bool rtengine::ImageDatas::isBW () const
+{
+    return false;
+}

--- a/rtengine/iimage.h
+++ b/rtengine/iimage.h
@@ -98,6 +98,10 @@ public:
         return "unknown";
     }
 
+    virtual bool isBW () const
+    {
+        return false;
+    }
 };
 
 template <>

--- a/rtengine/iimage.h
+++ b/rtengine/iimage.h
@@ -67,41 +67,30 @@ public:
     // parameters that will never be used, replaced by the subclasses r, g and b parameters!
     // they are still necessary to implement operator() in this parent class
     virtual ~ImageDatas() {}
-    virtual void allocate (int W, int H) {}
-    virtual void rotate (int deg) {}
+    virtual void allocate (int W, int H);
+    virtual void rotate (int deg);
     // free the memory allocated for the image data without deleting the object.
-    virtual void flushData ()
-    {
-        allocate(0, 0);
-    }
+    virtual void flushData ();
 
-    virtual void hflip () {}
-    virtual void vflip () {}
+    virtual void hflip ();
+    virtual void vflip ();
 
     // Read the raw dump of the data
-    void readData  (FILE *fh) {}
+    void readData  (FILE *fh);
     // Write a raw dump of the data
-    void writeData (FILE *fh) {}
+    void writeData (FILE *fh);
 
-    virtual void normalizeInt (int srcMinVal, int srcMaxVal) {};
-    virtual void normalizeFloat (float srcMinVal, float srcMaxVal) {};
-    virtual void computeHistogramAutoWB (double &avg_r, double &avg_g, double &avg_b, int &n, LUTu &histogram, int compression) {}
+    virtual void normalizeInt (int srcMinVal, int srcMaxVal);
+    virtual void normalizeFloat (float srcMinVal, float srcMaxVal);
+    virtual void computeHistogramAutoWB (double &avg_r, double &avg_g, double &avg_b, int &n, LUTu &histogram, int compression);
     virtual void getSpotWBData (double &reds, double &greens, double &blues, int &rn, int &gn, int &bn,
                                 std::vector<Coord2D> &red, std::vector<Coord2D> &green, std::vector<Coord2D> &blue,
-                                int tran) {}
-    virtual void getAutoWBMultipliers (double &rm, double &gm, double &bm)
-    {
-        rm = gm = bm = 1.0;
-    }
-    virtual const char* getType () const
-    {
-        return "unknown";
-    }
+                                int tran);
+    virtual void getAutoWBMultipliers (double &rm, double &gm, double &bm);
 
-    virtual bool isBW () const
-    {
-        return false;
-    }
+    virtual const char* getType () const;
+
+    virtual bool isBW () const;
 };
 
 template <>

--- a/rtengine/image16.cc
+++ b/rtengine/image16.cc
@@ -284,6 +284,46 @@ void Image16::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, Preview
 #undef GCLIP
 }
 
+bool
+Image16::isBW() const
+{
+    if (!height || !width) {
+        return false;
+    }
+
+    bool res = true;
+
+    for ( int w = 0, h = height / 2; res && w < width; ++w ) {
+        res =
+            res
+            && (
+                r(h, w) == g(h, w)
+                || r(h, w) == b(h, w)
+            );
+    }
+
+    if (!res) {
+        return false;
+    }
+
+#ifdef _OPENMP
+    #pragma omp parallel for reduction(&&:res)
+#endif
+
+    for ( int h = 0; h < height; ++h ) {
+        for ( int w = 0; w < width; ++w ) {
+            res =
+                res
+                && (
+                    r(h, w) == g(h, w)
+                    || r(h, w) == b(h, w)
+                );
+        }
+    }
+
+    return res;
+}
+
 Image8*
 Image16::to8()
 {

--- a/rtengine/image16.cc
+++ b/rtengine/image16.cc
@@ -291,27 +291,19 @@ Image16::isBW() const
         return false;
     }
 
+    for (int w = 0, h = height / 2; w < width; ++w) {
+        if (r(h, w) != g(h, w) || r(h, w) != b(h, w)) {
+            return false;
+        }
+    }
+
     bool res = true;
-
-    for ( int w = 0, h = height / 2; res && w < width; ++w ) {
-        res =
-            res
-            && (
-                r(h, w) == g(h, w)
-                || r(h, w) == b(h, w)
-            );
-    }
-
-    if (!res) {
-        return false;
-    }
 
 #ifdef _OPENMP
     #pragma omp parallel for reduction(&&:res)
 #endif
-
-    for ( int h = 0; h < height; ++h ) {
-        for ( int w = 0; w < width; ++w ) {
+    for (int h = 0; h < height; ++h) {
+        for (int w = 0; w < width; ++w) {
             res =
                 res
                 && (

--- a/rtengine/image16.h
+++ b/rtengine/image16.h
@@ -51,6 +51,9 @@ public:
     {
         return sImage16;
     }
+
+    virtual bool         isBW        () const;
+
     virtual int          getBPS      ()
     {
         return 8 * sizeof(unsigned short);

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -23,6 +23,7 @@
 #include <tiffio.h>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <fcntl.h>
 #include <libiptcdata/iptc-jpeg.h>
 #include "rt_math.h"
@@ -61,6 +62,7 @@ FILE* g_fopen_withBinaryAndLock(const Glib::ustring& fname)
     std::unique_ptr<wchar_t, GFreeFunc> wfname (reinterpret_cast<wchar_t*>(g_utf8_to_utf16 (fname.c_str (), -1, NULL, NULL, NULL)), g_free);
 
     HANDLE hFile = CreateFileW ( wfname.get (), GENERIC_READ | GENERIC_WRITE, 0 /* no sharing allowed */, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
     if (hFile != INVALID_HANDLE_VALUE) {
         f = _fdopen (_open_osfhandle ((intptr_t)hFile, 0), "wb");
     }
@@ -80,6 +82,43 @@ Glib::ustring to_utf8 (const std::string& str)
         return Glib::locale_to_utf8 (str);
     } catch (Glib::Error&) {
         return Glib::convert_with_fallback (str, "UTF-8", "ISO-8859-1", "?");
+    }
+}
+
+unsigned short addSat (unsigned short a, unsigned short b)
+{
+    unsigned short res = a + b;
+    res |= -(res < a);
+    return res;
+}
+
+void scanlineToPseudoGrey (const unsigned short *in16, unsigned char *out8, unsigned long width)
+{
+    // For details see http://r0k.us/graphics/PseudoGreyPlus.html
+
+    static const unsigned short plusses[16][3] = {
+        {0 << 8, 0 << 8, 0 << 8},
+        {0 << 8, 0 << 8, 1 << 8},
+        {0 << 8, 0 << 8, 2 << 8},
+        {1 << 8, 0 << 8, 0 << 8},
+        {1 << 8, 0 << 8, 1 << 8},
+        {1 << 8, 0 << 8, 1 << 8},
+        {1 << 8, 0 << 8, 2 << 8},
+        {2 << 8, 0 << 8, 0 << 8},
+        {2 << 8, 0 << 8, 1 << 8},
+        {2 << 8, 0 << 8, 2 << 8},
+        {2 << 8, 0 << 8, 2 << 8},
+        {0 << 8, 1 << 8, 0 << 8},
+        {0 << 8, 1 << 8, 1 << 8},
+        {0 << 8, 1 << 8, 2 << 8},
+        {0 << 8, 1 << 8, 2 << 8},
+        {1 << 8, 1 << 8, 0 << 8}
+    };
+
+    for (unsigned long x = 0; x < width * 3; x += 3) {
+        out8[x + 0] = addSat(in16[x + 0], plusses[in16[x + 0] >> 4 & 0x0F][0]) >> 8;
+        out8[x + 1] = addSat(in16[x + 1], plusses[in16[x + 1] >> 4 & 0x0F][1]) >> 8;
+        out8[x + 2] = addSat(in16[x + 2], plusses[in16[x + 2] >> 4 & 0x0F][2]) >> 8;
     }
 }
 
@@ -964,14 +1003,26 @@ int ImageIO::savePNG  (Glib::ustring fname, int compression, volatile int bps)
     png_set_IHDR(png, info, width, height, bps, PNG_COLOR_TYPE_RGB,
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_BASE);
 
-
     int rowlen = width * 3 * bps / 8;
     unsigned char *row = new unsigned char [rowlen];
+
+    const bool do_pseudogrey = bps == 8 && isBW();
+
+    const std::unique_ptr<unsigned short[]> row16(
+        do_pseudogrey
+            ? new unsigned short[width * 3]
+            : nullptr
+    );
 
     png_write_info(png, info);
 
     for (int i = 0; i < height; i++) {
-        getScanline (i, row, bps);
+        if (do_pseudogrey) {
+            getScanline (i, reinterpret_cast<unsigned char*>(row16.get()), 16);
+            scanlineToPseudoGrey (row16.get(), row, width);
+        } else {
+            getScanline (i, row, bps);
+        }
 
         if (bps == 16) {
             // convert to network byte order
@@ -1146,6 +1197,14 @@ int ImageIO::saveJPEG (Glib::ustring fname, int quality, int subSamp)
     int rowlen = width * 3;
     unsigned char *row = new unsigned char [rowlen];
 
+    const bool do_pseudogrey = isBW();
+
+    const std::unique_ptr<unsigned short[]> row16(
+        do_pseudogrey
+            ? new unsigned short[width * 3]
+            : nullptr
+    );
+
     /* To avoid memory leaks we establish a new setjmp return context for my_error_exit to use. */
 #if defined( WIN32 ) && defined( __x86_64__ )
 
@@ -1166,7 +1225,12 @@ int ImageIO::saveJPEG (Glib::ustring fname, int quality, int subSamp)
 
     while (cinfo.next_scanline < cinfo.image_height) {
 
-        getScanline (cinfo.next_scanline, row, 8);
+        if (do_pseudogrey) {
+            getScanline (cinfo.next_scanline, reinterpret_cast<unsigned char*>(row16.get()), 16);
+            scanlineToPseudoGrey (row16.get(), row, width);
+        } else {
+            getScanline (cinfo.next_scanline, row, 8);
+        }
 
         if (jpeg_write_scanlines (&cinfo, &row, 1) < 1) {
             jpeg_destroy_compress (&cinfo);
@@ -1211,6 +1275,14 @@ int ImageIO::saveTIFF (Glib::ustring fname, int bps, bool uncompressed)
     int lineWidth = width * 3 * bps / 8;
     unsigned char* linebuffer = new unsigned char[lineWidth];
 
+    const bool do_pseudogrey = bps == 8 && isBW();
+
+    const std::unique_ptr<unsigned short[]> row16(
+        do_pseudogrey
+            ? new unsigned short[width * 3]
+            : nullptr
+    );
+
 // TODO the following needs to be looked into - do we really need two ways to write a Tiff file ?
     if (exifRoot && uncompressed) {
         FILE *file = g_fopen_withBinaryAndLock (fname);
@@ -1227,9 +1299,11 @@ int ImageIO::saveTIFF (Glib::ustring fname, int bps, bool uncompressed)
 
         // buffer for the exif and iptc
         int bufferSize = 165535;   //TODO: Is it really 165535... or 65535 ?
-        if(profileData)
+
+        if(profileData) {
             bufferSize += profileLength;
-        
+        }
+
         unsigned char* buffer = new unsigned char[bufferSize];
         unsigned char* iptcdata = NULL;
         unsigned int iptclen = 0;
@@ -1258,7 +1332,12 @@ int ImageIO::saveTIFF (Glib::ustring fname, int bps, bool uncompressed)
 #endif
 
         for (int i = 0; i < height; i++) {
-            getScanline (i, linebuffer, bps);
+            if (do_pseudogrey) {
+                getScanline (i, reinterpret_cast<unsigned char*>(row16.get()), 16);
+                scanlineToPseudoGrey (row16.get(), linebuffer, width);
+            } else {
+                getScanline (i, linebuffer, bps);
+            }
 
             if (needsReverse)
                 for (int i = 0; i < lineWidth; i += 2) {
@@ -1370,7 +1449,12 @@ int ImageIO::saveTIFF (Glib::ustring fname, int bps, bool uncompressed)
         }
 
         for (int row = 0; row < height; row++) {
-            getScanline (row, linebuffer, bps);
+            if (do_pseudogrey) {
+                getScanline (row, reinterpret_cast<unsigned char*>(row16.get()), 16);
+                scanlineToPseudoGrey (row16.get(), linebuffer, width);
+            } else {
+                getScanline (row, linebuffer, bps);
+            }
 
             if (TIFFWriteScanline (out, linebuffer, row, 0) < 0) {
                 TIFFClose (out);

--- a/rtengine/imageio.h
+++ b/rtengine/imageio.h
@@ -160,7 +160,7 @@ public:
     int loadJPEGFromMemory (const char* buffer, int bufsize);
     int loadPPMFromMemory(const char* buffer, int width, int height, bool swap, int bps);
 
-    int savePNG  (Glib::ustring fname, int compression = -1, volatile int bps = -1);
+    int savePNG  (Glib::ustring fname, int compression = -1, int bps = -1);
     int saveJPEG (Glib::ustring fname, int quality = 100, int subSamp = 3);
     int saveTIFF (Glib::ustring fname, int bps = -1, bool uncompressed = false);
 

--- a/rtengine/rt_math.h
+++ b/rtengine/rt_math.h
@@ -2,6 +2,7 @@
 #define _MYMATH_
 #include <cmath>
 #include <algorithm>
+#include <type_traits>
 
 
 namespace rtengine
@@ -101,10 +102,22 @@ T norm2(const T& x, const T& y)
     return std::sqrt(x * x + y * y);
 }
 
-template< typename T >
+template<typename T>
 T norminf(const T& x, const T& y)
 {
     return std::max(std::abs(x), std::abs(y));
+}
+
+template<
+    typename T,
+    typename = typename std::enable_if<std::is_integral<T>::value>::type,
+    typename = typename std::enable_if<std::is_unsigned<T>::value>::type
+>
+T adds(T a, T b)
+{
+    T res = a + b;
+    res |= -(res < a);
+    return res;
 }
 
 }


### PR DESCRIPTION
I rediscovered [Pat David's article on PseudoGrey](http://blog.patdavid.net/2012/06/true-pseudogrey-in-gimp.html) recently and came across PseudoGrey Plus on Rich Franzen's site. I implemented a little stand-alone converter first and tried it successfully on 16 bit TIFFs exported from RT. Now here's an implementation directly for RT. It might be a nice (though small) USP for what is already an excellent piece of software.

[PseudoGrey Plus](http://r0k.us/graphics/PseudoGreyPlus.html) by Rich Franzen is an algorithm to store 3110 levels of gray in 24 bit color images. This is simply done by adding 1 or 2 to the R, G, and/or B values to adjust the pixel's luminance. It's a subtle but perceivable effect and helps to prevent banding.

This implementation adds a new method `isBW()` to `IImage`, which is only implemented for `Image16` and defaults to `false`. It's only called once per saving and has a shortcut to determine that the image is *not* b/w.

The minimally invasive core algorithm was added to `rtengine/imageio.cc` and is only called when saving an 8 bit image that is b/w.

Please note that when saving as JPEG, compression squashes the effect and a quality of 95+ and 4:4:4 subsampling is recommended. Many PseudoGrey sample image on the net suffer from this and do not really show the benefit.