### PR TITLE
Use "find_program" to search for git executable

### DIFF
--- a/AboutThisBuild.cmake
+++ b/AboutThisBuild.cmake
@@ -5,13 +5,13 @@ find_file(REL_INFO_FILE ReleaseInfo.cmake PATHS "${PROJECT_SOURCE_DIR}" NO_DEFAU
 if (REL_INFO_FILE STREQUAL REL_INFO_FILE-NOTFOUND)
     # we look for the git command in this paths by order of preference
     if (WIN32)
-        find_file(GIT_CMD git.exe HINTS ENV Path PATH_SUFFIXES ../)
+        find_program(GIT_CMD git.exe HINTS ENV Path PATH_SUFFIXES ../)
     elseif (APPLE)
-        find_file(GIT_CMD git PATHS "/opt/local/bin" "/usr/local/bin" "/usr/bin")
-        find_file(GIT_CMD git)
+        find_program(GIT_CMD git PATHS "/opt/local/bin" "/usr/local/bin" "/usr/bin")
+        find_program(GIT_CMD git)
         set (SHELL "/bin/bash")
     else (WIN32) # Linux
-        find_file(GIT_CMD git)
+        find_program(GIT_CMD git)
         set (SHELL "/bin/bash")
     endif (WIN32)
 


### PR DESCRIPTION
CMake's "find_file" can return non-executable files or folders, thus "find_program" must be used to ensure that only executable files are detected.
Tested on Linux only.
Fixes issue #3290.
