### PR TITLE
HaldCLUT cleanups after the dust (#3154) has settled

### DIFF
--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -56,7 +56,7 @@ bool loadFile(
             img_src.convertColorSpace(img_float.get(), icm, curr_wb);
         }
 
-        AlignedBuffer<std::uint16_t> image(fw * fh * 4 + 8); // + 8 because of SSE4_1 version of getClutValues
+        AlignedBuffer<std::uint16_t> image(fw * fh * 4 + 4); // getClutValues() loads one pixel in advance
 
         std::size_t index = 0;
 

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -56,7 +56,7 @@ bool loadFile(
             img_src.convertColorSpace(img_float.get(), icm, curr_wb);
         }
 
-        AlignedBuffer<std::uint16_t> image(fw * fh * 4 + 8); // + 8 because of SSE4_1 version of getClutValue
+        AlignedBuffer<std::uint16_t> image(fw * fh * 4 + 8); // + 8 because of SSE4_1 version of getClutValues
 
         std::size_t index = 0;
 
@@ -78,12 +78,19 @@ bool loadFile(
 }
 
 #ifdef __SSE2__
-vfloat getClutValue(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
+vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
 {
+    const __m128i v_values = _mm_loadu_si128(reinterpret_cast<const __m128i*>(clut_image.data + index));
 #ifdef __SSE4_1__
-    return _mm_cvtepi32_ps(_mm_cvtepu16_epi32(_mm_loadu_si128(reinterpret_cast<const __m128i*>(clut_image.data + index))));
+    return {
+        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(v_values)),
+        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(_mm_srli_si128(v_values, 8)))
+    };
 #else
-    return _mm_set_ps(clut_image.data[index + 3], clut_image.data[index + 2], clut_image.data[index + 1], clut_image.data[index]);
+    return {
+        _mm_cvtpu16_ps(_mm_movepi64_pi64(v_values)),
+        _mm_cvtpu16_ps(_mm_movepi64_pi64(_mm_srli_si128(v_values, 8)))
+    };
 #endif
 }
 #endif
@@ -212,11 +219,13 @@ void rtengine::HaldCLUT::getRGB(
 
         const vfloat v_r = PERMUTEPS(v_rgb, _MM_SHUFFLE(0, 0, 0, 0));
 
-        vfloat v_tmp1 = vintpf(v_r, getClutValue(clut_image, index + 4), getClutValue(clut_image, index));
+        vfloat2 v_clut_values = getClutValues(clut_image, index);
+        vfloat v_tmp1 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         index = (color + level) * 4;
 
-        vfloat v_tmp2 = vintpf(v_r, getClutValue(clut_image, index + 4), getClutValue(clut_image, index));
+        v_clut_values = getClutValues(clut_image, index);
+        vfloat v_tmp2 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         const vfloat v_g = PERMUTEPS(v_rgb, _MM_SHUFFLE(1, 1, 1, 1));
 
@@ -224,11 +233,13 @@ void rtengine::HaldCLUT::getRGB(
 
         index = (color + level_square) * 4;
 
-        v_tmp1 = vintpf(v_r, getClutValue(clut_image, index + 4), getClutValue(clut_image, index));
+        v_clut_values = getClutValues(clut_image, index);
+        v_tmp1 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         index = (color + level + level_square) * 4;
 
-        v_tmp2 = vintpf(v_r, getClutValue(clut_image, index + 4), getClutValue(clut_image, index));
+        v_clut_values = getClutValues(clut_image, index);
+        v_tmp2 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         v_tmp1 = vintpf(v_g, v_tmp2, v_tmp1);
 

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -3226,8 +3226,8 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                 xyz2clut = iccStore->workingSpaceInverseMatrix( hald_clut->getProfile() );
                 xyz2work = iccStore->workingSpaceInverseMatrix( params->icm.working );
                 clut2xyz = iccStore->workingSpaceMatrix( hald_clut->getProfile() );
-#ifdef __SSE2__
 
+#ifdef __SSE2__
                 for (int i = 0; i < 3; ++i) {
                     for (int j = 0; j < 3; ++j) {
                         v_work2xyz[i][j] = F2V(work2xyz[i][j]);
@@ -3236,8 +3236,8 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                         v_clut2xyz[i][j] = F2V(clut2xyz[i][j]);
                     }
                 }
-
 #endif
+
             }
         }
     }
