### PR TITLE
Fix Clang warnings and build failure on OSX 10.12

### DIFF
--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -17,14 +17,16 @@
  *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _COLOR_H_
-#define _COLOR_H_
+#pragma once
+
+#include <array>
 
 #include "rt_math.h"
 #include "LUT.h"
 #include "labimage.h"
 #include "iccmatrices.h"
 #include "sleef.c"
+
 #define SAT(a,b,c) ((float)max(a,b,c)-(float)min(a,b,c))/(float)max(a,b,c)
 
 namespace rtengine
@@ -1680,5 +1682,3 @@ public:
 };
 
 }
-
-#endif

--- a/rtengine/dfmanager.cc
+++ b/rtengine/dfmanager.cc
@@ -598,12 +598,13 @@ std::vector<badPix> *DFManager::getBadPixels ( const std::string &mak, const std
             found = true;
         }
 
-        if( settings->verbose )
+        if( settings->verbose ) {
             if(found) {
                 printf("%s.badpixels found\n", s.str().c_str());
             } else {
                 printf("%s.badpixels not found\n", s.str().c_str());
             }
+        }
 
     }
 
@@ -617,12 +618,13 @@ std::vector<badPix> *DFManager::getBadPixels ( const std::string &mak, const std
             found = true;
         }
 
-        if( settings->verbose )
+        if( settings->verbose ) {
             if(found) {
                 printf("%s.badpixels found\n", s.str().c_str());
             } else {
                 printf("%s.badpixels not found\n", s.str().c_str());
             }
+        }
     }
 
     if(!found) {

--- a/rtengine/iccjpeg.cc
+++ b/rtengine/iccjpeg.cc
@@ -142,7 +142,9 @@ marker_is_icc (jpeg_saved_marker_ptr marker)
         GETJOCTET(marker->data[8]) == 0x49 &&
         GETJOCTET(marker->data[9]) == 0x4C &&
         GETJOCTET(marker->data[10]) == 0x45 &&
-        GETJOCTET(marker->data[11]) == 0x0;
+        GETJOCTET(marker->data[11]) == 0x0
+            ? TRUE
+            : FALSE;
 }
 
 

--- a/rtengine/iptransform.cc
+++ b/rtengine/iptransform.cc
@@ -794,12 +794,13 @@ void ImProcFunctions::transformHighQuality (Imagefloat* original, Imagefloat* tr
                     // multiplier for vignetting correction
                     double vignmul = 1.0;
 
-                    if (needsVignetting())
+                    if (needsVignetting()) {
                         if(darkening) {
                             vignmul /= std::max(v + mul * tanh (b * (maxRadius - s * r2) / maxRadius), 0.001);
                         } else {
                             vignmul *= (v + mul * tanh (b * (maxRadius - s * r2) / maxRadius));
                         }
+                    }
 
                     if (needsGradient()) {
                         vignmul *= calcGradientFactor(gp, cx + x, cy + y);
@@ -963,12 +964,13 @@ void ImProcFunctions::transformPreview (Imagefloat* original, Imagefloat* transf
                 // multiplier for vignetting correction
                 double vignmul = 1.0;
 
-                if (needsVignetting())
+                if (needsVignetting()) {
                     if(darkening) {
                         vignmul /= std::max(v + mul * tanh (b * (maxRadius - s * r2) / maxRadius), 0.001);
                     } else {
                         vignmul = v + mul * tanh (b * (maxRadius - s * r2) / maxRadius);
                     }
+                }
 
                 if (needsGradient()) {
                     vignmul *= calcGradientFactor(gp, cx + x, cy + y);

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -1851,7 +1851,7 @@ void RawImageSource::preprocess  (const RAWParams &raw, const LensProfParams &le
     }
 
 
-    if( totBP )
+    if( totBP ) {
         if ( ri->getSensorType() == ST_BAYER ) {
             interpolateBadPixelsBayer( *bitmapBads );
         } else if ( ri->getSensorType() == ST_FUJI_XTRANS ) {
@@ -1859,6 +1859,7 @@ void RawImageSource::preprocess  (const RAWParams &raw, const LensProfParams &le
         } else {
             interpolateBadPixelsNColours( *bitmapBads, ri->get_colors() );
         }
+    }
 
     if ( ri->getSensorType() == ST_BAYER && raw.bayersensor.linenoise > 0 ) {
         if (plistener) {

--- a/rtgui/windirmonitor.h
+++ b/rtgui/windirmonitor.h
@@ -24,8 +24,9 @@
 
 class WinDirChangeListener
 {
-
 public:
+    virtual ~WinDirChangeListener() = default;
+
     virtual void winDirChanged () {}
 };
 


### PR DESCRIPTION
Over at pixls.us user Partha has fixed his OSX 10.12 build. I've kind of incorporated his fixes and had `master` compile with Clang 3.8 under Debian Stretch, which reported some warnings that I also fixed (apart from missing enum values in switch statements).