### PR TITLE
Fix buffer overflow in dcraw

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -3221,7 +3221,10 @@ void CLASS smal_decode_segment (unsigned seg[2][2], int holes)
       diff = diff ? -diff : 0x80;
     if (ftell(ifp) + 12 >= seg[1][1])
       diff = 0;
-    raw_image[pix] = pred[pix & 1] += diff;
+    if(pix>=raw_width*raw_height)
+      derror();
+    else
+      raw_image[pix] = pred[pix & 1] += diff;
     if (!(pix & 1) && HOLE(pix / raw_width)) pix += 2;
   }
   maximum = 0xff;

--- a/rtengine/dcraw.patch
+++ b/rtengine/dcraw.patch
@@ -1,5 +1,5 @@
---- dcraw.c	2016-06-04 20:34:18.405932434 +0200
-+++ dcraw.cc	2016-07-09 17:40:46.405632563 +0200
+--- dcraw.c	2016-09-30 21:19:28.312191811 +0200
++++ dcraw.cc	2016-09-30 22:41:28.157442526 +0200
 @@ -1,3 +1,16 @@
 +/*RT*/#include <glib.h>
 +/*RT*/#include <glib/gstdio.h>
@@ -778,7 +778,19 @@
  }
  
  void CLASS samsung_load_raw()
-@@ -3038,7 +3354,7 @@
+@@ -2905,7 +3221,10 @@
+       diff = diff ? -diff : 0x80;
+     if (ftell(ifp) + 12 >= seg[1][1])
+       diff = 0;
+-    raw_image[pix] = pred[pix & 1] += diff;
++    if(pix>=raw_width*raw_height)
++      derror();
++    else
++      raw_image[pix] = pred[pix & 1] += diff;
+     if (!(pix & 1) && HOLE(pix / raw_width)) pix += 2;
+   }
+   maximum = 0xff;
+@@ -3038,7 +3357,7 @@
  
  void CLASS foveon_decoder (unsigned size, unsigned code)
  {
@@ -787,7 +799,7 @@
    struct decode *cur;
    int i, len;
  
-@@ -3135,7 +3451,7 @@
+@@ -3135,7 +3454,7 @@
  	pred[c] += diff[dindex->leaf];
  	if (pred[c] >> 16 && ~pred[c] >> 16) derror();
        }
@@ -796,7 +808,7 @@
      }
    }
  }
-@@ -3746,6 +4062,8 @@
+@@ -3746,6 +4065,8 @@
    if (load_raw == &CLASS phase_one_load_raw ||
        load_raw == &CLASS phase_one_load_raw_c)
      phase_one_correct();
@@ -805,7 +817,7 @@
    if (fuji_width) {
      for (row=0; row < raw_height-top_margin*2; row++) {
        for (col=0; col < fuji_width << !fuji_layout; col++) {
-@@ -3761,10 +4079,13 @@
+@@ -3761,10 +4082,13 @@
        }
      }
    } else {
@@ -821,7 +833,7 @@
    if (mask[0][3] > 0) goto mask_set;
    if (load_raw == &CLASS canon_load_raw ||
        load_raw == &CLASS lossless_jpeg_load_raw) {
-@@ -4366,239 +4687,8 @@
+@@ -4366,239 +4690,8 @@
      }
  }
  
@@ -872,7 +884,8 @@
 -   This algorithm is officially called:
 -
 -   "Interpolation using a Threshold-based variable number of gradients"
--
++/* RT: delete interpolation functions */
+ 
 -   described in http://scien.stanford.edu/pages/labsite/1999/psych221/projects/99/tingchen/algodep/vargra.html
 -
 -   I've extended the basic idea to work with non-Bayer filter arrays.
@@ -1016,8 +1029,7 @@
 -
 -  border_interpolate(3);
 -  if (verbose) fprintf (stderr,_("PPG interpolation...\n"));
