### PR TITLE
issue 3598 and 2289 - util functions to determine file types by ending

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -46,8 +46,6 @@ ImageMetaData* ImageMetaData::fromFile (const Glib::ustring& fname, RawMetaDataL
 
 ImageData::ImageData (Glib::ustring fname, RawMetaDataLocation* ri) : iso_speed(0), aperture(0.), shutter(0.)
 {
-
-    size_t dotpos = fname.find_last_of ('.');
     root = nullptr;
     iptc = nullptr;
 
@@ -72,7 +70,7 @@ ImageData::ImageData (Glib::ustring fname, RawMetaDataLocation* ri) : iso_speed(
             fclose (f);
             extractInfo ();
         }
-    } else if ((dotpos < fname.size() - 3 && !fname.casefold().compare (dotpos, 4, ".jpg")) || (dotpos < fname.size() - 4 && !fname.casefold().compare (dotpos, 5, ".jpeg"))) {
+    } else if (hasJpegExtension(fname)) {
         FILE* f = g_fopen (fname.c_str (), "rb");
 
         if (f) {
@@ -83,7 +81,7 @@ ImageData::ImageData (Glib::ustring fname, RawMetaDataLocation* ri) : iso_speed(
             iptc = iptc_data_new_from_jpeg_file (ff);
             fclose (ff);
         }
-    } else if ((dotpos < fname.size() - 3 && !fname.casefold().compare (dotpos, 4, ".tif")) || (dotpos < fname.size() - 4 && !fname.casefold().compare (dotpos, 5, ".tiff"))) {
+    } else if (hasTiffExtension(fname)) {
         FILE* f = g_fopen (fname.c_str (), "rb");
 
         if (f) {

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -1441,19 +1441,11 @@ void png_flush(png_structp png_ptr)
 int ImageIO::load (Glib::ustring fname)
 {
 
-    size_t lastdot = fname.find_last_of ('.');
-
-    if( Glib::ustring::npos == lastdot ) {
-        return IMIO_FILETYPENOTSUPPORTED;
-    }
-
-    if (!fname.casefold().compare (lastdot, 4, ".png")) {
+    if (hasPngExtension(fname)) {
         return loadPNG (fname);
-    } else if (!fname.casefold().compare (lastdot, 4, ".jpg") ||
-               !fname.casefold().compare (lastdot, 5, ".jpeg")) {
+    } else if (hasJpegExtension(fname)) {
         return loadJPEG (fname);
-    } else if (!fname.casefold().compare (lastdot, 4, ".tif") ||
-               !fname.casefold().compare (lastdot, 5, ".tiff")) {
+    } else if (hasTiffExtension(fname)) {
         return loadTIFF (fname);
     } else {
         return IMIO_FILETYPENOTSUPPORTED;
@@ -1462,20 +1454,11 @@ int ImageIO::load (Glib::ustring fname)
 
 int ImageIO::save (Glib::ustring fname)
 {
-
-    size_t lastdot = fname.find_last_of ('.');
-
-    if( Glib::ustring::npos == lastdot ) {
-        return IMIO_FILETYPENOTSUPPORTED;
-    }
-
-    if (!fname.casefold().compare (lastdot, 4, ".png")) {
+    if (hasPngExtension(fname)) {
         return savePNG (fname);
-    } else if (!fname.casefold().compare (lastdot, 4, ".jpg") ||
-               !fname.casefold().compare (lastdot, 5, ".jpeg")) {
+    } else if (hasJpegExtension(fname)) {
         return saveJPEG (fname);
-    } else if (!fname.casefold().compare (lastdot, 4, ".tif") ||
-               !fname.casefold().compare (lastdot, 5, ".tiff")) {
+    } else if (hasTiffExtension(fname)) {
         return saveTIFF (fname);
     } else {
         return IMIO_FILETYPENOTSUPPORTED;

--- a/rtengine/stdimagesource.cc
+++ b/rtengine/stdimagesource.cc
@@ -74,27 +74,19 @@ void StdImageSource::getSampleFormat (const Glib::ustring &fname, IIOSampleForma
     sFormat = IIOSF_UNKNOWN;
     sArrangement = IIOSA_UNKNOWN;
 
-    size_t lastdot = fname.find_last_of ('.');
-
-    if( Glib::ustring::npos == lastdot ) {
-        return;
-    }
-
-    if (!fname.casefold().compare (lastdot, 4, ".jpg") ||
-            !fname.casefold().compare (lastdot, 5, ".jpeg")) {
+    if (hasJpegExtension(fname)) {
         // For now, png and jpeg files are converted to unsigned short by the loader itself,
         // but there should be functions that read the sample format first, like the TIFF case below
         sFormat = IIOSF_UNSIGNED_CHAR;
         sArrangement = IIOSA_CHUNKY;
         return;
-    } else if (!fname.casefold().compare (lastdot, 4, ".png")) {
+    } else if (hasPngExtension(fname)) {
         int result = ImageIO::getPNGSampleFormat (fname, sFormat, sArrangement);
 
         if (result == IMIO_SUCCESS) {
             return;
         }
-    } else if (!fname.casefold().compare (lastdot, 4, ".tif") ||
-               !fname.casefold().compare (lastdot, 5, ".tiff")) {
+    } else if (hasTiffExtension(fname)) {
         int result = ImageIO::getTIFFSampleFormat (fname, sFormat, sArrangement);
 
         if (result == IMIO_SUCCESS) {

--- a/rtengine/utils.cc
+++ b/rtengine/utils.cc
@@ -224,6 +224,34 @@ void vflip (unsigned char* img, int w, int h)
     delete [] flipped;
 }
 
+/**
+ * Return lower case extension without the "." or "" if the given name contains no "."
+ */
+Glib::ustring getFileExtension(const Glib::ustring &fname) {
+    // issue 3598 do not use casefold() to compare ignoring case - it seems to mangle sharp-s character and length of string
+    // simply get extension first, then use lowercase()
+    const Glib::ustring::size_type lastdot = fname.find_last_of ('.');
+    if( Glib::ustring::npos == lastdot ) {
+        return "";
+    }
+    return fname.substr(lastdot + 1).lowercase();
+}
+
+bool hasJpegExtension(const Glib::ustring &fname) {
+   const Glib::ustring extension = getFileExtension(fname);
+   return ((extension == "jpg") || (extension == "jpeg"));
+}
+
+bool hasTiffExtension(const Glib::ustring &fname) {
+   const Glib::ustring extension = getFileExtension(fname);
+   return ((extension == "tif") || (extension == "tiff"));
+}
+
+bool hasPngExtension(const Glib::ustring &fname) {
+   const Glib::ustring extension = getFileExtension(fname);
+   return (extension == "png");
+}
+
 }
 
 

--- a/rtengine/utils.h
+++ b/rtengine/utils.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <type_traits>
+#include <glibmm.h>
 
 namespace rtengine
 {
@@ -41,5 +42,25 @@ typename std::underlying_type<ENUM>::type toUnderlying(ENUM value)
 {
     return static_cast<typename std::underlying_type<ENUM>::type>(value);
 }
+
+/**
+ * Return lower case extension without the "." or "" if the given name contains no "."
+ */
+Glib::ustring getFileExtension(const Glib::ustring &fname);
+
+/**
+ * Return true if file has .jpeg or .jpg extension (ignoring case)
+ */
+bool hasJpegExtension(const Glib::ustring &fname);
+
+/**
+ * Return true if file has .tiff or .tif extension (ignoring case)
+ */
+bool hasTiffExtension(const Glib::ustring &fname);
+
+/**
+ * Return true if file has .png extension (ignoring case)
+ */
+bool hasPngExtension(const Glib::ustring &fname);
 
 }

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -2381,7 +2381,7 @@ bool Options::has_retained_extention (Glib::ustring fname)
 bool Options::is_extention_enabled (Glib::ustring ext)
 {
     for (int j = 0; j < (int)parseExtensions.size(); j++)
-        if (parseExtensions[j].casefold() == ext.casefold()) {
+        if (parseExtensions[j].casefold() == ext.casefold()) { // issue 3598 REVIEW OK - no change required
             return j >= (int)parseExtensionsEnabled.size() || parseExtensionsEnabled[j];
         }
 

--- a/rtgui/profilestore.cc
+++ b/rtgui/profilestore.cc
@@ -277,13 +277,14 @@ const ProfileStoreEntry* ProfileStore::findEntryFromFullPathU(Glib::ustring path
     if (path == DEFPROFILE_INTERNAL) {
         return internalDefaultEntry;
     }
+    // consistently apply casefold() to make sure dot position is correct
+    const Glib::ustring::size_type lastdot = path.casefold().find_last_of ('.');
 
-    size_t lastdot = path.find_last_of ('.');
-
-    if (lastdot != Glib::ustring::npos && lastdot <= path.size() - 4 && !path.casefold().compare (lastdot, 4, paramFileExtension))
+    if ((lastdot != Glib::ustring::npos) && (lastdot <= path.casefold().size() - 4) && (!path.casefold().compare (lastdot, 4, paramFileExtension)))
         // removing the extension
     {
-        path = path.substr(0, lastdot);
+        // now use dot position without casefold()
+        path = path.substr(0, path.find_last_of ('.'));
     }
 
     // dir separator may come from options file and may be \ or /, we convert them to G_DIR_SEPARATOR_S


### PR DESCRIPTION
OK, this solves 3598 and should also solve 2289.
Please review the changes and maybe test the changes in ProfileStore::findEntryFromFullPathU() - I am not quite sure when this method is actually invoked.
To sum up: existing routines attempted a case insensitive compare of file extensions by using Glib::ustring::casefold() but that would change letngth of the string (e.g. replacing ß by ss) thus breaking the "dot position" that was previously determined without using casefold().
Solution is to use either

1. lowercase() instead of casefold()
2. consistently use casefold() before using find_last_of() size() and compare()

Redundant code to determine file types for non-raw images was consolidated into util functions.