### PR TITLE
IPTC strings updated to version 1.2

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -706,7 +706,7 @@ IPTCPANEL_EMBEDDEDHINT;Reset to IPTC data embedded in the image file.
 IPTCPANEL_HEADLINE;Headline
 IPTCPANEL_HEADLINEHINT;Enter a brief publishable synopsis or summary of the contents of the image.
 IPTCPANEL_INSTRUCTIONS;Instructions
-IPTCPANEL_INSTRUCTIONSHINT;Enter information about embargoes, or other restrictions not covered by the Rights Usage field.
+IPTCPANEL_INSTRUCTIONSHINT;Enter information about embargoes, or other restrictions not covered by the Copyright field.
 IPTCPANEL_KEYWORDS;Keywords
 IPTCPANEL_KEYWORDSHINT;Enter any number of keywords, terms or phrases used to express the subject matter in the image.
 IPTCPANEL_PASTEHINT;Paste IPTC settings from clipboard.

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2,6 +2,7 @@
 #01 Developers should add translations to this file and then run the 'generateTranslationDiffs' Bash script to update other locales.
 #02 Translators please append a comment here with the current date and your name(s) as used in the RawTherapee forum or GitHub page, e.g.:
 #03 2525-12-24 Zager and Evans
+
 ABOUT_TAB_BUILD;Version
 ABOUT_TAB_CREDITS;Credits
 ABOUT_TAB_LICENSE;License
@@ -679,47 +680,48 @@ HISTORY_NEWSNAPSHOT;Add
 HISTORY_NEWSNAPSHOT_TOOLTIP;Shortcut: <b>Alt-s</b>
 HISTORY_SNAPSHOT;Snapshot
 HISTORY_SNAPSHOTS;Snapshots
-IPTCPANEL_AUTHOR;Author
-IPTCPANEL_AUTHORSPOSITION;Author's position
-IPTCPANEL_AUTHORSPOSITIONHINT;Title of the creator or creators of the object (By-line Title).
-IPTCPANEL_CAPTION;Caption
-IPTCPANEL_CAPTIONHINT;A textual description of the data (Caption - Abstract).
-IPTCPANEL_CAPTIONWRITER;Caption writer
-IPTCPANEL_CAPTIONWRITERHINT;The name of the person involved in the writing, editing or correcting the image or caption/abstract (Writer - Editor).
 IPTCPANEL_CATEGORY;Category
-IPTCPANEL_CATEGORYHINT;Identifies the subject of the image in the opinion of the provider (Category).
+IPTCPANEL_CATEGORYHINT;Identifies the subject of the image in the opinion of the provider.
 IPTCPANEL_CITY;City
-IPTCPANEL_CITYHINT;City of image origin (City).
+IPTCPANEL_CITYHINT;Enter the name of the city pictured in this image.
 IPTCPANEL_COPYHINT;Copy IPTC settings to clipboard.
-IPTCPANEL_COPYRIGHT;Copyright
-IPTCPANEL_COPYRIGHTHINT;Any necessary copyright notice (Copyright Notice).
+IPTCPANEL_COPYRIGHT;Copyright notice
+IPTCPANEL_COPYRIGHTHINT;Enter a Notice on the current owner of the Copyright for this image, such as ©2008 Jane Doe.
 IPTCPANEL_COUNTRY;Country
-IPTCPANEL_COUNTRYHINT;The name of the country/primary location where the image was created (Country - Primary Location Name).
-IPTCPANEL_CREDIT;Credit
-IPTCPANEL_CREDITHINT;Identifies the provider of the image, not necessarily the owner/creator (Credit).
+IPTCPANEL_COUNTRYHINT;Enter the name of the country pictured in this image.
+IPTCPANEL_CREATOR;Creator
+IPTCPANEL_CREATORHINT;Enter the name of the person that created this image.
+IPTCPANEL_CREATORJOBTITLE;Creator's job title
+IPTCPANEL_CREATORJOBTITLEHINT;Enter the Job Title of the person listed in the Creator field.
+IPTCPANEL_CREDIT;Credit line
+IPTCPANEL_CREDITHINT;Enter who should be credited when this image is published.
 IPTCPANEL_DATECREATED;Date created