-+/* RT: delete interpolation functions */
- 
+-
 -/*  Fill in the green layer with gradients and pattern recognition: */
 -  for (row=3; row < height-3; row++)
 -    for (col=3+(FC(row,3) & 1), c=FC(row,col); col < width-3; col+=2) {
@@ -1062,7 +1074,7 @@
  
  void CLASS cielab (ushort rgb[3], short lab[3])
  {
-@@ -4864,112 +4954,7 @@
+@@ -4864,112 +4957,7 @@
  }
  #undef fcol
  
@@ -1175,7 +1187,7 @@
  #undef TS
  
  void CLASS median_filter()
-@@ -5139,7 +5124,7 @@
+@@ -5139,7 +5127,7 @@
    }
  }
  
@@ -1184,7 +1196,7 @@
  
  void CLASS parse_makernote (int base, int uptag)
  {
-@@ -5244,6 +5229,11 @@
+@@ -5244,6 +5232,11 @@
      tag |= uptag << 16;
      if (tag == 2 && strstr(make,"NIKON") && !iso_speed)
        iso_speed = (get2(),get2());
@@ -1196,7 +1208,7 @@
      if (tag == 4 && len > 26 && len < 35) {
        if ((i=(get4(),get2())) != 0x7fff && !iso_speed)
  	iso_speed = 50 * pow (2, i/32.0 - 4);
-@@ -5296,12 +5286,16 @@
+@@ -5296,12 +5289,16 @@
  	cam_mul[2] = get4() << 2;
        }
      }
@@ -1214,7 +1226,7 @@
      if (tag == 0x1d)
        while ((c = fgetc(ifp)) && c != EOF)
  	serial = serial*10 + (isdigit(c) ? c - '0' : c % 10);
-@@ -5491,14 +5485,14 @@
+@@ -5491,14 +5488,14 @@
    while (entries--) {
      tiff_get (base, &tag, &type, &len, &save);
      switch (tag) {
@@ -1232,7 +1244,7 @@
  		     shutter = pow (2, expo);		break;
        case 37378:  aperture = pow (2, getreal(type)/2);	break;
        case 37386:  focal_len = getreal(type);		break;
-@@ -5667,28 +5661,33 @@
+@@ -5667,28 +5664,33 @@
    }
  }
  
@@ -1272,7 +1284,7 @@
    entries = get2();
    if (entries > 512) return 1;
    while (entries--) {
-@@ -5758,7 +5757,8 @@
+@@ -5758,7 +5760,8 @@
  	fgets (make, 64, ifp);
  	break;
        case 272:				/* Model */
@@ -1282,7 +1294,7 @@
  	break;
        case 280:				/* Panasonic RW2 offset */
  	if (type != 4) break;
-@@ -5818,6 +5818,9 @@
+@@ -5818,6 +5821,9 @@
        case 315:				/* Artist */
  	fread (artist, 64, 1, ifp);
  	break;
@@ -1292,7 +1304,7 @@
        case 322:				/* TileWidth */
  	tiff_ifd[ifd].tile_width = getint(type);
  	break;
-@@ -5833,6 +5836,9 @@
+@@ -5833,6 +5839,9 @@
  	  is_raw = 5;
  	}
  	break;
@@ -1302,7 +1314,7 @@
        case 330:				/* SubIFDs */
  	if (!strcmp(model,"DSLR-A100") && tiff_ifd[ifd].width == 3872) {
  	  load_raw = &CLASS sony_arw_load_raw;
-@@ -5846,6 +5852,9 @@
+@@ -5846,6 +5855,9 @@
  	  fseek (ifp, i+4, SEEK_SET);
  	}
  	break;
@@ -1312,7 +1324,7 @@
        case 400:
  	strcpy (make, "Sarnoff");
  	maximum = 0xfff;
-@@ -6063,12 +6072,21 @@
+@@ -6063,12 +6075,21 @@
        case 61450:
  	cblack[4] = cblack[5] = MIN(sqrt(len),64);
        case 50714:			/* BlackLevel */
@@ -1340,7 +1352,7 @@
        case 50715:			/* BlackLevelDeltaH */
        case 50716:			/* BlackLevelDeltaV */
  	for (num=i=0; i < (len & 0xffff); i++)
