### PR TITLE
GTK3 fixes, handles issue #3446 and fixes #3495

### DIFF
--- a/rtdata/themes/RawTherapee.css
+++ b/rtdata/themes/RawTherapee.css
@@ -26,6 +26,10 @@
     color: #666666;
 }
 
+.background {
+    background-color: #484848;
+}
+
 .view:selected {
     color: #262626;
     background-color: #AAAAAA
@@ -659,4 +663,24 @@ paned > separator {
 
 .tooltip {
     padding: 0;
+}
+
+/* Decently sized tabs */
+#PrefNotebook tab, #AboutNotebook tab {
+    padding: 0.8em;
+}
+
+/* Add space between bottom panel and window edge */
+#IopsPanel {
+    padding: 0 2px 2px;
+}
+
+/* The thing you catch with the mouse to resize a panel */
+paned > separator {
+    border: 1px solid #262626;
+}
+
+/* Move places paned (Places and Folders) away from window edges */
+#PlacesPaned {
+    padding: 5px;
 }

--- a/rtdata/themes/RawTherapee.css
+++ b/rtdata/themes/RawTherapee.css
@@ -70,6 +70,11 @@ frame {
     padding: 4px;
 }
 
+/* Create space between frame contents and frame border */
+frame border {
+    padding: 4px;
+}
+
 frame > label {
     color: #D8D8D8;
 }

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -439,13 +439,13 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     vboxright = new Gtk::VBox (false, 0);
     vboxright->set_size_request (300, 250);
 
-
     vboxright->pack_start (*ppframe, Gtk::PACK_SHRINK, 2);
     // main notebook
     vboxright->pack_start (*tpc->toolPanelNotebook);
 
     // Save buttons
     Gtk::Grid *iops = new Gtk::Grid ();
+    iops->set_name ("IopsPanel");
     iops->set_orientation (Gtk::ORIENTATION_HORIZONTAL);
     iops->set_row_spacing (2);
     iops->set_column_spacing (2);

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -131,8 +131,6 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     buttonBar->set_name ("ToolBarPanelFileBrowser");
     pack_start (*buttonBar, Gtk::PACK_SHRINK);
 
-    buttonBar->pack_start (*Gtk::manage(new Gtk::VSeparator), Gtk::PACK_SHRINK);
-
     tbLeftPanel_1 = new Gtk::ToggleButton ();
     iLeftPanel_1_Show = new RTImage("panel-to-right.png");
     iLeftPanel_1_Hide = new RTImage("panel-to-left.png");
@@ -144,8 +142,8 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     tbLeftPanel_1->signal_toggled().connect( sigc::mem_fun(*this, &FileCatalog::tbLeftPanel_1_toggled) );
     buttonBar->pack_start (*tbLeftPanel_1, Gtk::PACK_SHRINK);
 
-    buttonBar->pack_start (*(new Gtk::VSeparator), Gtk::PACK_SHRINK);
-
+    vSepiLeftPanel = new Gtk::VSeparator ();
+    buttonBar->pack_start (*vSepiLeftPanel, Gtk::PACK_SHRINK);
 
     iFilterClear = new RTImage ("filterclear.png");
     igFilterClear = new RTImage ("filter.png");
@@ -2084,8 +2082,10 @@ void FileCatalog::tbLeftPanel_1_visible (bool visible)
 {
     if (visible) {
         tbLeftPanel_1->show();
+        vSepiLeftPanel->show();
     } else {
         tbLeftPanel_1->hide();
+        vSepiLeftPanel->hide();
     }
 }
 void FileCatalog::tbRightPanel_1_visible (bool visible)

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -96,6 +96,8 @@ private:
     Gtk::HBox* fltrRecentlySavedBox;
     Gtk::VBox* fltrVbox2;
 
+    Gtk::VSeparator* vSepiLeftPanel;
+
     Gtk::ToggleButton* tbLeftPanel_1;
     Gtk::ToggleButton* tbRightPanel_1;
     Gtk::ToggleButton* bFilterClear;

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -44,6 +44,7 @@ FilePanel::FilePanel () : parent(nullptr)
 
     // The whole left panel. Contains Places, Recent Folders and Folders.
     placespaned = Gtk::manage ( new Gtk::VPaned () );
+    placespaned->set_name ("PlacesPaned");
     placespaned->set_size_request(250, 100);
     placespaned->set_position (options.dirBrowserHeight);
 

--- a/rtgui/history.cc
+++ b/rtgui/history.cc
@@ -88,9 +88,6 @@ History::History (bool bookmarkSupport) : blistener(nullptr), tpc (nullptr), bmn
     // Bookmark List
     // ~~~~~~~~~~~~~
 