-IPTCPANEL_DATECREATEDHINT;The date the intellectual content of the image was created; Format: YYYYMMDD (Date Created).
+IPTCPANEL_DATECREATEDHINT;Enter the Date the image was taken.
+IPTCPANEL_DESCRIPTION;Description
+IPTCPANEL_DESCRIPTIONHINT;Enter a "caption" describing the who, what, and why of what is happening in this image, this might include names of people, and/or their role in the action that is taking place within the image.
+IPTCPANEL_DESCRIPTIONWRITER;Description writer
+IPTCPANEL_DESCRIPTIONWRITERHINT;Enter the name of the person involved in writing, editing or correcting the description of the image.
 IPTCPANEL_EMBEDDED;Embedded
 IPTCPANEL_EMBEDDEDHINT;Reset to IPTC data embedded in the image file.
 IPTCPANEL_HEADLINE;Headline
-IPTCPANEL_HEADLINEHINT;A publishable entry providing a synopsis of the contents of the image (Headline).
+IPTCPANEL_HEADLINEHINT;Enter a brief publishable synopsis or summary of the contents of the image.
 IPTCPANEL_INSTRUCTIONS;Instructions
-IPTCPANEL_INSTRUCTIONSHINT;Other editorial instructions concerning the use of the image (Special Instructions).
+IPTCPANEL_INSTRUCTIONSHINT;Enter information about embargoes, or other restrictions not covered by the Rights Usage field.
 IPTCPANEL_KEYWORDS;Keywords
-IPTCPANEL_KEYWORDSHINT;Used to indicate specific information retrieval words (Keywords).
+IPTCPANEL_KEYWORDSHINT;Enter any number of keywords, terms or phrases used to express the subject matter in the image.
 IPTCPANEL_PASTEHINT;Paste IPTC settings from clipboard.
-IPTCPANEL_PROVINCE;Province
-IPTCPANEL_PROVINCEHINT;The Province/State where the image originates (Province-State).
+IPTCPANEL_PROVINCE;Province or state
+IPTCPANEL_PROVINCEHINT;Enter the name of the province or state pictured in this image.
 IPTCPANEL_RESET;Reset
 IPTCPANEL_RESETHINT;Reset to profile default.
 IPTCPANEL_SOURCE;Source
-IPTCPANEL_SOURCEHINT;The original owner of the intellectual content of the image (Source).
-IPTCPANEL_SUPPCATEGORIES;Suppl. categories
-IPTCPANEL_SUPPCATEGORIESHINT;Further refines the subject of the image (Supplemental Categories).
+IPTCPANEL_SOURCEHINT;Enter or edit the name of a person or party who has a role in the content supply chain, such as a person or entity from whom you received this image from.
+IPTCPANEL_SUPPCATEGORIES;Supplemental categories
+IPTCPANEL_SUPPCATEGORIESHINT;Further refines the subject of the image.
 IPTCPANEL_TITLE;Title
-IPTCPANEL_TITLEHINT;A shorthand reference for the image (Object Name).
-IPTCPANEL_TRANSREFERENCE;Trans. reference
-IPTCPANEL_TRANSREFERENCEHINT;A code representing the location of the original transmission (Original Transmission Reference).
+IPTCPANEL_TITLEHINT;Enter a short verbal and human readable name for the image, this may be the file name.
+IPTCPANEL_TRANSREFERENCE;Job ID
+IPTCPANEL_TRANSREFERENCEHINT;Enter a number or identifier needed for workflow control or tracking.
 MAIN_BUTTON_FULLSCREEN;Fullscreen
 MAIN_BUTTON_NAVNEXT_TOOLTIP;Navigate to the next image relative to image opened in the Editor.\nShortcut: <b>Shift-F4</b>\n\nTo navigate to the next image relative to the currently selected thumbnail in the File Browser or Filmstrip:\nShortcut: <b>F4</b>
 MAIN_BUTTON_NAVPREV_TOOLTIP;Navigate to the previous image relative to image opened in the Editor.\nShortcut: <b>Shift-F3</b>\n\nTo navigate to the previous image relative to the currently selected thumbnail in the File Browser or Filmstrip:\nShortcut: <b>F3</b>
@@ -2034,3 +2036,4 @@ ZOOMPANEL_ZOOMFITCROPSCREEN;Fit crop to screen\nShortcut: <b>Alt</b>-<b>f</b>
 ZOOMPANEL_ZOOMFITSCREEN;Fit whole image to screen\nShortcut: <b>f</b>
 ZOOMPANEL_ZOOMIN;Zoom In\nShortcut: <b>+</b>
 ZOOMPANEL_ZOOMOUT;Zoom Out\nShortcut: <b>-</b>