-@@ -6085,13 +6103,13 @@
+@@ -6085,13 +6106,13 @@
        case 50721:			/* ColorMatrix1 */
        case 50722:			/* ColorMatrix2 */
  	FORCC for (j=0; j < 3; j++)
@@ -1356,7 +1368,7 @@
  	break;
        case 50727:			/* AnalogBalance */
  	FORCC ab[c] = getreal(type);
-@@ -6114,6 +6132,11 @@
+@@ -6114,6 +6135,11 @@
        case 50752:
  	read_shorts (cr2_slice, 3);
  	break;
@@ -1368,7 +1380,7 @@
        case 50829:			/* ActiveArea */
  	top_margin = getint(type);
  	left_margin = getint(type);
-@@ -6146,21 +6169,27 @@
+@@ -6146,21 +6172,27 @@
      fread (buf, sony_length, 1, ifp);
      sony_decrypt (buf, sony_length/4, 1, sony_key);
      sfp = ifp;
@@ -1404,7 +1416,7 @@
      cam_xyz_coeff (cmatrix, cam_xyz);
    }
    if (asn[0]) {
-@@ -6168,13 +6197,14 @@
+@@ -6168,13 +6200,14 @@
      FORCC cam_mul[c] = 1 / asn[c];
    }
    if (!use_cm)
@@ -1420,7 +1432,7 @@
  
    fseek (ifp, base, SEEK_SET);
    order = get2();
-@@ -6206,6 +6236,7 @@
+@@ -6206,6 +6239,7 @@
        shutter = tiff_ifd[i].shutter;
      tiff_ifd[i].shutter = shutter;
    }
@@ -1428,7 +1440,7 @@
    for (i=0; i < tiff_nifds; i++) {
      if (max_samp < tiff_ifd[i].samples)
  	max_samp = tiff_ifd[i].samples;
-@@ -6266,7 +6297,12 @@
+@@ -6266,7 +6300,12 @@
  	  case  8: load_raw = &CLASS eight_bit_load_raw;	break;
  	  case 12: if (tiff_ifd[raw].phint == 2)
  		     load_flags = 6;
@@ -1442,7 +1454,7 @@
  	  case 14: load_flags = 0;
  	  case 16: load_raw = &CLASS unpacked_load_raw;
  		   if (!strncmp(make,"OLYMPUS",7) &&
-@@ -6305,6 +6341,7 @@
+@@ -6305,6 +6344,7 @@
  	  case 32803: load_raw = &CLASS kodak_65000_load_raw;
  	}
        case 32867: case 34892: break;
@@ -1450,7 +1462,7 @@
        default: is_raw = 0;
      }
    if (!dng_version)
