### PR TITLE
Fix "-Wignored-attributes" with vector arguments in `rtengine/median.h`

### DIFF
--- a/rtengine/median.h
+++ b/rtengine/median.h
@@ -24,6 +24,10 @@
 
 #include "opthelper.h"
 
+#if defined __GNUC__ && __GNUC__>=6 && defined __SSE2__
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 template<typename T, std::size_t N>
 inline T median(std::array<T, N> array)
 {


### PR DESCRIPTION
See [GCC bug 69884](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69884).