+

--- a/rtgui/iptcpanel.cc
+++ b/rtgui/iptcpanel.cc
@@ -33,26 +33,26 @@ IPTCPanel::IPTCPanel ()
     iptc->set_border_width (3);
     iptc->set_spacing(3);
 
-    Gtk::Label* capl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_CAPTION") + ":") );
+    Gtk::Label* capl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_DESCRIPTION") + ":") );
     capl->set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER);
     captionText = Gtk::TextBuffer::create ();
     captionView = Gtk::manage( new Gtk::TextView (captionText) );
     Gtk::ScrolledWindow* scrolledWindowc = Gtk::manage( new Gtk::ScrolledWindow() );
     scrolledWindowc->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
     scrolledWindowc->add(*captionView);
-    capl->set_tooltip_text (M("IPTCPANEL_CAPTIONHINT"));
-    captionView->set_tooltip_text (M("IPTCPANEL_CAPTIONHINT"));
+    capl->set_tooltip_text (M("IPTCPANEL_DESCRIPTIONHINT"));
+    captionView->set_tooltip_text (M("IPTCPANEL_DESCRIPTIONHINT"));
     captionView->set_size_request(32, 80);
     iptc->pack_start(*capl, Gtk::PACK_EXPAND_PADDING, 0);
     iptc->pack_start(*scrolledWindowc, Gtk::PACK_EXPAND_WIDGET, 0);
 
     // --------------------------
 
-    Gtk::Label* capwl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_CAPTIONWRITER") + ":") );
+    Gtk::Label* capwl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_DESCRIPTIONWRITER") + ":") );
     capwl->set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER);
     captionWriter = Gtk::manage( new Gtk::Entry () );
-    capwl->set_tooltip_text (M("IPTCPANEL_CAPTIONWRITERHINT"));
-    captionWriter->set_tooltip_text (M("IPTCPANEL_CAPTIONWRITERHINT"));
+    capwl->set_tooltip_text (M("IPTCPANEL_DESCRIPTIONWRITERHINT"));
+    captionWriter->set_tooltip_text (M("IPTCPANEL_DESCRIPTIONWRITERHINT"));
     iptc->pack_start(*capwl, Gtk::PACK_EXPAND_PADDING, 0);
     iptc->pack_start(*captionWriter, Gtk::PACK_EXPAND_WIDGET, 0);
 
@@ -158,7 +158,7 @@ IPTCPanel::IPTCPanel ()
     iptc->pack_start(*hsep3, Gtk::PACK_EXPAND_WIDGET, 0);
     // --------------------------
 
-    Gtk::Label* creatorLbl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_AUTHOR") + ":") );
+    Gtk::Label* creatorLbl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_CREATOR") + ":") );
     creatorLbl->set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER);
     creator = Gtk::manage( new Gtk::Entry () );
     creatorLbl->set_tooltip_text (M("IPTCPANEL_CREATORHINT"));
@@ -168,11 +168,11 @@ IPTCPanel::IPTCPanel ()
 
     // --------------------------
 
-    Gtk::Label* creatorJobTitleLbl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_AUTHORSPOSITION") + ":") );
+    Gtk::Label* creatorJobTitleLbl = Gtk::manage( new Gtk::Label (M("IPTCPANEL_CREATORJOBTITLE") + ":") );
     creatorJobTitleLbl->set_alignment(Gtk::ALIGN_LEFT, Gtk::ALIGN_CENTER);
     creatorJobTitle = Gtk::manage(  new Gtk::Entry () );
-    creatorJobTitleLbl->set_tooltip_text (M("IPTCPANEL_AUTHORSPOSITIONHINT"));
-    creatorJobTitle->set_tooltip_text (M("IPTCPANEL_AUTHORSPOSITIONHINT"));
+    creatorJobTitleLbl->set_tooltip_text (M("IPTCPANEL_CREATORJOBTITLEHINT"));
+    creatorJobTitle->set_tooltip_text (M("IPTCPANEL_CREATORJOBTITLEHINT"));
     iptc->pack_start(*creatorJobTitleLbl, Gtk::PACK_EXPAND_PADDING, 0);
     iptc->pack_start(*creatorJobTitle, Gtk::PACK_EXPAND_WIDGET, 0);
 


### PR DESCRIPTION
The IPTC tab's strings and tooltips are updated to match IPTC Core 1.2 from 2014 (with final updates in October 2016, the latest available).