-@@ -6390,7 +6427,7 @@
+@@ -6390,7 +6430,7 @@
  {
    const char *file, *ext;
    char *jname, *jfile, *jext;
@@ -1459,7 +1471,7 @@
  
    ext  = strrchr (ifname, '.');
    file = strrchr (ifname, '/');
-@@ -6412,13 +6449,14 @@
+@@ -6412,13 +6452,14 @@
    } else
      while (isdigit(*--jext)) {
        if (*jext != '9') {
@@ -1476,7 +1488,7 @@
        if (verbose)
  	fprintf (stderr,_("Reading metadata from %s ...\n"), jname);
        parse_tiff (12);
-@@ -6693,6 +6731,7 @@
+@@ -6693,6 +6734,7 @@
    load_raw = ph1.format < 3 ?
  	&CLASS phase_one_load_raw : &CLASS phase_one_load_raw_c;
    maximum = 0xffff;
@@ -1484,7 +1496,7 @@
    strcpy (make, "Phase One");
    if (model[0]) return;
    switch (raw_height) {
-@@ -6761,7 +6800,11 @@
+@@ -6761,7 +6803,11 @@
      order = get2();
      hlen  = get4();
      if (get4() == 0x48454150)		/* "HEAP" */
@@ -1496,7 +1508,7 @@
      if (parse_tiff (save+6)) apply_tiff();
      fseek (ifp, save+len, SEEK_SET);
    }
-@@ -7033,7 +7076,8 @@
+@@ -7033,7 +7079,8 @@
  {
    static const struct {
      const char *prefix;
@@ -1506,7 +1518,7 @@
    } table[] = {
      { "AgfaPhoto DC-833m", 0, 0,	/* DJC */
  	{ 11438,-3762,-1115,-2409,9914,2497,-1227,2295,5300 } },
-@@ -7977,12 +8021,12 @@
+@@ -7977,12 +8024,12 @@
  	{ 6596,-2079,-562,-4782,13016,1933,-970,1581,5181 } },
      { "Sony DSC-RX100", 0, 0,
  	{ 8651,-2754,-1057,-3464,12207,1373,-568,1398,4434 } },
@@ -1521,7 +1533,7 @@
      { "Sony DSLR-A100", 0, 0xfeb,
  	{ 9437,-2811,-774,-8405,16215,2290,-710,596,7181 } },
      { "Sony DSLR-A290", 0, 0,
-@@ -8088,6 +8132,33 @@
+@@ -8088,6 +8135,33 @@
        }
        break;
      }
@@ -1555,7 +1567,7 @@
  }
  
  void CLASS simple_coeff (int index)
-@@ -8410,7 +8481,7 @@
+@@ -8410,7 +8484,7 @@
    tiff_flip = flip = filters = UINT_MAX;	/* unknown */
    raw_height = raw_width = fuji_width = fuji_layout = cr2_slice[0] = 0;
    maximum = height = width = top_margin = left_margin = 0;
@@ -1564,7 +1576,7 @@
    iso_speed = shutter = aperture = focal_len = unique_id = 0;
    tiff_nifds = 0;
    memset (tiff_ifd, 0, sizeof tiff_ifd);
-@@ -8442,13 +8513,20 @@
+@@ -8442,13 +8516,20 @@
    fread (head, 1, 32, ifp);
    fseek (ifp, 0, SEEK_END);
    flen = fsize = ftell(ifp);
@@ -1587,7 +1599,7 @@
        parse_ciff (hlen, flen-hlen, 0);
        load_raw = &CLASS canon_load_raw;
      } else if (parse_tiff(0)) apply_tiff();
-@@ -8494,6 +8572,7 @@
+@@ -8494,6 +8575,7 @@
      fseek (ifp, 100+28*(shot_select > 0), SEEK_SET);
      parse_tiff (data_offset = get4());
      parse_tiff (thumb_offset+12);
@@ -1595,7 +1607,7 @@
      apply_tiff();
    } else if (!memcmp (head,"RIFF",4)) {
      fseek (ifp, 0, SEEK_SET);
-@@ -8607,9 +8686,10 @@
+@@ -8607,9 +8689,10 @@
    if (make[0] == 0) parse_smal (0, flen);
    if (make[0] == 0) {
      parse_jpeg(0);
@@ -1609,7 +1621,7 @@
        strcpy (make, "OmniVision");
        data_offset = ftell(ifp) + 0x8000-32;
        width = raw_width;
-@@ -8618,6 +8698,7 @@
+@@ -8618,6 +8701,7 @@
        filters = 0x16161616;
      } else is_raw = 0;
    }
@@ -1617,7 +1629,7 @@
  
    for (i=0; i < sizeof corp / sizeof *corp; i++)
      if (strcasestr (make, corp[i]))	/* Simplify company names */
-@@ -8649,7 +8730,7 @@
+@@ -8649,7 +8733,7 @@
    if (height == 3136 && width == 4864)  /* Pentax K20D and Samsung GX20 */
      { height  = 3124;   width  = 4688; filters = 0x16161616; }
    if (width == 4352 && (!strcmp(model,"K-r") || !strcmp(model,"K-x")))
