### PR TITLE
Fix missing return value in LensGeometry::doDisableAutoFillIfActive()

### DIFF
--- a/rtgui/lensgeom.cc
+++ b/rtgui/lensgeom.cc
@@ -140,4 +140,6 @@ int LensGeometry::doDisableAutoFillIfActive (void* data)
             instance->fillConn.block (false);
         }
     }
+
+    return 0;
 }


### PR DESCRIPTION
This should fix #3328.