### PR TITLE
Fix build warnings

### DIFF
--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -263,7 +263,7 @@ cmsHPROFILE ICCStore::makeStdGammaProfile (cmsHPROFILE iprof)
                 tags[i].sig == 0x6B545243) { // kTRC
             if (gamma_offset == 0) {
                 gamma_offset = offset;
-                uint32_t pcurve[] = { htonl(0x63757276), htonl(0), htonl(gamma_size == 12 ? 0 : 1) };
+                uint32_t pcurve[] = { htonl(0x63757276), htonl(0), htonl(gamma_size == 12 ? 0U : 1U) };
                 memcpy(&nd[offset], pcurve, 12);
 
                 if (gamma_size == 14) {

--- a/rtengine/jdatasrc.cc
+++ b/rtengine/jdatasrc.cc
@@ -32,6 +32,8 @@
 
 
 /* Expanded data source object for stdio input */
+namespace
+{
 
 typedef struct {
     struct jpeg_source_mgr pub;   /* public fields */
@@ -43,6 +45,8 @@ typedef struct {
 } my_source_mgr;
 
 typedef my_source_mgr * my_src_ptr;
+
+}
 
 #define INPUT_BUF_SIZE  4096    /* choose an efficiently fread'able size */
 

--- a/rtengine/jpeg_memsrc.cc
+++ b/rtengine/jpeg_memsrc.cc
@@ -26,6 +26,8 @@
 
 
 /* Expanded data source object for memory input */
+namespace
+{
 
 typedef struct {
     struct jpeg_source_mgr pub; /* public fields */
@@ -36,6 +38,7 @@ typedef struct {
 
 typedef my_source_mgr * my_src_ptr;
 
+}
 
 /*
  * Initialize source --- called by jpeg_read_header


### PR DESCRIPTION
Fix two warnings when building special configurations:
- ODR violation when building with LTO enabled
- Narrowing conversion when building for PPC

LTO seems to really speed things up, btw. :)