@@ -1626,7 +1638,7 @@
    if (width >= 4960 && !strncmp(model,"K-5",3))
      { left_margin = 10; width  = 4950; filters = 0x16161616; }
    if (width == 4736 && !strcmp(model,"K-7"))
-@@ -8669,6 +8750,7 @@
+@@ -8669,6 +8753,7 @@
        case 0:
        case 1:     load_raw = &CLASS   packed_dng_load_raw;  break;
        case 7:     load_raw = &CLASS lossless_dng_load_raw;  break;
@@ -1634,7 +1646,7 @@
        case 34892: load_raw = &CLASS    lossy_dng_load_raw;  break;
        default:    load_raw = 0;
      }
-@@ -8725,6 +8807,7 @@
+@@ -8725,6 +8810,7 @@
      if (height   > width) pixel_aspect = 2;
      filters = 0;
      simple_coeff(0);
@@ -1642,7 +1654,7 @@
    } else if (!strcmp(make,"Canon") && tiff_bps == 15) {
      switch (width) {
        case 3344: width -= 66;
-@@ -9034,24 +9117,53 @@
+@@ -9034,24 +9120,53 @@
      if (load_raw == &CLASS lossless_jpeg_load_raw)
        load_raw = &CLASS hasselblad_load_raw;
      if (raw_width == 7262) {
@@ -1701,7 +1713,7 @@
      } else if (raw_width == 4090) {
        strcpy (model, "V96C");
        height -= (top_margin = 6);
-@@ -9109,6 +9221,7 @@
+@@ -9109,6 +9224,7 @@
        filters = 0x16161616;
      }
    } else if (!strcmp(make,"Leica") || !strcmp(make,"Panasonic")) {
@@ -1709,7 +1721,7 @@
      if ((flen - data_offset) / (raw_width*8/7) == raw_height)
        load_raw = &CLASS panasonic_load_raw;
      if (!load_raw) {
-@@ -9126,6 +9239,7 @@
+@@ -9126,6 +9242,7 @@
        }
      filters = 0x01010101 * (uchar) "\x94\x61\x49\x16"
  	[((filters-1) ^ (left_margin & 1) ^ (top_margin << 1)) & 3];
@@ -1717,7 +1729,7 @@
    } else if (!strcmp(model,"C770UZ")) {
      height = 1718;
      width  = 2304;
-@@ -9201,13 +9315,15 @@
+@@ -9201,13 +9318,15 @@
        width -= 6;
    } else if (!strcmp(make,"Sony") && raw_width == 7392) {
      width -= 30;
@@ -1740,7 +1752,7 @@
    } else if (!strcmp(model,"DSLR-A100")) {
      if (width == 3880) {
        height--;
-@@ -9357,6 +9473,18 @@
+@@ -9357,6 +9476,18 @@
      memcpy (rgb_cam, cmatrix, sizeof cmatrix);
      raw_color = 0;
    }
@@ -1759,7 +1771,7 @@
    if (raw_color) adobe_coeff (make, model);
    if (load_raw == &CLASS kodak_radc_load_raw)
      if (raw_color) adobe_coeff ("Apple","Quicktake");
-@@ -9371,9 +9499,9 @@
+@@ -9371,9 +9502,9 @@
      if (raw_width  < width ) raw_width  = width;
    }
    if (!tiff_bps) tiff_bps = 12;
@@ -1771,7 +1783,7 @@
      is_raw = 0;
  #ifdef NO_JASPER
    if (load_raw == &CLASS redcine_load_raw) {
-@@ -9452,199 +9580,250 @@
+@@ -9452,199 +9583,250 @@
  }
  #endif
  
@@ -2205,7 +2217,7 @@
  struct tiff_tag {
    ushort tag, type;
    int count;
-@@ -9667,594 +9846,11 @@
+@@ -9667,594 +9849,11 @@
    char desc[512], make[64], model[64], soft[32], date[20], artist[64];
  };
  


### PR DESCRIPTION
Apply patch from https://github.com/LibRaw/LibRaw/commit/89d065424f09b788f443734d44857289489ca9e2, this fixes CVE-2015-8366.