@@ -4361,12 +4361,12 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                             // Convert from working to clut profile
                             int j = jstart;
                             int tj = 0;
-#ifdef __SSE2__
 
+#ifdef __SSE2__
                             for (; j < tW - 3; j += 4, tj += 4) {
-                                vfloat sourceR = LVFU(rtemp[ti * TS + tj]);
-                                vfloat sourceG = LVFU(gtemp[ti * TS + tj]);
-                                vfloat sourceB = LVFU(btemp[ti * TS + tj]);
+                                vfloat sourceR = LVF(rtemp[ti * TS + tj]);
+                                vfloat sourceG = LVF(gtemp[ti * TS + tj]);
+                                vfloat sourceB = LVF(btemp[ti * TS + tj]);
 
                                 vfloat x;
                                 vfloat y;
@@ -4374,11 +4374,10 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                                 Color::rgbxyz(sourceR, sourceG, sourceB, x, y, z, v_work2xyz);
                                 Color::xyz2rgb(x, y, z, sourceR, sourceG, sourceB, v_xyz2clut);
 
-                                STVFU(rtemp[ti * TS + tj], sourceR);
-                                STVFU(gtemp[ti * TS + tj], sourceG);
-                                STVFU(btemp[ti * TS + tj], sourceB);
+                                STVF(rtemp[ti * TS + tj], sourceR);
+                                STVF(gtemp[ti * TS + tj], sourceG);
+                                STVF(btemp[ti * TS + tj], sourceB);
                             }
-
 #endif
 
                             for (; j < tW; j++, tj++) {
@@ -4428,12 +4427,12 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                             // Convert from clut to working profile
                             int j = jstart;
                             int tj = 0;
-#ifdef __SSE2__
 
+#ifdef __SSE2__
                             for (; j < tW - 3; j += 4, tj += 4) {
-                                vfloat sourceR = LVFU(rtemp[ti * TS + tj]);
-                                vfloat sourceG = LVFU(gtemp[ti * TS + tj]);
-                                vfloat sourceB = LVFU(btemp[ti * TS + tj]);
+                                vfloat sourceR = LVF(rtemp[ti * TS + tj]);
+                                vfloat sourceG = LVF(gtemp[ti * TS + tj]);
+                                vfloat sourceB = LVF(btemp[ti * TS + tj]);
 
                                 vfloat x;
                                 vfloat y;
@@ -4441,11 +4440,10 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                                 Color::rgbxyz(sourceR, sourceG, sourceB, x, y, z, v_clut2xyz);
                                 Color::xyz2rgb(x, y, z, sourceR, sourceG, sourceB, v_xyz2work);
 
-                                STVFU(rtemp[ti * TS + tj], sourceR);
-                                STVFU(gtemp[ti * TS + tj], sourceG);
-                                STVFU(btemp[ti * TS + tj], sourceB);
+                                STVF(rtemp[ti * TS + tj], sourceR);
+                                STVF(gtemp[ti * TS + tj], sourceG);
+                                STVF(btemp[ti * TS + tj], sourceB);
                             }
-
 #endif
 
                             for (; j < tW; j++, tj++) {


### PR DESCRIPTION
Here are some cleanups, mainly conceived by @heckflosse, for the HaldCLUT code:
- Load and store `source[RGB]` aligned again
- Switch `getClutValue()` to `vfloat2`
- Optimize the SSE2 version of `getClutValue()` and omit MMX (by Ingo)

Best,
Flössie