### PR TITLE
Sanitize `ImageDimensions` base class

### DIFF
--- a/rtengine/FTblockDN.cc
+++ b/rtengine/FTblockDN.cc
@@ -495,8 +495,8 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
 
     //printf("NL=%f \n",noisevarL);
     if (useNoiseLCurve || useNoiseCCurve) {
-        int hei = calclum->height;
-        int wid = calclum->width;
+        int hei = calclum->getHeight();
+        int wid = calclum->getWidth();
         TMatrix wprofi = iccStore->workingSpaceMatrix (params->icm.working);
 
         const float wpi[3][3] = {
@@ -573,7 +573,7 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
         calclum = nullptr;
     }
 
-    const short int imheight = src->height, imwidth = src->width;
+    const short int imheight = src->getHeight(), imwidth = src->getWidth();
 
     if (dnparams.luma != 0 || dnparams.chroma != 0 || dnparams.methodmed == "Lab" || dnparams.methodmed == "Lonly") {
         // gamma transform for input data
@@ -1717,8 +1717,8 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
                 #pragma omp parallel for
 #endif
 
-                for (int i = 0; i < dst->height; ++i) {
-                    for (int j = 0; j < dst->width; ++j) {
+                for (int i = 0; i < dst->getHeight(); ++i) {
+                    for (int j = 0; j < dst->getWidth(); ++j) {
                         dst->r(i, j) = Color::gammatab_srgb[ dst->r(i, j) ];
                         dst->g(i, j) = Color::gammatab_srgb[ dst->g(i, j) ];
                         dst->b(i, j) = Color::gammatab_srgb[ dst->b(i, j) ];
@@ -1746,7 +1746,7 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
 //median 3x3 in complement on RGB
     if (dnparams.methodmed == "RGB" && dnparams.median) {
 //printf("RGB den\n");
-        int wid = dst->width, hei = dst->height;
+        int wid = dst->getWidth(), hei = dst->getHeight();
         float** tm;
         tm = new float*[hei];
 
@@ -3115,8 +3115,8 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise_info(Imagefloat * src, Imagefloat 
     float** lumcalc;
     float** acalc;
     float** bcalc;
-    hei = provicalc->height;
-    wid = provicalc->width;
+    hei = provicalc->getHeight();
+    wid = provicalc->getWidth();
     TMatrix wprofi = iccStore->workingSpaceMatrix (params->icm.working);
 
     const float wpi[3][3] = {
@@ -3165,7 +3165,7 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise_info(Imagefloat * src, Imagefloat 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-    const int imheight = src->height, imwidth = src->width;
+    const int imheight = src->getHeight(), imwidth = src->getWidth();
 
     bool denoiseMethodRgb = (dnparams.dmethod == "RGB");
 

--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -1015,8 +1015,8 @@ void DCPProfile::apply(
         #pragma omp parallel for
 #endif
 
-        for (int y = 0; y < img->height; ++y) {
-            for (int x = 0; x < img->width; x++) {
+        for (int y = 0; y < img->getHeight(); ++y) {
+            for (int x = 0; x < img->getWidth(); x++) {
                 const float& newr = mat[0][0] * img->r(y, x) + mat[0][1] * img->g(y, x) + mat[0][2] * img->b(y, x);
                 const float& newg = mat[1][0] * img->r(y, x) + mat[1][1] * img->g(y, x) + mat[1][2] * img->b(y, x);
                 const float& newb = mat[2][0] * img->r(y, x) + mat[2][1] * img->g(y, x) + mat[2][2] * img->b(y, x);
@@ -1053,8 +1053,8 @@ void DCPProfile::apply(
         #pragma omp parallel for schedule(dynamic,16)
 #endif
 
-        for (int y = 0; y < img->height; ++y) {
-            for (int x = 0; x < img->width; x++) {
+        for (int y = 0; y < img->getHeight(); ++y) {
+            for (int x = 0; x < img->getWidth(); x++) {
                 float newr = pro_photo[0][0] * img->r(y, x) + pro_photo[0][1] * img->g(y, x) + pro_photo[0][2] * img->b(y, x);
                 float newg = pro_photo[1][0] * img->r(y, x) + pro_photo[1][1] * img->g(y, x) + pro_photo[1][2] * img->b(y, x);
                 float newb = pro_photo[2][0] * img->r(y, x) + pro_photo[2][1] * img->g(y, x) + pro_photo[2][2] * img->b(y, x);

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -103,7 +103,7 @@ void Crop::setEditSubscriber(EditSubscriber* newSubscriber)
             PipetteBuffer::LabBuffer = nullptr;
         }
 
-        if (PipetteBuffer::singlePlaneBuffer.getW() != -1) {
+        if (PipetteBuffer::singlePlaneBuffer.getWidth() != -1) {
             PipetteBuffer::singlePlaneBuffer.flushData();
         }
     }

--- a/rtengine/image16.cc
+++ b/rtengine/image16.cc
@@ -153,8 +153,8 @@ void Image16::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, Preview
 
     transform (pp, tran, sx1, sy1, sx2, sy2);
 
-    int imwidth = image->width; // Destination image
-    int imheight = image->height; // Destination image
+    int imwidth = image->getWidth(); // Destination image
+    int imheight = image->getHeight(); // Destination image
 
     if (((tran & TR_ROT) == TR_R90) || ((tran & TR_ROT) == TR_R270)) {
         int swap = imwidth;
@@ -165,7 +165,7 @@ void Image16::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, Preview
     int maxx = width; // Source image
     int maxy = height; // Source image
     int mtran = tran & TR_ROT;
-    int skip = pp.skip;
+    int skip = pp.getSkip();
 
     //if ((sx1 + skip*imwidth)>maxx) imwidth -- ; // we have a boundary condition that can cause errors
 

--- a/rtengine/image8.cc
+++ b/rtengine/image8.cc
@@ -113,8 +113,8 @@ void Image8::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, PreviewP
 
     transform (pp, tran, sx1, sy1, sx2, sy2);
 
-    int imwidth = image->width; // Destination image
-    int imheight = image->height; // Destination image
+    int imwidth = image->getWidth(); // Destination image
+    int imheight = image->getHeight(); // Destination image
 
     if (((tran & TR_ROT) == TR_R90) || ((tran & TR_ROT) == TR_R270)) {
         int swap = imwidth;
@@ -125,7 +125,7 @@ void Image8::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, PreviewP
     int maxx = width; // Source image
     int maxy = height; // Source image
     int mtran = tran & TR_ROT;
-    int skip = pp.skip;
+    int skip = pp.getSkip();
 
     //if ((sx1 + skip*imwidth)>maxx) imwidth -- ; // we have a boundary condition that can cause errors
 

--- a/rtengine/imagedimensions.cc
+++ b/rtengine/imagedimensions.cc
@@ -20,49 +20,88 @@
 #include "imagedimensions.h"
 #include "rtengine.h"
 
-void ImageDimensions::transform (PreviewProps pp, int tran, int &sx1, int &sy1, int &sx2, int &sy2)
+PreviewProps::PreviewProps(int _x, int _y, int _width, int _height, int _skip) :
+    x(_x),
+    y(_y),
+    width(_width),
+    height(_height),
+    skip(_skip)
 {
+}
 
-    int sw = width, sh = height;
+int PreviewProps::getX() const
+{
+    return x;
+}
+
+int PreviewProps::getY() const
+{
+    return y;
+}
+
+int PreviewProps::getWidth() const
+{
+    return width;
+}
+
+int PreviewProps::getHeight() const
+{
+    return height;
+}
+
+int PreviewProps::getSkip() const
+{
+    return skip;
+}
+
+ImageDimensions::ImageDimensions() :
+    width(-1),
+    height(-1)
+{
+}
+
+void ImageDimensions::transform(const PreviewProps& pp, int tran, int& sx1, int& sy1, int& sx2, int& sy2) const
+{
+    int sw = width;
+    int sh = height;
 
     if ((tran & TR_ROT) == TR_R90 || (tran & TR_ROT) == TR_R270) {
-        sw = height;
-        sh = width;
+        std::swap(sw, sh);
     }
 
-    int ppx = pp.x, ppy = pp.y;
+    int ppx = pp.getX();
+    int ppy = pp.getY();
 
     if (tran & TR_HFLIP) {
-        ppx = sw - pp.x - pp.w;
+        ppx = sw - pp.getX() - pp.getWidth();
     }
 
     if (tran & TR_VFLIP) {
-        ppy = sh - pp.y - pp.h;
+        ppy = sh - pp.getY() - pp.getHeight();
     }
 
     sx1 = ppx;
     sy1 = ppy;
-    sx2 = ppx + pp.w;
-    sy2 = ppy + pp.h;
+    sx2 = ppx + pp.getWidth();
+    sy2 = ppy + pp.getHeight();
 
     if ((tran & TR_ROT) == TR_R180) {
-        sx1 = width - ppx - pp.w;
-        sy1 = height - ppy - pp.h;
-        sx2 = sx1 + pp.w;
-        sy2 = sy1 + pp.h;
+        sx1 = width - ppx - pp.getWidth();
+        sy1 = height - ppy - pp.getHeight();
+        sx2 = sx1 + pp.getWidth();
+        sy2 = sy1 + pp.getHeight();
     } else if ((tran & TR_ROT) == TR_R90) {
         sx1 = ppy;
-        sy1 = height - ppx - pp.w;
-        sx2 = sx1 + pp.h;
-        sy2 = sy1 + pp.w;
+        sy1 = height - ppx - pp.getWidth();
+        sx2 = sx1 + pp.getHeight();
+        sy2 = sy1 + pp.getWidth();
     } else if ((tran & TR_ROT) == TR_R270) {
-        sx1 = width - ppy - pp.h;
+        sx1 = width - ppy - pp.getHeight();
         sy1 = ppx;
-        sx2 = sx1 + pp.h;
-        sy2 = sy1 + pp.w;
+        sx2 = sx1 + pp.getHeight();
+        sy2 = sy1 + pp.getWidth();
     }
 
-    //printf ("ppx %d ppy %d ppw %d pph %d s: %d %d %d %d\n",pp.x, pp.y,pp.w,pp.h,sx1,sy1,sx2,sy2);
     if (sx1 < 0) {
         sx1 = 0;
     }

--- a/rtengine/imagedimensions.h
+++ b/rtengine/imagedimensions.h
@@ -17,47 +17,47 @@
  *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _IMAGEDIMENSIONS_
-#define _IMAGEDIMENSIONS_
+#pragma once
 
 class PreviewProps
 {
 public:
-    int x, y, w, h, skip;
-    PreviewProps (int _x, int _y, int _w, int _h, int _skip)
-        : x(_x), y(_y), w(_w), h(_h), skip(_skip) {}
+    PreviewProps(int _x, int _y, int _width, int _height, int _skip);
+
+    int getX() const;
+    int getY() const;
+    int getWidth() const;
+    int getHeight() const;
+    int getSkip() const;
+
+private:
+    int x;
+    int y;
+    int width;
+    int height;
+    int skip;
 };
 
 /*
- * Description of an image dimension, with getter and setter
+ * Description of an image dimension, with getter
  */
 class ImageDimensions
 {
-
 public:
+    ImageDimensions();
+
+    int getWidth() const
+    {
+        return width;
+    }
+    int getHeight() const
+    {
+        return height;
+    }
+
+    void transform(const PreviewProps& pp, int tran, int& sx1, int& sy1, int& sx2, int& sy2) const;
+
+protected:
     int width;
     int height;
-
-public:
-    ImageDimensions() : width(-1), height(-1) {}
-    int getW       ()
-    {
-        return width;
-    }
-    int getH       ()
-    {
-        return height;
-    }
-    int getWidth   () const
-    {
-        return width;
-    }
-    int getHeight  () const
-    {
-        return height;
-    }
-    void transform (PreviewProps pp, int tran, int &sx1, int &sy1, int &sx2, int &sy2);
 };
-
-
-#endif

--- a/rtengine/imagefloat.cc
+++ b/rtengine/imagefloat.cc
@@ -203,7 +203,7 @@ void Imagefloat::getStdImage (ColorTemp ctemp, int tran, Imagefloat* image, Prev
     int maxx = width; // Source image
     int maxy = height; // Source image
     int mtran = tran & TR_ROT;
-    int skip = pp.skip;
+    int skip = pp.getSkip();
 
     // improve speed by integrating the area division into the multipliers
     // switched to using ints for the red/green/blue channel buffer.

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -909,7 +909,7 @@ int ImageIO::loadPPMFromMemory(const char* buffer, int width, int height, bool s
 
 int ImageIO::savePNG  (Glib::ustring fname, int compression, volatile int bps)
 {
-    if (getW() < 1 || getH() < 1) {
+    if (getWidth() < 1 || getHeight() < 1) {
         return IMIO_HEADERERROR;
     }
 
@@ -949,8 +949,8 @@ int ImageIO::savePNG  (Glib::ustring fname, int compression, volatile int bps)
 
     png_set_compression_level(png, compression);
 
-    int width = getW ();
-    int height = getH ();
+    int width = getWidth ();
+    int height = getHeight ();
 
     if (bps < 0) {
         bps = getBPS ();
@@ -1006,7 +1006,7 @@ int ImageIO::savePNG  (Glib::ustring fname, int compression, volatile int bps)
 // Quality 0..100, subsampling: 1=low quality, 2=medium, 3=high
 int ImageIO::saveJPEG (Glib::ustring fname, int quality, int subSamp)
 {
-    if (getW() < 1 || getH() < 1) {
+    if (getWidth() < 1 || getHeight() < 1) {
         return IMIO_HEADERERROR;
     }
 
@@ -1054,8 +1054,8 @@ int ImageIO::saveJPEG (Glib::ustring fname, int quality, int subSamp)
 
     jpeg_stdio_dest (&cinfo, file);
 
-    int width = getW ();
-    int height = getH ();
+    int width = getWidth ();
+    int height = getHeight ();
 
     cinfo.image_width  = width;
     cinfo.image_height = height;
@@ -1196,14 +1196,14 @@ int ImageIO::saveJPEG (Glib::ustring fname, int quality, int subSamp)
 
 int ImageIO::saveTIFF (Glib::ustring fname, int bps, bool uncompressed)
 {
-    if (getW() < 1 || getH() < 1) {
+    if (getWidth() < 1 || getHeight() < 1) {
         return IMIO_HEADERERROR;
     }
 
     //TODO: Handling 32 bits floating point output images!
     bool writeOk = true;
-    int width = getW ();
-    int height = getH ();
+    int width = getWidth ();
+    int height = getHeight ();
 
     if (bps < 0) {
         bps = getBPS ();

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1216,8 +1216,8 @@ void ImProcCoordinator::saveInputICCReference (const Glib::ustring& fname, bool 
     // image may contain out of range samples, clip them to avoid wrap-arounds
     #pragma omp parallel for
 
-    for(int i = 0; i < im->height; i++) {
-        for(int j = 0; j < im->width; j++) {
+    for(int i = 0; i < im->getHeight(); i++) {
+        for(int j = 0; j < im->getWidth(); j++) {
             im->r(i, j) = CLIP(im->r(i, j));
             im->g(i, j) = CLIP(im->g(i, j));
             im->b(i, j) = CLIP(im->b(i, j));

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -142,8 +142,8 @@ void ImProcFunctions::firstAnalysis (const Imagefloat* const original, const Pro
     lumimul[0] = wprof[1][0];
     lumimul[1] = wprof[1][1];
     lumimul[2] = wprof[1][2];
-    int W = original->width;
-    int H = original->height;
+    int W = original->getWidth();
+    int H = original->getHeight();
 
     float lumimulf[3] = {static_cast<float>(lumimul[0]), static_cast<float>(lumimul[1]), static_cast<float>(lumimul[2])};
 
@@ -2875,8 +2875,8 @@ void ImProcFunctions::moyeqt (Imagefloat* working, float &moyS, float &eqty)
 {
     BENCHFUN
 
-    int tHh = working->height;
-    int tWw = working->width;
+    int tHh = working->getHeight();
+    int tWw = working->getWidth();
     double moy = 0.0;
     double sqrs = 0.0;
 
@@ -3271,11 +3271,11 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
     bool hasgammabw = gammabwr != 1.f || gammabwg != 1.f || gammabwb != 1.f;
 
     if (hasColorToning || blackwhite || (params->dirpyrequalizer.cbdlMethod == "bef" && params->dirpyrequalizer.enabled)) {
-        tmpImage = new Imagefloat(working->width, working->height);
+        tmpImage = new Imagefloat(working->getWidth(), working->getHeight());
     }
 
-    int W = working->width;
-    int H = working->height;
+    int W = working->getWidth();
+    int H = working->getHeight();
 
     // For tonecurve histogram
     int toneCurveHistSize = histToneCurve ? histToneCurve.getSize() : 0;
@@ -3340,12 +3340,12 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
         #pragma omp for schedule(dynamic) collapse(2)
 #endif
 
-        for(int ii = 0; ii < working->height; ii += TS)
-            for(int jj = 0; jj < working->width; jj += TS) {
+        for(int ii = 0; ii < working->getHeight(); ii += TS)
+            for(int jj = 0; jj < working->getWidth(); jj += TS) {
                 istart = ii;
                 jstart = jj;
-                tH = min(ii + TS, working->height);
-                tW = min(jj + TS, working->width);
+                tH = min(ii + TS, working->getHeight());
+                tW = min(jj + TS, working->getWidth());
 
 
                 for (int i = istart, ti = 0; i < tH; i++, ti++) {
@@ -4425,8 +4425,8 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
 
     // starting a new tile processing with a 'reduction' clause for the auto mixer computing
     if (blackwhite) {//channel-mixer
-        int tW = working->width;
-        int tH = working->height;
+        int tW = working->getWidth();
+        int tH = working->getHeight();
 
         if (algm == 2) { //channel-mixer
             //end auto chmix

--- a/rtengine/ipresize.cc
+++ b/rtengine/ipresize.cc
@@ -53,18 +53,18 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
     #pragma omp parallel
     {
         // storage for precomputed parameters for horisontal interpolation
-        float * wwh = new float[support * dst->width];
-        int * jj0 = new int[dst->width];
-        int * jj1 = new int[dst->width];
+        float * wwh = new float[support * dst->getWidth()];
+        int * jj0 = new int[dst->getWidth()];
+        int * jj1 = new int[dst->getWidth()];
 
         // temporal storage for vertically-interpolated row of pixels
-        float * lr = new float[src->width];
-        float * lg = new float[src->width];
-        float * lb = new float[src->width];
+        float * lr = new float[src->getWidth()];
+        float * lg = new float[src->getWidth()];
+        float * lb = new float[src->getWidth()];
 
         // Phase 1: precompute coefficients for horisontal interpolation
 
-        for (int j = 0; j < dst->width; j++) {
+        for (int j = 0; j < dst->getWidth(); j++) {
 
             // x coord of the center of pixel on src image
             float x0 = (static_cast<float>(j) + 0.5f) * delta - 0.5f;
@@ -76,7 +76,7 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
             float ws = 0.0f;
 
             jj0[j] = max(0, static_cast<int>(floorf(x0 - a / sc)) + 1);
-            jj1[j] = min(src->width, static_cast<int>(floorf(x0 + a / sc)) + 1);
+            jj1[j] = min(src->getWidth(), static_cast<int>(floorf(x0 + a / sc)) + 1);
 
             // calculate weights
             for (int jj = jj0[j]; jj < jj1[j]; jj++) {
@@ -95,7 +95,7 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
         // Phase 2: do actual interpolation
         #pragma omp for
 
-        for (int i = 0; i < dst->height; i++) {
+        for (int i = 0; i < dst->getHeight(); i++) {
 
             // y coord of the center of pixel on src image
             float y0 = (static_cast<float>(i) + 0.5f) * delta - 0.5f;
@@ -107,7 +107,7 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
             float ws = 0.0f;
 
             int ii0 = max(0, static_cast<int>(floorf(y0 - a / sc)) + 1);
-            int ii1 = min(src->height, static_cast<int>(floorf(y0 + a / sc)) + 1);
+            int ii1 = min(src->getHeight(), static_cast<int>(floorf(y0 + a / sc)) + 1);
 
             // calculate weights for vertical interpolation
             for (int ii = ii0; ii < ii1; ii++) {
@@ -123,7 +123,7 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
             }
 
             // Do vertical interpolation. Store results.
-            for (int j = 0; j < src->width; j++) {
+            for (int j = 0; j < src->getWidth(); j++) {
 
                 float r = 0.0f, g = 0.0f, b = 0.0f;
 
@@ -141,7 +141,7 @@ void ImProcFunctions::Lanczos(const Image16* src, Image16* dst, float scale)
             }
 
             // Do horizontal interpolation
-            for(int j = 0; j < dst->width; j++) {
+            for(int j = 0; j < dst->getWidth(); j++) {
 
                 float * wh = wwh + support * j;
 
@@ -407,13 +407,13 @@ void ImProcFunctions::resize (Image16* src, Image16* dst, float dScale)
         #pragma omp parallel for if (multiThread)
 #endif
 
-        for (int i = 0; i < dst->height; i++) {
+        for (int i = 0; i < dst->getHeight(); i++) {
             int sy = i / dScale;
-            sy = LIM(sy, 0, src->height - 1);
+            sy = LIM(sy, 0, src->getHeight() - 1);
 
-            for (int j = 0; j < dst->width; j++) {
+            for (int j = 0; j < dst->getWidth(); j++) {
                 int sx = j / dScale;
-                sx = LIM(sx, 0, src->width - 1);
+                sx = LIM(sx, 0, src->getWidth() - 1);
                 dst->r(i, j) = src->r(sy, sx);
                 dst->g(i, j) = src->g(sy, sx);
                 dst->b(i, j) = src->b(sy, sx);

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -101,10 +101,10 @@ void transLineFuji (const float* const red, const float* const green, const floa
                 int y = i + j - fw;
                 int x = fw - i + j;
 
-                if (x >= 0 && y < image->height && y >= 0 && x < image->width) {
-                    image->r(image->height - 1 - y, image->width - 1 - x) = red[j];
-                    image->g(image->height - 1 - y, image->width - 1 - x) = green[j];
-                    image->b(image->height - 1 - y, image->width - 1 - x) = blue[j];
+                if (x >= 0 && y < image->getHeight() && y >= 0 && x < image->getWidth()) {
+                    image->r(image->getHeight() - 1 - y, image->getWidth() - 1 - x) = red[j];
+                    image->g(image->getHeight() - 1 - y, image->getWidth() - 1 - x) = green[j];
+                    image->b(image->getHeight() - 1 - y, image->getWidth() - 1 - x) = blue[j];
                 }
             }
 
@@ -115,10 +115,10 @@ void transLineFuji (const float* const red, const float* const green, const floa
                 int y = i + j - fw;
                 int x = fw - i + j;
 
-                if (x >= 0 && x < image->height && y >= 0 && y < image->width) {
-                    image->r(image->height - 1 - x, y) = red[j];
-                    image->g(image->height - 1 - x, y) = green[j];
-                    image->b(image->height - 1 - x, y) = blue[j];
+                if (x >= 0 && x < image->getHeight() && y >= 0 && y < image->getWidth()) {
+                    image->r(image->getHeight() - 1 - x, y) = red[j];
+                    image->g(image->getHeight() - 1 - x, y) = green[j];
+                    image->b(image->getHeight() - 1 - x, y) = blue[j];
                 }
             }
 
@@ -129,10 +129,10 @@ void transLineFuji (const float* const red, const float* const green, const floa
                 int y = i + j - fw;
                 int x = fw - i + j;
 
-                if (x >= 0 && y < image->width && y >= 0 && x < image->height) {
-                    image->r(x, image->width - 1 - y) = red[j];
-                    image->g(x, image->width - 1 - y) = green[j];
-                    image->b(x, image->width - 1 - y) = blue[j];
+                if (x >= 0 && y < image->getWidth() && y >= 0 && x < image->getHeight()) {
+                    image->r(x, image->getWidth() - 1 - y) = red[j];
+                    image->g(x, image->getWidth() - 1 - y) = green[j];
+                    image->b(x, image->getWidth() - 1 - y) = blue[j];
                 }
             }
 
@@ -144,7 +144,7 @@ void transLineFuji (const float* const red, const float* const green, const floa
                 int y = i + j - fw;
                 int x = fw - i + j;
 
-                if (x >= 0 && y < image->height && y >= 0 && x < image->width) {
+                if (x >= 0 && y < image->getHeight() && y >= 0 && x < image->getWidth()) {
                     image->r(y, x) = red[j];
                     image->g(y, x) = green[j];
                     image->b(y, x) = blue[j];
@@ -499,17 +499,18 @@ RawImageSource::~RawImageSource ()
 
 void RawImageSource::transformRect (PreviewProps pp, int tran, int &ssx1, int &ssy1, int &width, int &height, int &fw)
 {
-
-    pp.x += border;
-    pp.y += border;
+    int pp_x = pp.getX() + border;
+    int pp_y = pp.getY() + border;
+    int pp_width = pp.getWidth();
+    int pp_height = pp.getHeight();
 
     if (d1x) {
         if ((tran & TR_ROT) == TR_R90 || (tran & TR_ROT) == TR_R270) {
-            pp.x /= 2;
-            pp.w = pp.w / 2 + 1;
+            pp_x /= 2;
+            pp_width = pp_width / 2 + 1;
         } else {
-            pp.y /= 2;
-            pp.h = pp.h / 2 + 1;
+            pp_y /= 2;
+            pp_height = pp_height / 2 + 1;
         }
     }
 
@@ -527,44 +528,44 @@ void RawImageSource::transformRect (PreviewProps pp, int tran, int &ssx1, int &s
         sh = w;
     }
 
-    if( pp.w > sw - 2 * border) {
-        pp.w = sw - 2 * border;
+    if( pp_width > sw - 2 * border) {
+        pp_width = sw - 2 * border;
     }
 
-    if( pp.h > sh - 2 * border) {
-        pp.h = sh - 2 * border;
+    if( pp_height > sh - 2 * border) {
+        pp_height = sh - 2 * border;
     }
 
-    int ppx = pp.x, ppy = pp.y;
+    int ppx = pp_x, ppy = pp_y;
 
     if (tran & TR_HFLIP) {
-        ppx = sw - pp.x - pp.w;
+        ppx = sw - pp_x - pp_width;
     }
 
     if (tran & TR_VFLIP) {
-        ppy = sh - pp.y - pp.h;
+        ppy = sh - pp_y - pp_height;
     }
 
     int sx1 = ppx;        // assuming it's >=0
     int sy1 = ppy;        // assuming it's >=0
-    int sx2 = max(ppx + pp.w, w - 1);
-    int sy2 = max(ppy + pp.h, h - 1);
+    int sx2 = max(ppx + pp_width, w - 1);
+    int sy2 = max(ppy + pp_height, h - 1);
 
     if ((tran & TR_ROT) == TR_R180) {
-        sx1 = max(w - ppx - pp.w, 0);
-        sy1 = max(h - ppy - pp.h, 0);
-        sx2 = min(sx1 + pp.w, w - 1);
-        sy2 = min(sy1 + pp.h, h - 1);
+        sx1 = max(w - ppx - pp_width, 0);
+        sy1 = max(h - ppy - pp_height, 0);
+        sx2 = min(sx1 + pp_width, w - 1);
+        sy2 = min(sy1 + pp_height, h - 1);
     } else if ((tran & TR_ROT) == TR_R90) {
         sx1 = ppy;
-        sy1 = max(h - ppx - pp.w, 0);
-        sx2 = min(sx1 + pp.h, w - 1);
-        sy2 = min(sy1 + pp.w, h - 1);
+        sy1 = max(h - ppx - pp_width, 0);
+        sx2 = min(sx1 + pp_height, w - 1);
+        sy2 = min(sy1 + pp_width, h - 1);
     } else if ((tran & TR_ROT) == TR_R270) {
-        sx1 = max(w - ppy - pp.h, 0);
+        sx1 = max(w - ppy - pp_height, 0);
         sy1 = ppx;
-        sx2 = min(sx1 + pp.h, w - 1);
-        sy2 = min(sy1 + pp.w, h - 1);
+        sx2 = min(sx1 + pp_height, w - 1);
+        sy2 = min(sy1 + pp_width, h - 1);
     }
 
     if (fuji) {
@@ -574,14 +575,14 @@ void RawImageSource::transformRect (PreviewProps pp, int tran, int &ssx1, int &s
         ssy1 = (sy1 - sx2 ) / 2 + ri->get_FujiWidth();
         int ssx2 = (sx2 + sy2) / 2 + 1;
         int ssy2 = (sy2 - sx1) / 2 + ri->get_FujiWidth();
-        fw   = (sx2 - sx1) / 2 / pp.skip;
-        width  = (ssx2 - ssx1) / pp.skip + ((ssx2 - ssx1) % pp.skip > 0);
-        height = (ssy2 - ssy1) / pp.skip + ((ssy2 - ssy1) % pp.skip > 0);
+        fw   = (sx2 - sx1) / 2 / pp.getSkip();
+        width  = (ssx2 - ssx1) / pp.getSkip() + ((ssx2 - ssx1) % pp.getSkip() > 0);
+        height = (ssy2 - ssy1) / pp.getSkip() + ((ssy2 - ssy1) % pp.getSkip() > 0);
     } else {
         ssx1 = sx1;
         ssy1 = sy1;
-        width  = (sx2 - sx1) / pp.skip + ((sx2 - sx1) % pp.skip > 0);
-        height = (sy2 - sy1) / pp.skip + ((sy2 - sy1) % pp.skip > 0);
+        width  = (sx2 - sx1) / pp.getSkip() + ((sx2 - sx1) % pp.getSkip() > 0);
+        height = (sy2 - sy1) / pp.getSkip() + ((sy2 - sy1) % pp.getSkip() > 0);
     }
 }
 
@@ -674,11 +675,11 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
     int maximwidth, maximheight;
 
     if ((tran & TR_ROT) == TR_R90 || (tran & TR_ROT) == TR_R270) {
-        maximwidth = image->height;
-        maximheight = image->width;
+        maximwidth = image->getHeight();
+        maximheight = image->getWidth();
     } else {
-        maximwidth = image->width;
-        maximheight = image->height;
+        maximwidth = image->getWidth();
+        maximheight = image->getHeight();
     }
 
     if (d1x) {
@@ -699,7 +700,7 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
         imheight = maximheight;
     }
 
-    int maxx = this->W, maxy = this->H, skip = pp.skip;
+    int maxx = this->W, maxy = this->H, skip = pp.getSkip();
 
     // raw clip levels after white balance
     hlmax[0] = clmax[0] * rm;
@@ -818,18 +819,18 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
 #endif
 
     if (fuji) {
-        int a = ((tran & TR_ROT) == TR_R90 && image->width % 2 == 0) || ((tran & TR_ROT) == TR_R180 && image->height % 2 + image->width % 2 == 1) || ((tran & TR_ROT) == TR_R270 && image->height % 2 == 0);
+        int a = ((tran & TR_ROT) == TR_R90 && image->getWidth() % 2 == 0) || ((tran & TR_ROT) == TR_R180 && image->getHeight() % 2 + image->getWidth() % 2 == 1) || ((tran & TR_ROT) == TR_R270 && image->getHeight() % 2 == 0);
 
         // first row
-        for (int j = 1 + a; j < image->width - 1; j += 2) {
+        for (int j = 1 + a; j < image->getWidth() - 1; j += 2) {
             image->r(0, j) = (image->r(1, j) + image->r(0, j + 1) + image->r(0, j - 1)) / 3;
             image->g(0, j) = (image->g(1, j) + image->g(0, j + 1) + image->g(0, j - 1)) / 3;
             image->b(0, j) = (image->b(1, j) + image->b(0, j + 1) + image->b(0, j - 1)) / 3;
         }
 
         // other rows
-        for (int i = 1; i < image->height - 1; i++) {
-            for (int j = 2 - (a + i + 1) % 2; j < image->width - 1; j += 2) {
+        for (int i = 1; i < image->getHeight() - 1; i++) {
+            for (int j = 2 - (a + i + 1) % 2; j < image->getWidth() - 1; j += 2) {
                 // edge-adaptive interpolation
                 double dh = (ABS(image->r(i, j + 1) - image->r(i, j - 1)) + ABS(image->g(i, j + 1) - image->g(i, j - 1)) + ABS(image->b(i, j + 1) - image->b(i, j - 1))) / 1.0;
                 double dv = (ABS(image->r(i + 1, j) - image->r(i - 1, j)) + ABS(image->g(i + 1, j) - image->g(i - 1, j)) + ABS(image->b(i + 1, j) - image->b(i - 1, j))) / 1.0;
@@ -848,20 +849,20 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
             }
 
             // last pixel
-            if (2 - (a + i + image->width) % 2 == 2) {
-                image->r(i, image->width - 1) = (image->r(i + 1, image->width - 1) + image->r(i - 1, image->width - 1) + image->r(i, image->width - 2)) / 3;
-                image->g(i, image->width - 1) = (image->g(i + 1, image->width - 1) + image->g(i - 1, image->width - 1) + image->g(i, image->width - 2)) / 3;
-                image->b(i, image->width - 1) = (image->b(i + 1, image->width - 1) + image->b(i - 1, image->width - 1) + image->b(i, image->width - 2)) / 3;
+            if (2 - (a + i + image->getWidth()) % 2 == 2) {
+                image->r(i, image->getWidth() - 1) = (image->r(i + 1, image->getWidth() - 1) + image->r(i - 1, image->getWidth() - 1) + image->r(i, image->getWidth() - 2)) / 3;
+                image->g(i, image->getWidth() - 1) = (image->g(i + 1, image->getWidth() - 1) + image->g(i - 1, image->getWidth() - 1) + image->g(i, image->getWidth() - 2)) / 3;
+                image->b(i, image->getWidth() - 1) = (image->b(i + 1, image->getWidth() - 1) + image->b(i - 1, image->getWidth() - 1) + image->b(i, image->getWidth() - 2)) / 3;
             }
         }
 
         // last row
-        int b = (a == 1 && image->height % 2) || (a == 0 && image->height % 2 == 0);
+        int b = (a == 1 && image->getHeight() % 2) || (a == 0 && image->getHeight() % 2 == 0);
 
-        for (int j = 1 + b; j < image->width - 1; j += 2) {
-            image->r(image->height - 1, j) = (image->r(image->height - 2, j) + image->r(image->height - 1, j + 1) + image->r(image->height - 1, j - 1)) / 3;
-            image->g(image->height - 1, j) = (image->g(image->height - 2, j) + image->g(image->height - 1, j + 1) + image->g(image->height - 1, j - 1)) / 3;
-            image->b(image->height - 1, j) = (image->b(image->height - 2, j) + image->b(image->height - 1, j + 1) + image->b(image->height - 1, j - 1)) / 3;
+        for (int j = 1 + b; j < image->getWidth() - 1; j += 2) {
+            image->r(image->getHeight() - 1, j) = (image->r(image->getHeight() - 2, j) + image->r(image->getHeight() - 1, j + 1) + image->r(image->getHeight() - 1, j - 1)) / 3;
+            image->g(image->getHeight() - 1, j) = (image->g(image->getHeight() - 2, j) + image->g(image->getHeight() - 1, j + 1) + image->g(image->getHeight() - 1, j - 1)) / 3;
+            image->b(image->getHeight() - 1, j) = (image->b(image->getHeight() - 2, j) + image->b(image->getHeight() - 1, j + 1) + image->b(image->getHeight() - 1, j - 1)) / 3;
         }
     }
 
@@ -875,7 +876,7 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
     }
 
     // Colour correction (only when running on full resolution)
-    if(pp.skip == 1) {
+    if(pp.getSkip() == 1) {
         switch(ri->getSensorType()) {
             case ST_BAYER:
                 processFalseColorCorrection (image, raw.bayersensor.ccSteps);
@@ -1472,9 +1473,8 @@ void RawImageSource::getFullSize (int& w, int& h, int tr)
 
 void RawImageSource::getSize (PreviewProps pp, int& w, int& h)
 {
-
-    w = pp.w / pp.skip + (pp.w % pp.skip > 0);
-    h = pp.h / pp.skip + (pp.h % pp.skip > 0);
+    w = pp.getWidth() / pp.getSkip() + (pp.getWidth() % pp.getSkip() > 0);
+    h = pp.getHeight() / pp.getSkip() + (pp.getHeight() % pp.getSkip() > 0);
 }
 
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3514,7 +3514,7 @@ int RawImageSource::defTransform (int tran)
 void RawImageSource::processFalseColorCorrectionThread  (Imagefloat* im, array2D<float> &rbconv_Y, array2D<float> &rbconv_I, array2D<float> &rbconv_Q, array2D<float> &rbout_I, array2D<float> &rbout_Q, const int row_from, const int row_to)
 {
 
-    const int W = im->width;
+    const int W = im->getWidth();
     constexpr float onebynine = 1.f / 9.f;
 
 #ifdef __SSE2__
@@ -3661,7 +3661,7 @@ void RawImageSource::processFalseColorCorrectionThread  (Imagefloat* im, array2D
 void RawImageSource::processFalseColorCorrection  (Imagefloat* im, const int steps)
 {
 
-    if (im->height < 4 || steps < 1) {
+    if (im->getHeight() < 4 || steps < 1) {
         return;
     }
 
@@ -3671,14 +3671,14 @@ void RawImageSource::processFalseColorCorrection  (Imagefloat* im, const int ste
         multi_array2D<float, 5> buffer (W, 3);
         int tid = omp_get_thread_num();
         int nthreads = omp_get_num_threads();
-        int blk = (im->height - 2) / nthreads;
+        int blk = (im->getHeight() - 2) / nthreads;
 
         for (int t = 0; t < steps; t++) {
 
             if (tid < nthreads - 1) {
                 processFalseColorCorrectionThread (im, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], 1 + tid * blk, 1 + (tid + 1)*blk);
             } else {
-                processFalseColorCorrectionThread (im, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], 1 + tid * blk, im->height - 1);
+                processFalseColorCorrectionThread (im, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], 1 + tid * blk, im->getHeight() - 1);
             }
 
             #pragma omp barrier
@@ -3688,7 +3688,7 @@ void RawImageSource::processFalseColorCorrection  (Imagefloat* im, const int ste
     multi_array2D<float, 5> buffer (W, 3);
 
     for (int t = 0; t < steps; t++) {
-        processFalseColorCorrectionThread (im, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], 1 , im->height - 1);
+        processFalseColorCorrectionThread (im, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], 1 , im->getHeight() - 1);
     }
 
 #endif
@@ -3812,8 +3812,8 @@ void RawImageSource::colorSpaceConversion_ (Imagefloat* im, ColorManagementParam
         #pragma omp parallel for
 #endif
 
-        for (int i = 0; i < im->height; i++)
-            for (int j = 0; j < im->width; j++) {
+        for (int i = 0; i < im->getHeight(); i++)
+            for (int j = 0; j < im->getWidth(); j++) {
 
                 float newr = mat[0][0] * im->r(i, j) + mat[0][1] * im->g(i, j) + mat[0][2] * im->b(i, j);
                 float newg = mat[1][0] * im->r(i, j) + mat[1][1] * im->g(i, j) + mat[1][2] * im->b(i, j);
@@ -3945,18 +3945,18 @@ void RawImageSource::colorSpaceConversion_ (Imagefloat* im, ColorManagementParam
         #pragma omp parallel
 #endif
         {
-            AlignedBuffer<float> buffer(im->width * 3);
-            AlignedBuffer<float> hl_buffer(im->width * 3);
-            AlignedBuffer<float> hl_scale(im->width);
+            AlignedBuffer<float> buffer(im->getWidth() * 3);
+            AlignedBuffer<float> hl_buffer(im->getWidth() * 3);
+            AlignedBuffer<float> hl_scale(im->getWidth());
 #ifdef _OPENMP
             #pragma omp for schedule(static)
 #endif
 
-            for ( int h = 0; h < im->height; ++h ) {
+            for ( int h = 0; h < im->getHeight(); ++h ) {
                 float *p = buffer.data, *pR = im->r(h), *pG = im->g(h), *pB = im->b(h);
 
                 // Apply pre-processing
-                for ( int w = 0; w < im->width; ++w ) {
+                for ( int w = 0; w < im->getWidth(); ++w ) {
                     float r = *(pR++);
                     float g = *(pG++);
                     float b = *(pB++);
@@ -4027,10 +4027,10 @@ void RawImageSource::colorSpaceConversion_ (Imagefloat* im, ColorManagementParam
                 }
 
                 // Run icc transform
-                cmsDoTransform (hTransform, buffer.data, buffer.data, im->width);
+                cmsDoTransform (hTransform, buffer.data, buffer.data, im->getWidth());
 
                 if (separate_pcs_lab_highlights) {
-                    cmsDoTransform (hTransform, hl_buffer.data, hl_buffer.data, im->width);
+                    cmsDoTransform (hTransform, hl_buffer.data, hl_buffer.data, im->getWidth());
                 }
 
                 // Apply post-processing
@@ -4039,7 +4039,7 @@ void RawImageSource::colorSpaceConversion_ (Imagefloat* im, ColorManagementParam
                 pG = im->g(h);
                 pB = im->b(h);
 
-                for ( int w = 0; w < im->width; ++w ) {
+                for ( int w = 0; w < im->getWidth(); ++w ) {
 
                     float r, g, b, hr, hg, hb;
 

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -98,16 +98,16 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
 
     if (inspectorMode) {
         // Special case, meaning that we want a full sized thumbnail image (e.g. for the Inspector feature)
-        w = img->width;
-        h = img->height;
+        w = img->getWidth();
+        h = img->getHeight();
         tpp->scale = 1.;
     } else {
         if (fixwh == 1) {
-            w = h * img->width / img->height;
-            tpp->scale = (double)img->height / h;
+            w = h * img->getWidth() / img->getHeight();
+            tpp->scale = (double)img->getHeight() / h;
         } else {
-            h = w * img->height / img->width;
-            tpp->scale = (double)img->width / w;
+            h = w * img->getHeight() / img->getWidth();
+            tpp->scale = (double)img->getWidth() / w;
         }
     }
 
@@ -223,16 +223,16 @@ Thumbnail* Thumbnail::loadQuickFromRaw (const Glib::ustring& fname, RawMetaDataL
 
     if (inspectorMode) {
         // Special case, meaning that we want a full sized thumbnail image (e.g. for the Inspector feature)
-        w = img->width;
-        h = img->height;
+        w = img->getWidth();
+        h = img->getHeight();
         tpp->scale = 1.;
     } else {
         if (fixwh == 1) {
-            w = h * img->width / img->height;
-            tpp->scale = (double)img->height / h;
+            w = h * img->getWidth() / img->getHeight();
+            tpp->scale = (double)img->getHeight() / h;
         } else {
-            h = w * img->height / img->width;
-            tpp->scale = (double)img->width / w;
+            h = w * img->getHeight() / img->getWidth();
+            tpp->scale = (double)img->getWidth() / w;
         }
     }
 
@@ -260,8 +260,8 @@ Thumbnail* Thumbnail::loadQuickFromRaw (const Glib::ustring& fname, RawMetaDataL
         if (suffix != "mos" && suffix != "mef" && suffix != "iiq")  {
             tpp->thumbImg->rotate(ri->get_rotateDegree());
             // width/height may have changed after rotating
-            w = tpp->thumbImg->width;
-            h = tpp->thumbImg->height;
+            w = tpp->thumbImg->getWidth();
+            h = tpp->thumbImg->getHeight();
         }
     }
 
@@ -810,9 +810,9 @@ IImage8* Thumbnail::quickProcessImage (const procparams::ProcParams& params, int
 
     if (params.coarse.rotate == 90 || params.coarse.rotate == 270) {
         rwidth = rheight;
-        rheight = thumbImg->height * rwidth / thumbImg->width;
+        rheight = thumbImg->getHeight() * rwidth / thumbImg->getWidth();
     } else {
-        rwidth = thumbImg->width * rheight / thumbImg->height;
+        rwidth = thumbImg->getWidth() * rheight / thumbImg->getHeight();
     }
 
     Image8* baseImg = resizeTo<Image8>(rwidth, rheight, interp, thumbImg);
@@ -889,9 +889,9 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, int rhei
 
     if (params.coarse.rotate == 90 || params.coarse.rotate == 270) {
         rwidth = rheight;
-        rheight = int(size_t(thumbImg->height) * size_t(rwidth) / size_t(thumbImg->width));
+        rheight = int(size_t(thumbImg->getHeight()) * size_t(rwidth) / size_t(thumbImg->getWidth()));
     } else {
-        rwidth = int(size_t(thumbImg->width) * size_t(rheight) / size_t(thumbImg->height));
+        rwidth = int(size_t(thumbImg->getWidth()) * size_t(rheight) / size_t(thumbImg->getHeight()));
     }
 
 
@@ -899,8 +899,8 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, int rhei
 
     if (params.coarse.rotate) {
         baseImg->rotate (params.coarse.rotate);
-        rwidth = baseImg->width;
-        rheight = baseImg->height;
+        rwidth = baseImg->getWidth();
+        rheight = baseImg->getHeight();
     }
 
     if (params.coarse.hflip) {
@@ -940,12 +940,12 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, int rhei
         StdImageSource::colorSpaceConversion (baseImg, params.icm, embProfile, thumbImg->getSampleFormat());
     }
 
-    int fw = baseImg->width;
-    int fh = baseImg->height;
+    int fw = baseImg->getWidth();
+    int fh = baseImg->getHeight();
     //ColorTemp::CAT02 (baseImg, &params)   ;//perhaps not good!
 
     ImProcFunctions ipf (&params, false);
-    ipf.setScale (sqrt(double(fw * fw + fh * fh)) / sqrt(double(thumbImg->width * thumbImg->width + thumbImg->height * thumbImg->height))*scale);
+    ipf.setScale (sqrt(double(fw * fw + fh * fh)) / sqrt(double(thumbImg->getWidth() * thumbImg->getWidth() + thumbImg->getHeight() * thumbImg->getHeight()))*scale);
     ipf.updateColorProfiles (options.rtSettings.monitorProfile, options.rtSettings.monitorIntent, false, false);
 
     LUTu hist16 (65536);
@@ -1206,9 +1206,9 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, int rhei
 
     // calculate scale
     if (params.coarse.rotate == 90 || params.coarse.rotate == 270) {
-        myscale = scale * thumbImg->width / fh;
+        myscale = scale * thumbImg->getWidth() / fh;
     } else {
-        myscale = scale * thumbImg->height / fh;
+        myscale = scale * thumbImg->getHeight() / fh;
     }
 
     myscale = 1.0 / myscale;
@@ -1238,9 +1238,9 @@ int Thumbnail::getImageWidth (const procparams::ProcParams& params, int rheight,
     int rwidth;
 
     if (params.coarse.rotate == 90 || params.coarse.rotate == 270) {
-        ratio = (float)(thumbImg->height) / (float)(thumbImg->width);
+        ratio = (float)(thumbImg->getHeight()) / (float)(thumbImg->getWidth());
     } else {
-        ratio = (float)(thumbImg->width) / (float)(thumbImg->height);
+        ratio = (float)(thumbImg->getWidth()) / (float)(thumbImg->getHeight());
     }
 
     rwidth = (int)(ratio * (float)rheight);
@@ -1251,8 +1251,8 @@ int Thumbnail::getImageWidth (const procparams::ProcParams& params, int rheight,
 void Thumbnail::getDimensions (int& w, int& h, double& scaleFac)
 {
     if (thumbImg) {
-        w = thumbImg->width;
-        h = thumbImg->height;
+        w = thumbImg->getWidth();
+        h = thumbImg->getHeight();
         scaleFac = scale;
     } else {
         w = 0;
@@ -1314,11 +1314,11 @@ void Thumbnail::getSpotWB (const procparams::ProcParams& params, int xp, int yp,
             points.push_back (Coord2D (j, i));
         }
 
-    int fw = thumbImg->width, fh = thumbImg->height;
+    int fw = thumbImg->getWidth(), fh = thumbImg->getHeight();
 
     if (params.coarse.rotate == 90 || params.coarse.rotate == 270) {
-        fw = thumbImg->height;
-        fh = thumbImg->width;
+        fw = thumbImg->getHeight();
+        fh = thumbImg->getWidth();
     }
 
     ImProcFunctions ipf (&params, false);
@@ -1343,8 +1343,8 @@ void Thumbnail::getSpotWB (const procparams::ProcParams& params, int xp, int yp,
 void Thumbnail::transformPixel (int x, int y, int tran, int& tx, int& ty)
 {
 
-    int W = thumbImg->width;
-    int H = thumbImg->height;
+    int W = thumbImg->getWidth();
+    int H = thumbImg->getHeight();
     int sw = W, sh = H;
 
     if ((tran & TR_ROT) == TR_R90 || (tran & TR_ROT) == TR_R270) {
@@ -1386,12 +1386,12 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         return nullptr;
     }
 
-    if (thumbImg->width < trim_width) {
+    if (thumbImg->getWidth() < trim_width) {
         return nullptr;
     }
 
     // to utilize the 8 bit color range of the thumbnail we brighten it and apply gamma correction
-    unsigned char* tmpdata = new unsigned char[thumbImg->height * trim_width];
+    unsigned char* tmpdata = new unsigned char[thumbImg->getHeight() * trim_width];
     int ix = 0, max;
 
     if (gammaCorrected) {
@@ -1417,7 +1417,7 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         }
 
         // Go down till we cut off that many pixels
-        unsigned long cutoff = thumbImg->height * thumbImg->height * 4 * BurnOffPct;
+        unsigned long cutoff = thumbImg->getHeight() * thumbImg->getHeight() * 4 * BurnOffPct;
 
         int max_;
         unsigned long sum = 0;
@@ -1434,8 +1434,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         if (thumbImg->getType() == sImage8) {
             Image8 *image = static_cast<Image8*>(thumbImg);
 
-            for (int i = 0; i < thumbImg->height; i++)
-                for (int j = (thumbImg->width - trim_width) / 2; j < trim_width + (thumbImg->width - trim_width) / 2; j++) {
+            for (int i = 0; i < thumbImg->getHeight(); i++)
+                for (int j = (thumbImg->getWidth() - trim_width) / 2; j < trim_width + (thumbImg->getWidth() - trim_width) / 2; j++) {
                     unsigned short r_, g_, b_;
                     image->convertTo(image->r(i, j), r_);
                     image->convertTo(image->g(i, j), g_);
@@ -1448,8 +1448,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         } else if (thumbImg->getType() == sImage16) {
             Image16 *image = static_cast<Image16*>(thumbImg);
 
-            for (int i = 0; i < thumbImg->height; i++)
-                for (int j = (thumbImg->width - trim_width) / 2; j < trim_width + (thumbImg->width - trim_width) / 2; j++) {
+            for (int i = 0; i < thumbImg->getHeight(); i++)
+                for (int j = (thumbImg->getWidth() - trim_width) / 2; j < trim_width + (thumbImg->getWidth() - trim_width) / 2; j++) {
                     unsigned short r_, g_, b_;
                     image->convertTo(image->r(i, j), r_);
                     image->convertTo(image->g(i, j), g_);
@@ -1462,8 +1462,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         } else if (thumbImg->getType() == sImagefloat) {
             Imagefloat *image = static_cast<Imagefloat*>(thumbImg);
 
-            for (int i = 0; i < thumbImg->height; i++)
-                for (int j = (thumbImg->width - trim_width) / 2; j < trim_width + (thumbImg->width - trim_width) / 2; j++) {
+            for (int i = 0; i < thumbImg->getHeight(); i++)
+                for (int j = (thumbImg->getWidth() - trim_width) / 2; j < trim_width + (thumbImg->getWidth() - trim_width) / 2; j++) {
                     unsigned short r_, g_, b_;
                     image->convertTo(image->r(i, j), r_);
                     image->convertTo(image->g(i, j), g_);
@@ -1482,8 +1482,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             Image8 *image = static_cast<Image8*>(thumbImg);
             unsigned char max_ = 0;
 
-            for (int row = 0; row < image->height; row++)
-                for (int col = 0; col < image->width; col++) {
+            for (int row = 0; row < image->getHeight(); row++)
+                for (int col = 0; col < image->getWidth(); col++) {
                     if (image->r(row, col) > max_) {
                         max_ = image->r(row, col);
                     }
@@ -1506,8 +1506,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             scaleForSave = 65535 * 8192 / max;
 
             // Correction and gamma to 8 Bit
-            for (int i = 0; i < image->height; i++)
-                for (int j = (image->width - trim_width) / 2; j < trim_width + (image->width - trim_width) / 2; j++) {
+            for (int i = 0; i < image->getHeight(); i++)
+                for (int j = (image->getWidth() - trim_width) / 2; j < trim_width + (image->getWidth() - trim_width) / 2; j++) {
                     unsigned short rtmp, gtmp, btmp;
                     image->convertTo(image->r(i, j), rtmp);
                     image->convertTo(image->g(i, j), gtmp);
@@ -1521,8 +1521,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             Image16 *image = static_cast<Image16*>(thumbImg);
             unsigned short max_ = 0;
 
-            for (int row = 0; row < image->height; row++)
-                for (int col = 0; col < image->width; col++) {
+            for (int row = 0; row < image->getHeight(); row++)
+                for (int col = 0; col < image->getWidth(); col++) {
                     if (image->r(row, col) > max_) {
                         max_ = image->r(row, col);
                     }
@@ -1545,8 +1545,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             scaleForSave = 65535 * 8192 / max;
 
             // Correction and gamma to 8 Bit
-            for (int i = 0; i < image->height; i++)
-                for (int j = (image->width - trim_width) / 2; j < trim_width + (image->width - trim_width) / 2; j++) {
+            for (int i = 0; i < image->getHeight(); i++)
+                for (int j = (image->getWidth() - trim_width) / 2; j < trim_width + (image->getWidth() - trim_width) / 2; j++) {
                     unsigned short rtmp, gtmp, btmp;
                     image->convertTo(image->r(i, j), rtmp);
                     image->convertTo(image->g(i, j), gtmp);
@@ -1560,8 +1560,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             Imagefloat *image = static_cast<Imagefloat*>(thumbImg);
             float max_ = 0.f;
 
-            for (int row = 0; row < image->height; row++)
-                for (int col = 0; col < image->width; col++) {
+            for (int row = 0; row < image->getHeight(); row++)
+                for (int col = 0; col < image->getWidth(); col++) {
                     if (image->r(row, col) > max_) {
                         max_ = image->r(row, col);
                     }
@@ -1584,8 +1584,8 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
             scaleForSave = 65535 * 8192 / max;
 
             // Correction and gamma to 8 Bit
-            for (int i = 0; i < image->height; i++)
-                for (int j = (image->width - trim_width) / 2; j < trim_width + (image->width - trim_width) / 2; j++) {
+            for (int i = 0; i < image->getHeight(); i++)
+                for (int j = (image->getWidth() - trim_width) / 2; j < trim_width + (image->getWidth() - trim_width) / 2; j++) {
                     unsigned short rtmp, gtmp, btmp;
                     image->convertTo(image->r(i, j), rtmp);
                     image->convertTo(image->g(i, j), gtmp);
@@ -1617,7 +1617,7 @@ unsigned char* Thumbnail::getGrayscaleHistEQ (int trim_width)
         }
 
         if (cdf_min != -1) {
-            hist[i] = (cdf - cdf_min) * 255 / ((thumbImg->height * trim_width) - cdf_min);
+            hist[i] = (cdf - cdf_min) * 255 / ((thumbImg->getHeight() * trim_width) - cdf_min);
         }
     }
 
@@ -1645,8 +1645,8 @@ bool Thumbnail::writeImage (const Glib::ustring& fname, int format)
 
     fwrite (thumbImg->getType(), sizeof (char), strlen(thumbImg->getType()), f);
     fputc ('\n', f);
-    guint32 w = guint32(thumbImg->width);
-    guint32 h = guint32(thumbImg->height);
+    guint32 w = guint32(thumbImg->getWidth());
+    guint32 h = guint32(thumbImg->getHeight());
     fwrite (&w, sizeof (guint32), 1, f);
     fwrite (&h, sizeof (guint32), 1, f);
 

--- a/rtengine/stdimagesource.cc
+++ b/rtengine/stdimagesource.cc
@@ -276,20 +276,19 @@ void StdImageSource::colorSpaceConversion (Imagefloat* im, const ColorManagement
 void StdImageSource::getFullSize (int& w, int& h, int tr)
 {
 
-    w = img->width;
-    h = img->height;
+    w = img->getWidth();
+    h = img->getHeight();
 
     if ((tr & TR_ROT) == TR_R90 || (tr & TR_ROT) == TR_R270) {
-        w = img->height;
-        h = img->width;
+        w = img->getHeight();
+        h = img->getWidth();
     }
 }
 
 void StdImageSource::getSize (PreviewProps pp, int& w, int& h)
 {
-
-    w = pp.w / pp.skip + (pp.w % pp.skip > 0);
-    h = pp.h / pp.skip + (pp.h % pp.skip > 0);
+    w = pp.getWidth() / pp.getSkip() + (pp.getWidth() % pp.getSkip() > 0);
+    h = pp.getHeight() / pp.getSkip() + (pp.getHeight() % pp.getSkip() > 0);
 }
 
 void StdImageSource::getAutoExpHistogram (LUTu & histogram, int& histcompr)

--- a/rtgui/bqentryupdater.cc
+++ b/rtgui/bqentryupdater.cc
@@ -120,11 +120,11 @@ void BatchQueueEntryUpdater::processThread ()
                 int prevh = img->getHeight();
 #ifndef NDEBUG
 
-                if (current.ow != img->getW() || current.oh != img->getH()) {
-                    printf("WARNING!  Expected image size: %dx%d ; image size is: %dx%d\n", current.ow, current.oh, img->getW(), img->getH());
+                if (current.ow != img->getWidth() || current.oh != img->getHeight()) {
+                    printf("WARNING!  Expected image size: %dx%d ; image size is: %dx%d\n", current.ow, current.oh, img->getWidth(), img->getHeight());
                 }
 
-                assert ((current.ow + 1)*current.oh >= img->getW()*img->getH());
+                assert ((current.ow + 1)*current.oh >= img->getWidth()*img->getHeight());
 #endif
                 current.ow = prevw;
                 current.oh = prevh;


### PR DESCRIPTION
Hi there, post-5.0 developers, :smile: 

Today I was browsing the code to find out, why we need virtual inheritance. Now, that point is clear to me and not that easy to change (well, you know, virtual inheritance has a certain smell...). Nevertheless I took the opportunity to refactor the very base class `ImageDimensions` with these goals in mind:

- Make `width` and `height` private
- Drop `getW()` and `getH()`
- Clean `PreviewProps`

I hope you like the result.

Best
Flössie