-    Gtk::HSeparator* hsepb = Gtk::manage (new Gtk::HSeparator ());
-    pack_end (*hsepb, Gtk::PACK_SHRINK, 0);
-
     Gtk::HBox* ahbox = Gtk::manage (new Gtk::HBox ());
     addBookmark = Gtk::manage (new Gtk::Button ());  // M("HISTORY_NEWSNAPSHOT")
     setExpandAlignProperties(addBookmark, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -61,10 +61,6 @@ Preferences::Preferences  (RTWindow *rtwindow)
     nb->set_name ("PrefNotebook");
     mainBox->pack_start (*nb);
 
-    Gtk::HBox* buttonpanel = Gtk::manage (new Gtk::HBox ());
-    buttonpanel->set_spacing(8);
-    mainBox->pack_start (*buttonpanel, Gtk::PACK_SHRINK, 0);
-
     Gtk::Button* about  = Gtk::manage (new Gtk::Button (M("GENERAL_ABOUT")));
     Gtk::Button* ok     = Gtk::manage (new Gtk::Button (M("GENERAL_OK")));
     Gtk::Button* cancel = Gtk::manage (new Gtk::Button (M("GENERAL_CANCEL")));
@@ -73,9 +69,10 @@ Preferences::Preferences  (RTWindow *rtwindow)
     ok->signal_clicked().connect( sigc::mem_fun(*this, &Preferences::okPressed) );
     cancel->signal_clicked().connect( sigc::mem_fun(*this, &Preferences::cancelPressed) );
 
-    buttonpanel->pack_start (*about, Gtk::PACK_SHRINK, 0);
-    buttonpanel->pack_end (*ok, Gtk::PACK_SHRINK, 0);
-    buttonpanel->pack_end (*cancel, Gtk::PACK_SHRINK, 0);
+    get_action_area()->pack_start (*about);
+    get_action_area()->pack_end (*ok);
+    get_action_area()->pack_end (*cancel);
+
     nb->append_page (*getGeneralPanel(),        M("PREFERENCES_TAB_GENERAL"));
     nb->append_page (*getProcParamsPanel(),     M("PREFERENCES_TAB_IMPROC"));
     nb->append_page (*getFileBrowserPanel(),    M("PREFERENCES_TAB_BROWSER"));

--- a/rtgui/splash.cc
+++ b/rtgui/splash.cc
@@ -105,17 +105,16 @@ Splash::Splash (Gtk::Window& parent) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, t
     releaseNotesSW = nullptr;
 
     nb = Gtk::manage (new Gtk::Notebook ());
+    nb->set_name ("AboutNotebook");
     get_content_area()->pack_start (*nb);
 
     // Add close button to bottom of the notebook
     Gtk::Button* closeButton = Gtk::manage (new Gtk::Button (M("GENERAL_CLOSE")));
     closeButton->signal_clicked().connect( sigc::mem_fun(*this, &Splash::closePressed) );
-    Gtk::HBox* bottomHBox = Gtk::manage (new Gtk::HBox ());
-    bottomHBox->pack_end (*closeButton, Gtk::PACK_SHRINK, 0);
-    get_content_area()->pack_start (*bottomHBox, Gtk::PACK_SHRINK, 0);
+    get_action_area()->pack_start (*closeButton, Gtk::PACK_SHRINK, 0);
 
     Glib::RefPtr<Gtk::CssProvider> localCSS = Gtk::CssProvider::create();
-    localCSS->load_from_data ("textview { font-family: monospace; font-size: 8pt; }");
+    localCSS->load_from_data ("textview { font-family: monospace; }");
 
     // Tab 1: the image
     splashImage = Gtk::manage(new SplashImage ());


### PR DESCRIPTION
GTK3 >=3.20 fixes for branch `gtk3-bugfix`

1. The background color of the About and Preferences window was not set.
2. Some of the About window's tabs have a font size hard-coded in pt, resulting in text in some tabs looking significantly bigger than in other tabs and in other programs. Removing the font selector means that font sizes should be inherited from the user's system.
https://i.imgur.com/0VM0M2T.png
https://i.imgur.com/v7Xs3HO.png
3. Preferences/About window About/OK/Cancel buttons are too small, they lack padding and margins. But the correct fix is not with CSS, see points 4 and 5.
4. There is an empty action_box below the "Close" button:
https://i.imgur.com/iI4Jk8Q.png
The GTK Dialog has a bottom area called the action area where "Close", "OK", "Apply" and "Cancel" buttons should go. Doing so also fixes the button sizes.
https://i.imgur.com/TJstAhq.png
5. Same as 3, but for Preferences:
https://i.imgur.com/CI3w38D.png
https://i.imgur.com/1J7cqz6.png
6. Notebook buttons are inconsistent, those in Preferences and About are too small and too close together:
Too small and too close together https://i.imgur.com/mGXyzr9.png
7. #3495 "Gtk+ >=3.20 Separators in Filmstrip toolbar".
8. One important (to me) fix is that the paned separator ("catchment area" where I can grab and resize panels) was only 1 pixel wide, making resizing those panels difficult or impossible. These: https://i.imgur.com/Q2Uygc3.jpg