### PR TITLE
Add full support of c++11 to the Eclipse IDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ else (WIN32)
   cmake_minimum_required(VERSION 2.6)
 endif (WIN32)
 
+# must stay before the 'project' command
+if(${CMAKE_EXTRA_GENERATOR} MATCHES "Eclipse CDT4")
+  set(CMAKE_CXX_COMPILER_ARG1 "-std=c++11" CACHE STRING "C++ version for eclipse" FORCE)
+  # users building with Eclipse should set CMAKE_ECLIPSE_VERSION through the command line to their current version of Eclipse
+  #set(CMAKE_ECLIPSE_VERSION "4.6.0" CACHE STRING "Eclipse version" FORCE)
+endif()
+
 PROJECT(RawTherapee)
 
 # the default target is 'Debug'


### PR DESCRIPTION
...(i.e. including when building the index), with the help of
-DCMAKE_ECLIPSE_VERSION="4.6.0" (set to your version, of course) on the
command line. Without this, the declared symbols are wrong and c++11 is
not supported by the IDE (vs the build makefiles).