### PR TITLE
Fix std::out_of_range exception with empty HaldCLUT basename

### DIFF
--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -283,11 +283,16 @@ void rtengine::HaldCLUT::splitClutFilename(
 
     profile_name = "sRGB";
 
-    for (const auto& working_profile : rtengine::getWorkingProfiles()) {
-        if (std::search(name.rbegin(), name.rend(), working_profile.rbegin(), working_profile.rend()) == name.rbegin()) {
-            profile_name = working_profile;
-            name.erase(name.size() - working_profile.size());
-            break;
+    if (!name.empty()) {
+        for (const auto& working_profile : rtengine::getWorkingProfiles()) {
+            if (
+                !working_profile.empty() // This isn't strictly needed, but an empty wp name should be skipped anyway
+                && std::search(name.rbegin(), name.rend(), working_profile.rbegin(), working_profile.rend()) == name.rbegin()
+            ) {
+                profile_name = working_profile;
+                name.erase(name.size() - working_profile.size());
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
User **jgschaefer** [reported an error on pixls.us](https://discuss.pixls.us/t/rt-build-from-git-crash-on-launch-debian-testing-64-bit/1425)
which could be traced down to an empty basename for a HaldCLUT. The
original implementation did not throw an exception due to the use of
`std::string::substr()` instead of `std::string::erase()`, but silently
assigned the first working profile to `profile_name`.