### PR TITLE
Change `-std=gnu++11` to `-std=c++11`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ endif ()
 string (TOUPPER ${CMAKE_BUILD_TYPE} UPPER_CMAKE_BUILD_TYPE)
 
 # Set required C and C++ standards and check GCC version
-SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
-SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
   message(FATAL_ERROR "Building RawTherapee requires using GCC version 4.9 or higher!")

--- a/rtengine/FTblockDN.cc
+++ b/rtengine/FTblockDN.cc
@@ -622,13 +622,13 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
 
             for (int i = 0; i < TS; ++i) {
                 float i1 = abs((i > TS / 2 ? i - TS + 1 : i));
-                float vmask = (i1 < border ? SQR(sin((M_PI * i1) / (2 * border))) : 1.0f);
-                float vmask2 = (i1 < 2 * border ? SQR(sin((M_PI * i1) / (2 * border))) : 1.0f);
+                float vmask = (i1 < border ? SQR(sin((rtengine::RT_PI * i1) / (2 * border))) : 1.0f);
+                float vmask2 = (i1 < 2 * border ? SQR(sin((rtengine::RT_PI * i1) / (2 * border))) : 1.0f);
 
                 for (int j = 0; j < TS; ++j) {
                     float j1 = abs((j > TS / 2 ? j - TS + 1 : j));
-                    tilemask_in[i][j] = (vmask * (j1 < border ? SQR(sin((M_PI * j1) / (2 * border))) : 1.0f)) + epsilon;
-                    tilemask_out[i][j] = (vmask2 * (j1 < 2 * border ? SQR(sin((M_PI * j1) / (2 * border))) : 1.0f)) + epsilon;
+                    tilemask_in[i][j] = (vmask * (j1 < border ? SQR(sin((rtengine::RT_PI * j1) / (2 * border))) : 1.0f)) + epsilon;
+                    tilemask_out[i][j] = (vmask2 * (j1 < 2 * border ? SQR(sin((rtengine::RT_PI * j1) / (2 * border))) : 1.0f)) + epsilon;
 
                 }
             }
@@ -1512,7 +1512,7 @@ SSEFUNCTION void ImProcFunctions::RGB_denoise(int kall, Imagefloat * src, Imagef
                                 }
 
                                 for (int i = 0; i < overlap; ++i) {
-                                    float mask = SQR(xsinf((M_PI * i) / (2 * overlap)));
+                                    float mask = SQR(xsinf((rtengine::RT_PI * i) / (2 * overlap)));
 
                                     if (tiletop > 0) {
                                         Vmask[i] = mask;

--- a/rtengine/ciecam02.cc
+++ b/rtengine/ciecam02.cc
@@ -577,7 +577,7 @@ void Ciecam02::Aab_to_rgbfloat( vfloat &r, vfloat &g, vfloat &b, vfloat A, vfloa
 
 void Ciecam02::calculate_ab( double &aa, double &bb, double h, double e, double t, double nbb, double a )
 {
-    double hrad = (h * M_PI) / 180.0;
+    double hrad = (h * rtengine::RT_PI) / 180.0;
     double sinh = sin( hrad );
     double cosh = cos( hrad );
     double x = (a / nbb) + 0.305;
@@ -605,7 +605,7 @@ void Ciecam02::calculate_ab( double &aa, double &bb, double h, double e, double 
 }
 void Ciecam02::calculate_abfloat( float &aa, float &bb, float h, float e, float t, float nbb, float a )
 {
-    float2 sincosval = xsincosf((h * M_PI) / 180.0f);
+    float2 sincosval = xsincosf((h * rtengine::RT_PI) / 180.0f);
     float sinh = sincosval.x;
     float cosh = sincosval.y;
     float x = (a / nbb) + 0.305f;
@@ -643,7 +643,7 @@ void Ciecam02::calculate_abfloat( float &aa, float &bb, float h, float e, float 
 #ifdef __SSE2__
 void Ciecam02::calculate_abfloat( vfloat &aa, vfloat &bb, vfloat h, vfloat e, vfloat t, vfloat nbb, vfloat a )
 {
-    vfloat2 sincosval = xsincosf((h * F2V(M_PI)) / F2V(180.0f));
+    vfloat2 sincosval = xsincosf((h * F2V(rtengine::RT_PI)) / F2V(180.0f));
     vfloat sinh = sincosval.x;
     vfloat cosh = sincosval.y;
     vfloat x = (a / nbb) + F2V(0.305f);
@@ -794,7 +794,7 @@ void Ciecam02::xyz2jchqms_ciecam02( double &J, double &C, double &h, double &Q, 
     ca = rpa - ((12.0 * gpa) / 11.0) + (bpa / 11.0);
     cb = (1.0 / 9.0) * (rpa + gpa - (2.0 * bpa));
 
-    myh = (180.0 / M_PI) * atan2( cb, ca );
+    myh = (180.0 / rtengine::RT_PI) * atan2( cb, ca );
 
     if ( myh < 0.0 ) {
         myh += 360.0;
@@ -831,7 +831,7 @@ void Ciecam02::xyz2jchqms_ciecam02( double &J, double &C, double &h, double &Q, 
 
     J = 100.0 * pow( a / aw, c * cz );
 
-    e = ((12500.0 / 13.0) * nc * ncb) * (cos( ((myh * M_PI) / 180.0) + 2.0 ) + 3.8);
+    e = ((12500.0 / 13.0) * nc * ncb) * (cos( ((myh * rtengine::RT_PI) / 180.0) + 2.0 ) + 3.8);
     t = (e * sqrt( (ca * ca) + (cb * cb) )) / (rpa + gpa + ((21.0 / 20.0) * bpa));
 
     C = pow( t, 0.9 ) * sqrt( J / 100.0 )
@@ -881,7 +881,7 @@ void Ciecam02::xyz2jchqms_ciecam02float( float &J, float &C, float &h, float &Q,
     myh = xatan2f( cb, ca );
 
     if ( myh < 0.0f ) {
-        myh += (2.f * M_PI);
+        myh += (2.f * rtengine::RT_PI);
     }
 
     a = ((2.0f * rpa) + gpa + (0.05f * bpa) - 0.305f) * nbb;
@@ -902,7 +902,7 @@ void Ciecam02::xyz2jchqms_ciecam02float( float &J, float &C, float &h, float &Q,
     M = C * pfl;
     Q = (Q == 0.f ? 0.0001f : Q); // avoid division by zero
     s = 100.0f * sqrtf( M / Q );
-    h = (myh * 180.f) / (float)M_PI;
+    h = (myh * 180.f) / (float)rtengine::RT_PI;
 }
 #ifdef __SSE2__
 void Ciecam02::xyz2jchqms_ciecam02float( vfloat &J, vfloat &C, vfloat &h, vfloat &Q, vfloat &M, vfloat &s, vfloat aw, vfloat fl, vfloat wh,
@@ -938,7 +938,7 @@ void Ciecam02::xyz2jchqms_ciecam02float( vfloat &J, vfloat &C, vfloat &h, vfloat
     cb = F2V(0.11111111f) * (rpa + gpa - (bpa + bpa));
 
     vfloat myh = xatan2f( cb, ca );
-    vfloat temp = F2V(M_PI);
+    vfloat temp = F2V(rtengine::RT_PI);
     temp += temp;
     temp += myh;
     myh = vself(vmaskf_lt(myh, ZEROV), temp, myh);
@@ -958,7 +958,7 @@ void Ciecam02::xyz2jchqms_ciecam02float( vfloat &J, vfloat &C, vfloat &h, vfloat
     M = C * pfl;
     Q = _mm_max_ps(Q, F2V(0.0001f)); // avoid division by zero
     s = F2V(100.0f) * _mm_sqrt_ps( M / Q );
-    h = (myh * F2V(180.f)) / F2V(M_PI);
+    h = (myh * F2V(180.f)) / F2V(rtengine::RT_PI);
 }
 #endif
 
@@ -1000,7 +1000,7 @@ void Ciecam02::xyz2jch_ciecam02float( float &J, float &C, float &h, float aw, fl
     myh = xatan2f( cb, ca );
 
     if ( myh < 0.0f ) {
-        myh += (2.f * M_PI);
+        myh += (2.f * rtengine::RT_PI);
     }
 
     a = ((2.0f * rpa) + gpa + (0.05f * bpa) - 0.305f) * nbb;
@@ -1017,7 +1017,7 @@ void Ciecam02::xyz2jch_ciecam02float( float &J, float &C, float &h, float aw, fl
     C = pow_F( t, 0.9f ) * J * pow1;
 
     J *= J * 100.0f;
-    h = (myh * 180.f) / (float)M_PI;
+    h = (myh * 180.f) / (float)rtengine::RT_PI;
 }
 
 
@@ -1034,7 +1034,7 @@ void Ciecam02::jch2xyz_ciecam02( double &x, double &y, double &z, double J, doub
     double e, t;
     gamu = 1;
     xyz_to_cat02( rw, gw, bw, xw, yw, zw, gamu );
-    e = ((12500.0 / 13.0) * nc * ncb) * (cos( ((h * M_PI) / 180.0) + 2.0 ) + 3.8);
+    e = ((12500.0 / 13.0) * nc * ncb) * (cos( ((h * rtengine::RT_PI) / 180.0) + 2.0 ) + 3.8);
     a = pow( J / 100.0, 1.0 / (c * cz) ) * aw;
     t = pow( C / (sqrt( J / 100) * pow( 1.64 - pow( 0.29, n ), 0.73 )), 10.0 / 9.0 );
 
@@ -1068,7 +1068,7 @@ void Ciecam02::jch2xyz_ciecam02float( float &x, float &y, float &z, float J, flo
     float e, t;
     gamu = 1;
     xyz_to_cat02float( rw, gw, bw, xw, yw, zw, gamu );
-    e = ((961.53846f) * nc * ncb) * (xcosf( ((h * M_PI) / 180.0f) + 2.0f ) + 3.8f);
+    e = ((961.53846f) * nc * ncb) * (xcosf( ((h * rtengine::RT_PI) / 180.0f) + 2.0f ) + 3.8f);
     a = pow_F( J / 100.0f, 1.0f / (c * cz) ) * aw;
     t = pow_F( 10.f * C / (sqrtf( J ) * pow1), 1.1111111f );
 
@@ -1102,7 +1102,7 @@ void Ciecam02::jch2xyz_ciecam02float( vfloat &x, vfloat &y, vfloat &z, vfloat J,
     vfloat a, ca, cb;
     vfloat e, t;
     xyz_to_cat02float( rw, gw, bw, xw, yw, zw);
-    e = ((F2V(961.53846f)) * nc * ncb) * (xcosf( ((h * F2V(M_PI)) / F2V(180.0f)) + F2V(2.0f) ) + F2V(3.8f));
+    e = ((F2V(961.53846f)) * nc * ncb) * (xcosf( ((h * F2V(rtengine::RT_PI)) / F2V(180.0f)) + F2V(2.0f) ) + F2V(3.8f));
     a = pow_F( J / F2V(100.0f), reccmcz ) * aw;
     t = pow_F( F2V(10.f) * C / (_mm_sqrt_ps( J ) * pow1), F2V(1.1111111f) );
 

--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -780,18 +780,18 @@ public:
     static inline T interpolatePolarHue_PI (T h1, T h2, U balance) {
         if (h1==h2)
             return h1;
-        if ((h1 > h2) && (h1-h2 > T(M_PI))){
-            h1 -= T(2*M_PI);
+        if ((h1 > h2) && (h1-h2 > T(rtengine::RT_PI))){
+            h1 -= T(2*rtengine::RT_PI);
             T value = h1 + T(balance) * (h2-h1);
-            if (value < T(-M_PI))
-                value += T(2*M_PI);
+            if (value < T(-rtengine::RT_PI))
+                value += T(2*rtengine::RT_PI);
             return value;
         }
-        else if (h2-h1 > T(M_PI)) {
-            h2 -= T(2*M_PI);
+        else if (h2-h1 > T(rtengine::RT_PI)) {
+            h2 -= T(2*rtengine::RT_PI);
             T value = h1 + T(balance) * (h2-h1);
             if (value < T(0))
-                value += T(2*M_PI);
+                value += T(2*rtengine::RT_PI);
             return value;
         }
         else
@@ -821,21 +821,21 @@ public:
             f = 1.f - f;
         }
 
-        if (d < T(-M_PI) || d < T(0) || d > T(M_PI)) { //there was an inversion here !! d > T(M_PI)
-            h1 += T(2 * M_PI);
+        if (d < T(-rtengine::RT_PI) || d < T(0) || d > T(rtengine::RT_PI)) { //there was an inversion here !! d > T(rtengine::RT_PI)
+            h1 += T(2 * rtengine::RT_PI);
             h = h1 + f * (h2 - h1);
-            h = std::fmod(h, 2 * M_PI);
+            h = std::fmod(h, 2 * rtengine::RT_PI);
         } else {
             h = h1 + f * d;
         }
 
         // not strictly necessary..but in case of
-        if(h < T(-M_PI)) {
-            h = T(2 * M_PI) - h;
+        if(h < T(-rtengine::RT_PI)) {
+            h = T(2 * rtengine::RT_PI) - h;
         }
 
-        if(h > T(M_PI)) {
-            h = h - T(2 * M_PI);
+        if(h > T(rtengine::RT_PI)) {
+            h = h - T(2 * rtengine::RT_PI);
         }
 
         return h;
@@ -864,7 +864,7 @@ public:
             f = 1.f - f;
         }
 
-        if (d < T(0) || d < T(0.5) || d > T(1.)) { //there was an inversion here !! d > T(M_PI)
+        if (d < T(0) || d < T(0.5) || d > T(1.)) { //there was an inversion here !! d > T(rtengine::RT_PI)
             h1 += T(1.);
             h = h1 + f * (h2 - h1);
             h = std::fmod(h, 1.);

--- a/rtengine/coord.cc
+++ b/rtengine/coord.cc
@@ -27,7 +27,7 @@ namespace rtengine
 Coord& Coord::operator= (const PolarCoord& other)
 {
     const auto radius = other.radius;
-    const auto angle = other.angle / 180.0 * M_PI;
+    const auto angle = other.angle / 180.0 * rtengine::RT_PI;
 
     x = radius * std::cos (angle);
     y = radius * std::sin (angle);
@@ -41,7 +41,7 @@ PolarCoord& PolarCoord::operator= (const Coord& other)
     const double y = other.y;
 
     radius = rtengine::norm2 (x, y);
-    angle = std::atan2 (y, x) * 180.0 / M_PI;
+    angle = std::atan2 (y, x) * 180.0 / rtengine::RT_PI;
 
     return *this;
 }

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -53,6 +53,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <strings.h>
 #include <sys/types.h>
 
 #if defined(DJGPP) || defined(__MINGW32__)
@@ -325,7 +326,7 @@ void CLASS read_shorts (ushort *pixel, int count)
 {
   if (fread (pixel, 2, count, ifp) < count) derror();
   if ((order == 0x4949) == (ntohs(0x1234) == 0x1234))
-	  swab ((char*)pixel, (char*)pixel, count*2);
+	  rtengine::swab ((char*)pixel, (char*)pixel, count*2);
 }
 
 void CLASS cubic_spline (const int *x_, const int *y_, const int len)
@@ -1046,7 +1047,7 @@ void CLASS ljpeg_idct (struct jhead *jh)
     47,55,62,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63 };
 
   if (!cs[0])
-    FORC(106) cs[c] = cos((c & 31)*M_PI/16)/2;
+    FORC(106) cs[c] = cos((c & 31)*rtengine::RT_PI/16)/2;
   memset (work, 0, sizeof work);
   work[0][0][0] = jh->vpred[0] += ljpeg_diff (jh->huff[0]) * jh->quant[0];
   for (i=1; i < 64; i++ ) {
@@ -1058,8 +1059,8 @@ void CLASS ljpeg_idct (struct jhead *jh)
       coef -= (1 << len) - 1;
     ((float *)work)[zigzag[i]] = coef * jh->quant[i];
   }
-  FORC(8) work[0][0][c] *= M_SQRT1_2;
-  FORC(8) work[0][c][0] *= M_SQRT1_2;
+  FORC(8) work[0][0][c] *= rtengine::RT_SQRT1_2;
+  FORC(8) work[0][c][0] *= rtengine::RT_SQRT1_2;
   for (i=0; i < 8; i++)
     for (j=0; j < 8; j++)
       FORC(8) work[1][i][j] += work[0][i][c] * cs[(j*2+1)*c];
@@ -2613,7 +2614,7 @@ fill_input_buffer (j_decompress_ptr cinfo)
   size_t nbytes;
 
   nbytes = fread (jpeg_buffer, 1, 4096, ifp);
-  swab ((char*)jpeg_buffer, (char*)jpeg_buffer, nbytes);
+  rtengine::swab ((char*)jpeg_buffer, (char*)jpeg_buffer, nbytes);
   cinfo->src->next_input_byte = jpeg_buffer;
   cinfo->src->bytes_in_buffer = nbytes;
   return TRUE;
@@ -3626,7 +3627,7 @@ short * CLASS foveon_make_curve (double max, double mul, double filt)
   double x;
 
   if (!filt) filt = 0.8;
-  size = 4*M_PI*max / filt;
+  size = 4*rtengine::RT_PI*max / filt;
   if (size == UINT_MAX) size--;
   curve = (short *) calloc (size+1, sizeof *curve);
   merror (curve, "foveon_make_curve()");

--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -16,9 +16,11 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <strings.h>
+#include <glib/gstdio.h>
+
 #include "imagedata.h"
 #include "iptcpairs.h"
-#include <glib/gstdio.h>
 
 using namespace rtengine;
 

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -895,7 +895,7 @@ int ImageIO::loadPPMFromMemory(const char* buffer, int width, int height, bool s
         char swapped[line_length];
 
         for ( int row = 0; row < height; ++row ) {
-            ::swab(((char*)buffer) + (row * line_length), swapped, line_length);
+            ::rtengine::swab(((char*)buffer) + (row * line_length), swapped, line_length);
             setScanline(row, (unsigned char*)&swapped[0], bps);
         }
     } else {

--- a/rtengine/ipresize.cc
+++ b/rtengine/ipresize.cc
@@ -37,7 +37,7 @@ static inline float Lanc(float x, float a)
     } else if (x * x > a * a) {
         return 0.0f;
     } else {
-        x = static_cast<float>(M_PI) * x;
+        x = static_cast<float>(rtengine::RT_PI) * x;
         return a * xsinf(x) * xsinf(x / a) / (x * x);
     }
 }

--- a/rtengine/iptransform.cc
+++ b/rtengine/iptransform.cc
@@ -90,7 +90,6 @@ namespace rtengine
 #undef CLIPTOC
 
 #define CLIPTOC(a,b,c,d) ((a)>=(b)?((a)<=(c)?(a):(d=true,(c))):(d=true,(b)))
-#define RT_PI 3.141592653589
 
 bool ImProcFunctions::transCoord (int W, int H, const std::vector<Coord2D> &src, std::vector<Coord2D> &red,  std::vector<Coord2D> &green, std::vector<Coord2D> &blue, double ascaleDef,
                                   const LCPMapper *pLCPMap)
@@ -122,19 +121,19 @@ bool ImProcFunctions::transCoord (int W, int H, const std::vector<Coord2D> &src,
     double distAmount = params->distortion.amount;
 
     // auxiliary variables for rotation
-    double cost = cos(params->rotate.degree * RT_PI / 180.0);
-    double sint = sin(params->rotate.degree * RT_PI / 180.0);
+    double cost = cos(params->rotate.degree * rtengine::RT_PI / 180.0);
+    double sint = sin(params->rotate.degree * rtengine::RT_PI / 180.0);
 
     // auxiliary variables for vertical perspective correction
     double vpdeg = params->perspective.vertical / 100.0 * 45.0;
-    double vpalpha = (90.0 - vpdeg) / 180.0 * RT_PI;
-    double vpteta  = fabs(vpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-oW * oW * tan(vpalpha) * tan(vpalpha) + (vpdeg > 0 ? 1.0 : -1.0) * oW * tan(vpalpha) * sqrt(16 * maxRadius * maxRadius + oW * oW * tan(vpalpha) * tan(vpalpha))) / (maxRadius * maxRadius * 8)));
+    double vpalpha = (90.0 - vpdeg) / 180.0 * rtengine::RT_PI;
+    double vpteta  = fabs(vpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-oW * oW * tan(vpalpha) * tan(vpalpha) + (vpdeg > 0 ? 1.0 : -1.0) * oW * tan(vpalpha) * sqrt(16 * maxRadius * maxRadius + oW * oW * tan(vpalpha) * tan(vpalpha))) / (maxRadius * maxRadius * 8)));
     double vpcospt = (vpdeg >= 0 ? 1.0 : -1.0) * cos (vpteta), vptanpt = tan (vpteta);
 
     // auxiliary variables for horizontal perspective correction
     double hpdeg = params->perspective.horizontal / 100.0 * 45.0;
-    double hpalpha = (90.0 - hpdeg) / 180.0 * RT_PI;
-    double hpteta  = fabs(hpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-oH * oH * tan(hpalpha) * tan(hpalpha) + (hpdeg > 0 ? 1.0 : -1.0) * oH * tan(hpalpha) * sqrt(16 * maxRadius * maxRadius + oH * oH * tan(hpalpha) * tan(hpalpha))) / (maxRadius * maxRadius * 8)));
+    double hpalpha = (90.0 - hpdeg) / 180.0 * rtengine::RT_PI;
+    double hpteta  = fabs(hpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-oH * oH * tan(hpalpha) * tan(hpalpha) + (hpdeg > 0 ? 1.0 : -1.0) * oH * tan(hpalpha) * sqrt(16 * maxRadius * maxRadius + oH * oH * tan(hpalpha) * tan(hpalpha))) / (maxRadius * maxRadius * 8)));
     double hpcospt = (hpdeg >= 0 ? 1.0 : -1.0) * cos (hpteta), hptanpt = tan (hpteta);
 
     double ascale = ascaleDef > 0 ? ascaleDef : (params->commonTrans.autofill ? getTransformAutoFill (oW, oH, pLCPMap) : 1.0);
@@ -351,14 +350,14 @@ static void calcGradientParams(int oW, int oH, const GradientParams& gradient, s
     double gradient_span = gradient.feather / 100.0;
     double gradient_center_x = gradient.centerX / 200.0 + 0.5;
     double gradient_center_y = gradient.centerY / 200.0 + 0.5;
-    double gradient_angle = gradient.degree / 180.0 * M_PI;
+    double gradient_angle = gradient.degree / 180.0 * rtengine::RT_PI;
     //fprintf(stderr, "%f %f %f %f %f %d %d\n", gradient_stops, gradient_span, gradient_center_x, gradient_center_y, gradient_angle, w, h);
 
-    // make 0.0 <= gradient_angle < 2 * M_PI
-    gradient_angle = fmod(gradient_angle, 2 * M_PI);
+    // make 0.0 <= gradient_angle < 2 * rtengine::RT_PI
+    gradient_angle = fmod(gradient_angle, 2 * rtengine::RT_PI);
 
     if (gradient_angle < 0.0) {
-        gradient_angle += 2.0 * M_PI;
+        gradient_angle += 2.0 * rtengine::RT_PI;
     }
 
     gp.bright_top = false;
@@ -372,24 +371,24 @@ static void calcGradientParams(int oW, int oH, const GradientParams& gradient, s
         // (actually we could transpose only for 90 degrees, but this way we avoid
         // division with extremely small numbers
         gp.transpose = true;
-        gradient_angle += 0.5 * M_PI;
+        gradient_angle += 0.5 * rtengine::RT_PI;
         cosgrad = cos(gradient_angle);
         double gxc = gradient_center_x;
         gradient_center_x = 1.0 - gradient_center_y;
         gradient_center_y = gxc;
     }
 
-    gradient_angle = fmod(gradient_angle, 2 * M_PI);
+    gradient_angle = fmod(gradient_angle, 2 * rtengine::RT_PI);
 
-    if (gradient_angle > 0.5 * M_PI && gradient_angle < M_PI) {
-        gradient_angle += M_PI;
+    if (gradient_angle > 0.5 * rtengine::RT_PI && gradient_angle < rtengine::RT_PI) {
+        gradient_angle += rtengine::RT_PI;
         gp.bright_top = true;
-    } else if (gradient_angle >= M_PI && gradient_angle < 1.5 * M_PI) {
-        gradient_angle -= M_PI;
+    } else if (gradient_angle >= rtengine::RT_PI && gradient_angle < 1.5 * rtengine::RT_PI) {
+        gradient_angle -= rtengine::RT_PI;
         gp.bright_top = true;
     }
 
-    if (fabs(gradient_angle) < 0.001 || fabs(gradient_angle - 2 * M_PI) < 0.001) {
+    if (fabs(gradient_angle) < 0.001 || fabs(gradient_angle - 2 * rtengine::RT_PI) < 0.001) {
         gradient_angle = 0;
         gp.angle_is_zero = true;
     }
@@ -444,7 +443,7 @@ static float calcGradientFactor(const struct grad_params& gp, int x, int y)
                 val = 1.f - val;
             }
 
-            val *= M_PIf_2;
+            val *= rtengine::RT_PI_F_2;
 
             if (gp.scale < 1.f) {
                 val = pow3(xsinf(val));
@@ -468,7 +467,7 @@ static float calcGradientFactor(const struct grad_params& gp, int x, int y)
 
             val = gp.bright_top ? 1.f - val : val;
 
-            val *= M_PIf_2;
+            val *= rtengine::RT_PI_F_2;
 
             if (gp.scale < 1.f) {
                 val = pow3(xsinf(val));
@@ -623,7 +622,7 @@ static float calcPCVignetteFactor(const struct pcv_params& pcv, int x, int y)
     if (dist >= dist_oe) {
         val = pcv.scale;
     } else {
-        val = M_PIf_2 * (dist - dist_ie) / (dist_oe - dist_ie);
+        val = rtengine::RT_PI_F_2 * (dist - dist_ie) / (dist_oe - dist_ie);
 
         if (pcv.scale < 1.f) {
             val = pow4(xcosf(val));
@@ -746,20 +745,20 @@ void ImProcFunctions::transformHighQuality (Imagefloat* original, Imagefloat* tr
     double distAmount = params->distortion.amount;
 
     // auxiliary variables for rotation
-    double cost = cos(params->rotate.degree * RT_PI / 180.0);
-    double sint = sin(params->rotate.degree * RT_PI / 180.0);
+    double cost = cos(params->rotate.degree * rtengine::RT_PI / 180.0);
+    double sint = sin(params->rotate.degree * rtengine::RT_PI / 180.0);
 
     // auxiliary variables for vertical perspective correction
     double vpdeg = params->perspective.vertical / 100.0 * 45.0;
-    double vpalpha = (90.0 - vpdeg) / 180.0 * RT_PI;
-    double vpteta  = fabs(vpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-SQR(oW * tan(vpalpha)) + (vpdeg > 0 ? 1.0 : -1.0) *
+    double vpalpha = (90.0 - vpdeg) / 180.0 * rtengine::RT_PI;
+    double vpteta  = fabs(vpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-SQR(oW * tan(vpalpha)) + (vpdeg > 0 ? 1.0 : -1.0) *
                      oW * tan(vpalpha) * sqrt(SQR(4 * maxRadius) + SQR(oW * tan(vpalpha)))) / (SQR(maxRadius) * 8)));
     double vpcospt = (vpdeg >= 0 ? 1.0 : -1.0) * cos (vpteta), vptanpt = tan (vpteta);
 
     // auxiliary variables for horizontal perspective correction
     double hpdeg = params->perspective.horizontal / 100.0 * 45.0;
-    double hpalpha = (90.0 - hpdeg) / 180.0 * RT_PI;
-    double hpteta  = fabs(hpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-SQR(oH * tan(hpalpha)) + (hpdeg > 0 ? 1.0 : -1.0) *
+    double hpalpha = (90.0 - hpdeg) / 180.0 * rtengine::RT_PI;
+    double hpteta  = fabs(hpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-SQR(oH * tan(hpalpha)) + (hpdeg > 0 ? 1.0 : -1.0) *
                      oH * tan(hpalpha) * sqrt(SQR(4 * maxRadius) + SQR(oH * tan(hpalpha)))) / (SQR(maxRadius) * 8)));
     double hpcospt = (hpdeg >= 0 ? 1.0 : -1.0) * cos (hpteta), hptanpt = tan (hpteta);
 
@@ -934,19 +933,19 @@ void ImProcFunctions::transformPreview (Imagefloat* original, Imagefloat* transf
     double distAmount = params->distortion.amount;
 
     // auxiliary variables for rotation
-    double cost = cos(params->rotate.degree * RT_PI / 180.0);
-    double sint = sin(params->rotate.degree * RT_PI / 180.0);
+    double cost = cos(params->rotate.degree * rtengine::RT_PI / 180.0);
+    double sint = sin(params->rotate.degree * rtengine::RT_PI / 180.0);
 
     // auxiliary variables for vertical perspective correction
     double vpdeg = params->perspective.vertical / 100.0 * 45.0;
-    double vpalpha = (90 - vpdeg) / 180.0 * RT_PI;
-    double vpteta  = fabs(vpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-oW * oW * tan(vpalpha) * tan(vpalpha) + (vpdeg > 0 ? 1.0 : -1.0) * oW * tan(vpalpha) * sqrt(16 * maxRadius * maxRadius + oW * oW * tan(vpalpha) * tan(vpalpha))) / (maxRadius * maxRadius * 8)));
+    double vpalpha = (90 - vpdeg) / 180.0 * rtengine::RT_PI;
+    double vpteta  = fabs(vpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((vpdeg > 0 ? 1.0 : -1.0) * sqrt((-oW * oW * tan(vpalpha) * tan(vpalpha) + (vpdeg > 0 ? 1.0 : -1.0) * oW * tan(vpalpha) * sqrt(16 * maxRadius * maxRadius + oW * oW * tan(vpalpha) * tan(vpalpha))) / (maxRadius * maxRadius * 8)));
     double vpcospt = (vpdeg >= 0 ? 1.0 : -1.0) * cos (vpteta), vptanpt = tan (vpteta);
 
     // auxiliary variables for horizontal perspective correction
     double hpdeg = params->perspective.horizontal / 100.0 * 45.0;
-    double hpalpha = (90 - hpdeg) / 180.0 * RT_PI;
-    double hpteta  = fabs(hpalpha - RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-oH * oH * tan(hpalpha) * tan(hpalpha) + (hpdeg > 0 ? 1.0 : -1.0) * oH * tan(hpalpha) * sqrt(16 * maxRadius * maxRadius + oH * oH * tan(hpalpha) * tan(hpalpha))) / (maxRadius * maxRadius * 8)));
+    double hpalpha = (90 - hpdeg) / 180.0 * rtengine::RT_PI;
+    double hpteta  = fabs(hpalpha - rtengine::RT_PI / 2) < 3e-4 ? 0.0 : acos ((hpdeg > 0 ? 1.0 : -1.0) * sqrt((-oH * oH * tan(hpalpha) * tan(hpalpha) + (hpdeg > 0 ? 1.0 : -1.0) * oH * tan(hpalpha) * sqrt(16 * maxRadius * maxRadius + oH * oH * tan(hpalpha) * tan(hpalpha))) / (maxRadius * maxRadius * 8)));
     double hpcospt = (hpdeg >= 0 ? 1.0 : -1.0) * cos (hpteta), hptanpt = tan (hpteta);
 
     double ascale = params->commonTrans.autofill ? getTransformAutoFill (oW, oH, pLCPMap) : 1.0;

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -1058,7 +1058,7 @@ SSEFUNCTION void ImProcFunctions::ip_wavelet(LabImage * lab, LabImage * dst, int
                         }
 
                         for (int i = 0; i < overlap; i++) {
-                            float mask = SQR(sin((M_PI * i) / (2 * overlap)));
+                            float mask = SQR(sin((rtengine::RT_PI * i) / (2 * overlap)));
 
                             if (tiletop > 0) {
                                 Vmask[i] = mask;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -4,15 +4,17 @@
  *  Created on: 20/nov/2010
  */
 
-#include "rawimage.h"
-#include "settings.h"
-#include "camconst.h"
-#include "utils.h"
+#include <strings.h>
 #ifdef WIN32
 #include <winsock2.h>
 #else
 #include <netinet/in.h>
 #endif
+
+#include "rawimage.h"
+#include "settings.h"
+#include "camconst.h"
+#include "utils.h"
 
 namespace rtengine
 {

--- a/rtengine/rt_math.h
+++ b/rtengine/rt_math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <limits>
 #include <cmath>
 #include <cstdint>
 
@@ -10,6 +11,21 @@ namespace rtengine
 constexpr int MAXVAL = 0xffff;
 constexpr float MAXVALF = static_cast<float>(MAXVAL);  // float version of MAXVAL
 constexpr double MAXVALD = static_cast<double>(MAXVAL); // double version of MAXVAL
+
+constexpr double RT_PI = 3.14159265358979323846; // pi
+constexpr double RT_PI_2 = 1.57079632679489661923; // pi/2
+constexpr double RT_1_PI = 0.31830988618379067154; // 1/pi
+constexpr double RT_2_PI = 0.63661977236758134308; // 2/pi
+constexpr double RT_SQRT1_2 = 0.70710678118654752440; // 1/sqrt(2)
+
+constexpr double RT_INFINITY = std::numeric_limits<double>::infinity();
+constexpr double RT_NAN = std::numeric_limits<double>::quiet_NaN();
+
+constexpr float RT_PI_F = RT_PI;
+constexpr float RT_PI_F_2 = RT_PI_2;
+
+constexpr float RT_INFINITY_F = std::numeric_limits<float>::infinity();
+constexpr float RT_NAN_F = std::numeric_limits<float>::quiet_NaN();
 
 template <typename _Tp>
 inline _Tp SQR (_Tp x)

--- a/rtengine/sleef.c
+++ b/rtengine/sleef.c
@@ -12,7 +12,8 @@
 
 #include <assert.h>
 #include <stdint.h>
-#include <math.h>
+//#include <math.h>
+#include "rt_math.h"
 //#include <bits/nan.h>
 //#include <bits/inf.h>
 
@@ -56,9 +57,9 @@ __inline double mla(double x, double y, double z) { return x * y + z; }
 __inline double xrint(double x) { return x < 0 ? (int)(x - 0.5) : (int)(x + 0.5); }
 
 __inline int xisnan(double x) { return x != x; }
-__inline int xisinf(double x) { return x == INFINITY || x == -INFINITY; }
-__inline int xisminf(double x) { return x == -INFINITY; }
-__inline int xispinf(double x) { return x == INFINITY; }
+__inline int xisinf(double x) { return x == rtengine::RT_INFINITY || x == -rtengine::RT_INFINITY; }
+__inline int xisminf(double x) { return x == -rtengine::RT_INFINITY; }
+__inline int xispinf(double x) { return x == rtengine::RT_INFINITY; }
 
 __inline double ldexpk(double x, int q) {
   double u;
@@ -87,7 +88,7 @@ __inline int ilogbp1(double d) {
 __inline int xilogb(double d) {
   int e = ilogbp1(xfabs(d)) - 1;
   e = d == 0 ? (-2147483647 - 1) : e;
-  e = d == INFINITY || d == -INFINITY ? 2147483647 : e;
+  e = d == rtengine::RT_INFINITY || d == -rtengine::RT_INFINITY ? 2147483647 : e;
   return e;
 }
 
@@ -309,7 +310,7 @@ __inline double atan2k(double y, double x) {
   u = u * t + (-0.333333333333311110369124);
 
   t = u * t * s + s;
-  t = q * (M_PI/2) + t;
+  t = q * (rtengine::RT_PI_2) + t;
 
   return t;
 }
@@ -318,11 +319,11 @@ __inline double xatan2(double y, double x) {
   double r = atan2k(xfabs(y), x);
 
   r = mulsign(r, x);
-  if (xisinf(x) || x == 0) r = M_PI/2 - (xisinf(x) ? (sign(x) * (M_PI  /2)) : 0);
-  if (xisinf(y)          ) r = M_PI/2 - (xisinf(x) ? (sign(x) * (M_PI*1/4)) : 0);
-  if (             y == 0) r = (sign(x) == -1 ? M_PI : 0);
+  if (xisinf(x) || x == 0) r = rtengine::RT_PI_2 - (xisinf(x) ? (sign(x) * (rtengine::RT_PI_2)) : 0);
+  if (xisinf(y)          ) r = rtengine::RT_PI_2 - (xisinf(x) ? (sign(x) * (rtengine::RT_PI*1/4)) : 0);
+  if (             y == 0) r = (sign(x) == -1 ? rtengine::RT_PI : 0);
 
-  return xisnan(x) || xisnan(y) ? NAN : mulsign(r, y);
+  return xisnan(x) || xisnan(y) ? rtengine::RT_NAN : mulsign(r, y);
 }
 
 __inline double xasin(double d) {
@@ -330,7 +331,7 @@ __inline double xasin(double d) {
 }
 
 __inline double xacos(double d) {
-  return mulsign(atan2k(sqrt((1+d)*(1-d)), xfabs(d)), d) + (d < 0 ? M_PI : 0);
+  return mulsign(atan2k(sqrt((1+d)*(1-d)), xfabs(d)), d) + (d < 0 ? rtengine::RT_PI : 0);
 }
 
 __inline double xatan(double s) {
@@ -374,7 +375,7 @@ __inline double xsin(double d) {
   int q;
   double u, s;
 
-  q = (int)xrint(d * M_1_PI);
+  q = (int)xrint(d * rtengine::RT_1_PI);
 
   d = mla(q, -PI4_A*4, d);
   d = mla(q, -PI4_B*4, d);
@@ -403,7 +404,7 @@ __inline double xcos(double d) {
   int q;
   double u, s;
 
-  q = 1 + 2*(int)xrint(d * M_1_PI - 0.5);
+  q = 1 + 2*(int)xrint(d * rtengine::RT_1_PI - 0.5);
 
   d = mla(q, -PI4_A*2, d);
   d = mla(q, -PI4_B*2, d);
@@ -433,7 +434,7 @@ __inline double2 xsincos(double d) {
   double u, s, t;
   double2 r;
 
-  q = (int)xrint(d * (2 * M_1_PI));
+  q = (int)xrint(d * (2 * rtengine::RT_1_PI));
 
   s = d;
 
@@ -469,7 +470,7 @@ __inline double2 xsincos(double d) {
   if ((q & 2) != 0) { r.x = -r.x; }
   if (((q+1) & 2) != 0) { r.y = -r.y; }
 
-  if (xisinf(d)) { r.x = r.y = NAN; }
+  if (xisinf(d)) { r.x = r.y = rtengine::RT_NAN; }
 
   return r;
 }
@@ -478,7 +479,7 @@ __inline double xtan(double d) {
   int q;
   double u, s, x;
 
-  q = (int)xrint(d * (2 * M_1_PI));
+  q = (int)xrint(d * (2 * rtengine::RT_1_PI));
 
   x = mla(q, -PI4_A*2, d);
   x = mla(q, -PI4_B*2, x);
@@ -508,7 +509,7 @@ __inline double xtan(double d) {
 
   if ((q & 1) != 0) u = 1.0 / u;
 
-  if (xisinf(d)) u = NAN;
+  if (xisinf(d)) u = rtengine::RT_NAN;
 
   return u;
 }
@@ -534,9 +535,9 @@ __inline double xlog(double d) {
 
   x = x * t + 0.693147180559945286226764 * e;
 
-  if (xisinf(d)) x = INFINITY;
-  if (d < 0) x = NAN;
-  if (d == 0) x = -INFINITY;
+  if (xisinf(d)) x = rtengine::RT_INFINITY;
+  if (d < 0) x = rtengine::RT_NAN;
+  if (d == 0) x = -rtengine::RT_INFINITY;
 
   return x;
 }
@@ -625,13 +626,13 @@ __inline double xpow(double x, double y) {
 
   double result = expk(mul_ds(logk(xfabs(x)), y));
 
-  result = xisnan(result) ? INFINITY : result;
-  result *=  (x >= 0 ? 1 : (!yisint ? NAN : (yisodd ? -1 : 1)));
+  result = xisnan(result) ? rtengine::RT_INFINITY : result;
+  result *=  (x >= 0 ? 1 : (!yisint ? rtengine::RT_NAN : (yisodd ? -1 : 1)));
 
   double efx = mulsign(xfabs(x) - 1, y);
-  if (xisinf(y)) result = efx < 0 ? 0.0 : (efx == 0 ? 1.0 : INFINITY);
-  if (xisinf(x) || x == 0) result = (yisodd ? sign(x) : 1) * ((x == 0 ? -y : y) < 0 ? 0 : INFINITY);
-  if (xisnan(x) || xisnan(y)) result = NAN;
+  if (xisinf(y)) result = efx < 0 ? 0.0 : (efx == 0 ? 1.0 : rtengine::RT_INFINITY);
+  if (xisinf(x) || x == 0) result = (yisodd ? sign(x) : 1) * ((x == 0 ? -y : y) < 0 ? 0 : rtengine::RT_INFINITY);
+  if (xisnan(x) || xisnan(y)) result = rtengine::RT_NAN;
   if (y == 0 || x == 1) result = 1;
 
   return result;
@@ -670,9 +671,9 @@ __inline double xsinh(double x) {
   d = add2_dd(d, div_dd(dd(-1, 0), d));
   y = (d.x + d.y) * 0.5;
 
-  y = xisinf(x) || xisnan(y) ? INFINITY : y;
+  y = xisinf(x) || xisnan(y) ? rtengine::RT_INFINITY : y;
   y = mulsign(y, x);
-  y = xisnan(x) ? NAN : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -682,8 +683,8 @@ __inline double xcosh(double x) {
   d = add2_dd(d, div_dd(dd(1, 0), d));
   double y = (d.x + d.y) * 0.5;
 
-  y = xisinf(x) || xisnan(y) ? INFINITY : y;
-  y = xisnan(x) ? NAN : y;
+  y = xisinf(x) || xisnan(y) ? rtengine::RT_INFINITY : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -697,7 +698,7 @@ __inline double xtanh(double x) {
 
   y = xisinf(x) || xisnan(y) ? 1.0 : y;
   y = mulsign(y, x);
-  y = xisnan(x) ? NAN : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -732,9 +733,9 @@ __inline double xasinh(double x) {
   double2 d = logk2(add2_ds(sqrt_d(add2_ds(mul_ss(y, y),  1)), y));
   y = d.x + d.y;
 
-  y = xisinf(x) || xisnan(y) ? INFINITY : y;
+  y = xisinf(x) || xisnan(y) ? rtengine::RT_INFINITY : y;
   y = mulsign(y, x);
-  y = xisnan(x) ? NAN : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -743,10 +744,10 @@ __inline double xacosh(double x) {
   double2 d = logk2(add2_ds(sqrt_d(add2_ds(mul_ss(x, x), -1)), x));
   double y = d.x + d.y;
 
-  y = xisinf(x) || xisnan(y) ? INFINITY : y;
+  y = xisinf(x) || xisnan(y) ? rtengine::RT_INFINITY : y;
   y = x == 1.0 ? 0.0 : y;
-  y = x < 1.0 ? NAN : y;
-  y = xisnan(x) ? NAN : y;
+  y = x < 1.0 ? rtengine::RT_NAN : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -754,11 +755,11 @@ __inline double xacosh(double x) {
 __inline double xatanh(double x) {
   double y = xfabs(x);
   double2 d = logk2(div_dd(add2_ss(1, y), add2_ss(1, -y)));
-  y = y > 1.0 ? NAN : (y == 1.0 ? INFINITY : (d.x + d.y) * 0.5);
+  y = y > 1.0 ? rtengine::RT_NAN : (y == 1.0 ? rtengine::RT_INFINITY : (d.x + d.y) * 0.5);
 
-  y = xisinf(x) || xisnan(y) ? NAN : y;
+  y = xisinf(x) || xisnan(y) ? rtengine::RT_NAN : y;
   y = mulsign(y, x);
-  y = xisnan(x) ? NAN : y;
+  y = xisnan(x) ? rtengine::RT_NAN : y;
 
   return y;
 }
@@ -809,7 +810,7 @@ __inline double xsqrt(double d) { // max error : 0.5 ulp
   // You can change xfma to fma if fma is correctly implemented
   x = xfma(d * x, d * x, -d) * (x * -0.5) + d * x;
 
-  return d == INFINITY ? INFINITY : x * q;
+  return d == rtengine::RT_INFINITY ? rtengine::RT_INFINITY : x * q;
 }
 
 __inline double xcbrt(double d) { // max error : 2 ulps
@@ -842,14 +843,14 @@ __inline double xcbrt(double d) { // max error : 2 ulps
 
 __inline double xexp2(double a) {
   double u = expk(mul_ds(dd(0.69314718055994528623, 2.3190468138462995584e-17), a));
-  if (xispinf(a)) u = INFINITY;
+  if (xispinf(a)) u = rtengine::RT_INFINITY;
   if (xisminf(a)) u = 0;
   return u;
 }
 
 __inline double xexp10(double a) {
   double u = expk(mul_ds(dd(2.3025850929940459011, -2.1707562233822493508e-16), a));
-  if (xispinf(a)) u = INFINITY;
+  if (xispinf(a)) u = rtengine::RT_INFINITY;
   if (xisminf(a)) u = 0;
   return u;
 }
@@ -857,7 +858,7 @@ __inline double xexp10(double a) {
 __inline double xexpm1(double a) {
   double2 d = add2_ds(expk2(dd(a, 0)), -1.0);
   double x = d.x + d.y;
-  if (xispinf(a)) x = INFINITY;
+  if (xispinf(a)) x = rtengine::RT_INFINITY;
   if (xisminf(a)) x = -1;
   return x;
 }
@@ -866,9 +867,9 @@ __inline double xlog10(double a) {
   double2 d = mul_dd(logk(a), dd(0.43429448190325176116, 6.6494347733425473126e-17));
   double x = d.x + d.y;
 
-  if (xisinf(a)) x = INFINITY;
-  if (a < 0) x = NAN;
-  if (a == 0) x = -INFINITY;
+  if (xisinf(a)) x = rtengine::RT_INFINITY;
+  if (a < 0) x = rtengine::RT_NAN;
+  if (a == 0) x = -rtengine::RT_INFINITY;
 
   return x;
 }
@@ -877,9 +878,9 @@ __inline double xlog1p(double a) {
   double2 d = logk2(add2_ss(a, 1));
   double x = d.x + d.y;
 
-  if (xisinf(a)) x = INFINITY;
-  if (a < -1) x = NAN;
-  if (a == -1) x = -INFINITY;
+  if (xisinf(a)) x = rtengine::RT_INFINITY;
+  if (a < -1) x = rtengine::RT_NAN;
+  if (a == -1) x = -rtengine::RT_INFINITY;
 
   return x;
 }
@@ -895,11 +896,6 @@ __inline double xlog1p(double a) {
 #define L2Lf 1.428606765330187045e-06f
 
 #define R_LN2f 1.442695040888963407359924681001892137426645954152985934135449406931f
-#define M_PIf ((float)M_PI)
-#define M_PIf_2 ((float)M_PI_2)
-
-#define INFINITYf ((float)INFINITY)
-#define NANf ((float)NAN)
 
 __inline int32_t floatToRawIntBits(float d) {
   union {
@@ -932,9 +928,9 @@ __inline float mlaf(float x, float y, float z) { return x * y + z; }
 __inline float xrintf(float x) { return x < 0 ? (int)(x - 0.5f) : (int)(x + 0.5f); }
 
 __inline int xisnanf(float x) { return x != x; }
-__inline int xisinff(float x) { return x == INFINITYf || x == -INFINITYf; }
-__inline int xisminff(float x) { return x == -INFINITYf; }
-__inline int xispinff(float x) { return x == INFINITYf; }
+__inline int xisinff(float x) { return x == rtengine::RT_INFINITY_F || x == -rtengine::RT_INFINITY_F; }
+__inline int xisminff(float x) { return x == -rtengine::RT_INFINITY_F; }
+__inline int xispinff(float x) { return x == rtengine::RT_INFINITY_F; }
 
 __inline int ilogbp1f(float d) {
   int m = d < 5.421010862427522E-20f;
@@ -988,7 +984,7 @@ __inline float xsinf(float d) {
   int q;
   float u, s;
 
-  q = (int)xrintf(d * (float)M_1_PI);
+  q = (int)xrintf(d * (float)rtengine::RT_1_PI);
 
   d = mlaf(q, -PI4_Af*4, d);
   d = mlaf(q, -PI4_Bf*4, d);
@@ -1013,7 +1009,7 @@ __inline float xcosf(float d) {
   int q;
   float u, s;
 
-  q = 1 + 2*(int)xrintf(d * (float)M_1_PI - 0.5f);
+  q = 1 + 2*(int)xrintf(d * (float)rtengine::RT_1_PI - 0.5f);
 
   d = mlaf(q, -PI4_Af*2, d);
   d = mlaf(q, -PI4_Bf*2, d);
@@ -1039,7 +1035,7 @@ __inline float2 xsincosf(float d) {
   float u, s, t;
   float2 r;
 
-  q = (int)rint(d * ((float)(2 * M_1_PI)));
+  q = (int)rint(d * ((float)(2 * rtengine::RT_1_PI)));
 
   s = d;
 
@@ -1071,7 +1067,7 @@ __inline float2 xsincosf(float d) {
   if ((q & 2) != 0) { r.x = -r.x; }
   if (((q+1) & 2) != 0) { r.y = -r.y; }
 
-  if (xisinff(d)) { r.x = r.y = NANf; }
+  if (xisinff(d)) { r.x = r.y = rtengine::RT_NAN_F; }
 
   return r;
 }
@@ -1080,7 +1076,7 @@ __inline float xtanf(float d) {
   int q;
   float u, s, x;
 
-  q = (int)xrintf(d * (float)(2 * M_1_PI));
+  q = (int)xrintf(d * (float)(2 * rtengine::RT_1_PI));
 
   x = d;
 
@@ -1104,7 +1100,7 @@ __inline float xtanf(float d) {
 
   if ((q & 1) != 0) u = 1.0f / u;
 
-  if (xisinff(d)) u = NANf;
+  if (xisinff(d)) u = rtengine::RT_NAN_F;
 
   return u;
 }
@@ -1156,18 +1152,18 @@ __inline float atan2kf(float y, float x) {
 
   t = u * t;
   t = mlaf(t,s,s);
-  return mlaf(q,(float)(M_PIf_2),t);
+  return mlaf(q,(float)(rtengine::RT_PI_F_2),t);
 }
 
 __inline float xatan2f(float y, float x) {
   float r = atan2kf(xfabsf(y), x);
 
   r = mulsignf(r, x);
-  if (xisinff(x) || x == 0) r = M_PIf/2 - (xisinff(x) ? (signf(x) * (float)(M_PIf*.5f)) : 0);
-  if (xisinff(y)          ) r = M_PIf/2 - (xisinff(x) ? (signf(x) * (float)(M_PIf*.25f)) : 0);
-  if (              y == 0) r = (signf(x) == -1 ? M_PIf : 0);
+  if (xisinff(x) || x == 0) r = rtengine::RT_PI_F/2 - (xisinff(x) ? (signf(x) * (float)(rtengine::RT_PI_F*.5f)) : 0);
+  if (xisinff(y)          ) r = rtengine::RT_PI_F/2 - (xisinff(x) ? (signf(x) * (float)(rtengine::RT_PI_F*.25f)) : 0);
+  if (              y == 0) r = (signf(x) == -1 ? rtengine::RT_PI_F : 0);
 
-  return xisnanf(x) || xisnanf(y) ? NANf : mulsignf(r, y);
+  return xisnanf(x) || xisnanf(y) ? rtengine::RT_NAN_F : mulsignf(r, y);
 }
 
 __inline float xasinf(float d) {
@@ -1175,7 +1171,7 @@ __inline float xasinf(float d) {
 }
 
 __inline float xacosf(float d) {
-  return mulsignf(atan2kf(sqrtf((1.0f+d)*(1.0f-d)), fabsf(d)), d) + (d < 0 ? (float)M_PI : 0.0f);
+  return mulsignf(atan2kf(sqrtf((1.0f+d)*(1.0f-d)), fabsf(d)), d) + (d < 0 ? (float)rtengine::RT_PI : 0.0f);
 }
 
 __inline float xlogf(float d) {
@@ -1196,9 +1192,9 @@ __inline float xlogf(float d) {
 
   x = x * t + 0.693147180559945286226764f * e;
 
-  if (xisinff(d)) x = INFINITYf;
-  if (d < 0) x = NANf;
-  if (d == 0) x = -INFINITYf;
+  if (xisinff(d)) x = rtengine::RT_INFINITY_F;
+  if (d < 0) x = rtengine::RT_NAN_F;
+  if (d == 0) x = -rtengine::RT_INFINITY_F;
 
   return x;
 }

--- a/rtengine/sleefsseavx.c
+++ b/rtengine/sleefsseavx.c
@@ -12,10 +12,11 @@
 #define SLEEFSSEAVX
 
 #include <assert.h>
-#include <math.h>
+//#include <math.h>
 //#include <bits/nan.h>
 //#include <bits/inf.h>
 //#include "sleefsseavx.h"
+#include "rt_math.h"
 #ifdef __SSE2__
 #include "helpersse2.h"
 
@@ -51,8 +52,8 @@
 #define L2Lf 1.428606765330187045e-06f
 #define R_LN2f 1.442695040888963407359924681001892137426645954152985934135449406931f
 
-#define INFINITYf ((float)INFINITY)
-#define NANf ((float)NAN)
+#define INFINITYf ((float)rtengine::RT_INFINITY)
+#define NANf ((float)rtengine::RT_NAN)
 
 //
 
@@ -259,7 +260,7 @@ static INLINE vdouble xldexp(vdouble x, vint q) { return vldexp(x, q); }
 static INLINE vint xilogb(vdouble d) {
   vdouble e = vcast_vd_vi(vsubi(vilogbp1(vabs(d)), vcast_vi_i(1)));
   e = vsel(vmask_eq(d, vcast_vd_d(0)), vcast_vd_d(-2147483648.0), e);
-  e = vsel(vmask_eq(vabs(d), vcast_vd_d(INFINITY)), vcast_vd_d(2147483647), e);
+  e = vsel(vmask_eq(vabs(d), vcast_vd_d(rtengine::RT_INFINITY)), vcast_vd_d(2147483647), e);
   return vrint_vi_vd(e);
 }
 
@@ -267,7 +268,7 @@ static INLINE vdouble xsin(vdouble d) {
   vint q;
   vdouble u, s;
 
-  q = vrint_vi_vd(vmul(d, vcast_vd_d(M_1_PI)));
+  q = vrint_vi_vd(vmul(d, vcast_vd_d(rtengine::RT_1_PI)));
 
   u = vcast_vd_vi(q);
   d = vadd(d, vmul(u, vcast_vd_d(-PI4_A*4)));
@@ -297,7 +298,7 @@ static INLINE vdouble xcos(vdouble d) {
   vint q;
   vdouble u, s;
 
-  q = vrint_vi_vd(vsub(vmul(d, vcast_vd_d(M_1_PI)), vcast_vd_d(0.5)));
+  q = vrint_vi_vd(vsub(vmul(d, vcast_vd_d(rtengine::RT_1_PI)), vcast_vd_d(0.5)));
   q = vaddi(vaddi(q, q), vcast_vi_i(1));
 
   u = vcast_vd_vi(q);
@@ -330,7 +331,7 @@ static INLINE vdouble2 xsincos(vdouble d) {
   vdouble u, s, t, rx, ry;
   vdouble2 r;
 
-  q = vrint_vi_vd(vmul(d, vcast_vd_d(M_2_PI)));
+  q = vrint_vi_vd(vmul(d, vcast_vd_d(rtengine::RT_2_PI)));
 
   s = d;
 
@@ -374,8 +375,8 @@ static INLINE vdouble2 xsincos(vdouble d) {
   r.y = vreinterpret_vd_vm(vxorm(vandm(m, vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(r.y)));
 
   m = vmask_isinf(d);
-  r.x = vsel(m, vcast_vd_d(NAN), r.x);
-  r.y = vsel(m, vcast_vd_d(NAN), r.y);
+  r.x = vsel(m, vcast_vd_d(rtengine::RT_NAN), r.x);
+  r.y = vsel(m, vcast_vd_d(rtengine::RT_NAN), r.y);
 
   return r;
 }
@@ -385,7 +386,7 @@ static INLINE vdouble xtan(vdouble d) {
   vdouble u, s, x;
   vmask m;
 
-  q = vrint_vi_vd(vmul(d, vcast_vd_d(M_2_PI)));
+  q = vrint_vi_vd(vmul(d, vcast_vd_d(rtengine::RT_2_PI)));
 
   u = vcast_vd_vi(q);
   x = vadd(d, vmul(u, vcast_vd_d(-PI4_A*2)));
@@ -417,7 +418,7 @@ static INLINE vdouble xtan(vdouble d) {
 
   u = vsel(m, vrec(u), u);
 
-  u = vsel(vmask_isinf(d), vcast_vd_d(NAN), u);
+  u = vsel(vmask_isinf(d), vcast_vd_d(rtengine::RT_NAN), u);
 
   return u;
 }
@@ -459,7 +460,7 @@ static INLINE vdouble atan2k(vdouble y, vdouble x) {
   u = vmla(u, t, vcast_vd_d(-0.333333333333311110369124));
 
   t = vadd(s, vmul(s, vmul(t, u)));
-  t = vadd(t, vmul(vcast_vd_vi(q), vcast_vd_d(M_PI/2)));
+  t = vadd(t, vmul(vcast_vd_vi(q), vcast_vd_d(rtengine::RT_PI/2)));
 
   return t;
 }
@@ -468,11 +469,11 @@ static INLINE vdouble xatan2(vdouble y, vdouble x) {
   vdouble r = atan2k(vabs(y), x);
 
   r = vmulsign(r, x);
-  r = vsel(vorm(vmask_isinf(x), vmask_eq(x, vcast_vd_d(0))), vsub(vcast_vd_d(M_PI/2), visinf2(x, vmulsign(vcast_vd_d(M_PI/2), x))), r);
-  r = vsel(vmask_isinf(y), vsub(vcast_vd_d(M_PI/2), visinf2(x, vmulsign(vcast_vd_d(M_PI/4), x))), r);
-  r = vsel(vmask_eq(y, vcast_vd_d(0)), vsel(vmask_eq(vsign(x), vcast_vd_d(-1.0)), vcast_vd_d(M_PI), vcast_vd_d(0)), r);
+  r = vsel(vorm(vmask_isinf(x), vmask_eq(x, vcast_vd_d(0))), vsub(vcast_vd_d(rtengine::RT_PI/2), visinf2(x, vmulsign(vcast_vd_d(rtengine::RT_PI/2), x))), r);
+  r = vsel(vmask_isinf(y), vsub(vcast_vd_d(rtengine::RT_PI/2), visinf2(x, vmulsign(vcast_vd_d(rtengine::RT_PI/4), x))), r);
+  r = vsel(vmask_eq(y, vcast_vd_d(0)), vsel(vmask_eq(vsign(x), vcast_vd_d(-1.0)), vcast_vd_d(rtengine::RT_PI), vcast_vd_d(0)), r);
 
-  return vsel(vorm(vmask_isnan(x), vmask_isnan(y)), vcast_vd_d(NAN), vmulsign(r, y));
+  return vsel(vorm(vmask_isnan(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_NAN), vmulsign(r, y));
 }
 
 static INLINE vdouble xasin(vdouble d) {
@@ -481,7 +482,7 @@ static INLINE vdouble xasin(vdouble d) {
   y = vsub(vcast_vd_d(1), d);
   x = vmul(x, y);
   x = vsqrt(x);
-  x = vsel(vmask_isnan(x), vcast_vd_d(NAN), atan2k(vabs(d), x));
+  x = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), atan2k(vabs(d), x));
   return vmulsign(x, d);
 }
 
@@ -492,7 +493,7 @@ static INLINE vdouble xacos(vdouble d) {
   x = vmul(x, y);
   x = vsqrt(x);
   x = vmulsign(atan2k(x, vabs(d)), d);
-  y = (vdouble)vandm(vmask_lt(d, vcast_vd_d(0)), (vmask)vcast_vd_d(M_PI));
+  y = (vdouble)vandm(vmask_lt(d, vcast_vd_d(0)), (vmask)vcast_vd_d(rtengine::RT_PI));
   x = vadd(x, y);
   return x;
 }
@@ -531,7 +532,7 @@ static INLINE vdouble xatan(vdouble s) {
 
   t = vadd(s, vmul(s, vmul(t, u)));
 
-  t = vsel(vmaski_eq(vandi(q, vcast_vi_i(1)), vcast_vi_i(1)), vsub(vcast_vd_d(M_PI/2), t), t);
+  t = vsel(vmaski_eq(vandi(q, vcast_vi_i(1)), vcast_vi_i(1)), vsub(vcast_vd_d(rtengine::RT_PI/2), t), t);
   t = vsel(vmaski_eq(vandi(q, vcast_vi_i(2)), vcast_vi_i(2)), vneg(t), t);
 
   return t;
@@ -559,9 +560,9 @@ static INLINE vdouble xlog(vdouble d) {
 
   x = vadd(vmul(x, t), vmul(vcast_vd_d(0.693147180559945286226764), vcast_vd_vi(e)));
 
-  x = vsel(vmask_ispinf(d), vcast_vd_d(INFINITY), x);
-  x = vsel(vmask_gt(vcast_vd_d(0), d), vcast_vd_d(NAN), x);
-  x = vsel(vmask_eq(d, vcast_vd_d(0)), vcast_vd_d(-INFINITY), x);
+  x = vsel(vmask_ispinf(d), vcast_vd_d(rtengine::RT_INFINITY), x);
+  x = vsel(vmask_gt(vcast_vd_d(0), d), vcast_vd_d(rtengine::RT_NAN), x);
+  x = vsel(vmask_eq(d, vcast_vd_d(0)), vcast_vd_d(-rtengine::RT_INFINITY), x);
 
   return x;
 }
@@ -659,7 +660,7 @@ static INLINE vdouble xpow(vdouble x, vdouble y) {
 
   vdouble result = expk(mul_ds(logk(vabs(x)), y));
 
-  //result = vsel(vmask_isnan(result), vcast_vd_d(INFINITY), result);
+  //result = vsel(vmask_isnan(result), vcast_vd_d(rtengine::RT_INFINITY), result);
 
   result = vmul(result,
 		vsel(vmask_gt(x, vcast_vd_d(0)),
@@ -668,7 +669,7 @@ static INLINE vdouble xpow(vdouble x, vdouble y) {
 			  vsel(yisodd,
 			       vcast_vd_d(-1),
 			       vcast_vd_d(1)),
-			  vcast_vd_d(NAN))));
+			  vcast_vd_d(rtengine::RT_NAN))));
 
   vdouble efx = vreinterpret_vd_vm(vxorm(vreinterpret_vm_vd(vsub(vabs(x), vcast_vd_d(1))), vsignbit(y)));
 
@@ -677,17 +678,17 @@ static INLINE vdouble xpow(vdouble x, vdouble y) {
 		     vcast_vd_d(0),
 		     vsel(vmask_eq(efx, vcast_vd_d(0)),
 			  vcast_vd_d(1.0),
-			  vcast_vd_d(INFINITY))),
+			  vcast_vd_d(rtengine::RT_INFINITY))),
 		result);
 
   result = vsel(vorm(vmask_isinf(x), vmask_eq(x, vcast_vd_d(0))),
 		vmul(vsel(yisodd, vsign(x), vcast_vd_d(1)),
 		     vsel(vmask_lt(vsel(vmask_eq(x, vcast_vd_d(0)), vneg(y), y), vcast_vd_d(0)),
 			  vcast_vd_d(0),
-			  vcast_vd_d(INFINITY))),
+			  vcast_vd_d(rtengine::RT_INFINITY))),
 		result);
 
-  result = vsel(vorm(vmask_isnan(x), vmask_isnan(y)), vcast_vd_d(NAN), result);
+  result = vsel(vorm(vmask_isnan(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_NAN), result);
 
   result = vsel(vorm(vmask_eq(y, vcast_vd_d(0)), vmask_eq(x, vcast_vd_d(1))), vcast_vd_d(1), result);
 
@@ -733,9 +734,9 @@ static INLINE vdouble xsinh(vdouble x) {
   d = add2_dd(d, div_dd(dd(vcast_vd_d(-1), vcast_vd_d(0)), d));
   y = vmul(vadd(d.x, d.y), vcast_vd_d(0.5));
 
-  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(INFINITY), y);
+  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_INFINITY), y);
   y = vmulsign(y, x);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -745,8 +746,8 @@ static INLINE vdouble xcosh(vdouble x) {
   d = add2_dd(d, div_dd(dd(vcast_vd_d(1), vcast_vd_d(0)), d));
   vdouble y = vmul(vadd(d.x, d.y), vcast_vd_d(0.5));
 
-  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(INFINITY), y);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_INFINITY), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -760,7 +761,7 @@ static INLINE vdouble xtanh(vdouble x) {
 
   y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(1.0), y);
   y = vmulsign(y, x);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -797,9 +798,9 @@ static INLINE vdouble xasinh(vdouble x) {
   vdouble2 d = logk2(add2_ds(sqrt_d(add2_ds(mul_ss(y, y),  vcast_vd_d(1))), y));
   y = vadd(d.x, d.y);
 
-  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(INFINITY), y);
+  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_INFINITY), y);
   y = vmulsign(y, x);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -808,10 +809,10 @@ static INLINE vdouble xacosh(vdouble x) {
   vdouble2 d = logk2(add2_ds(sqrt_d(add2_ds(mul_ss(x, x), vcast_vd_d(-1))), x));
   vdouble y = vadd(d.x, d.y);
 
-  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(INFINITY), y);
+  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_INFINITY), y);
   y = vsel(vmask_eq(x, vcast_vd_d(1.0)), vcast_vd_d(0.0), y);
-  y = vsel(vmask_lt(x, vcast_vd_d(1.0)), vcast_vd_d(NAN), y);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vmask_lt(x, vcast_vd_d(1.0)), vcast_vd_d(rtengine::RT_NAN), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -819,11 +820,11 @@ static INLINE vdouble xacosh(vdouble x) {
 static INLINE vdouble xatanh(vdouble x) {
   vdouble y = vabs(x);
   vdouble2 d = logk2(div_dd(add2_ss(vcast_vd_d(1), y), add2_ss(vcast_vd_d(1), -y)));
-  y = vsel(vmask_gt(y, vcast_vd_d(1.0)), vcast_vd_d(NAN), vsel(vmask_eq(y, vcast_vd_d(1.0)), vcast_vd_d(INFINITY), vmul(vadd(d.x, d.y), vcast_vd_d(0.5))));
+  y = vsel(vmask_gt(y, vcast_vd_d(1.0)), vcast_vd_d(rtengine::RT_NAN), vsel(vmask_eq(y, vcast_vd_d(1.0)), vcast_vd_d(rtengine::RT_INFINITY), vmul(vadd(d.x, d.y), vcast_vd_d(0.5))));
 
-  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(NAN), y);
+  y = vsel(vorm(vmask_isinf(x), vmask_isnan(y)), vcast_vd_d(rtengine::RT_NAN), y);
   y = vmulsign(y, x);
-  y = vsel(vmask_isnan(x), vcast_vd_d(NAN), y);
+  y = vsel(vmask_isnan(x), vcast_vd_d(rtengine::RT_NAN), y);
 
   return y;
 }
@@ -864,14 +865,14 @@ static INLINE vdouble xcbrt(vdouble d) {
 
 static INLINE vdouble xexp2(vdouble a) {
   vdouble u = expk(mul_ds(dd(vcast_vd_d(0.69314718055994528623), vcast_vd_d(2.3190468138462995584e-17)), a));
-  u = vsel(vmask_ispinf(a), vcast_vd_d(INFINITY), u);
+  u = vsel(vmask_ispinf(a), vcast_vd_d(rtengine::RT_INFINITY), u);
   u = vsel(vmask_isminf(a), vcast_vd_d(0), u);
   return u;
 }
 
 static INLINE vdouble xexp10(vdouble a) {
   vdouble u = expk(mul_ds(dd(vcast_vd_d(2.3025850929940459011), vcast_vd_d(-2.1707562233822493508e-16)), a));
-  u = vsel(vmask_ispinf(a), vcast_vd_d(INFINITY), u);
+  u = vsel(vmask_ispinf(a), vcast_vd_d(rtengine::RT_INFINITY), u);
   u = vsel(vmask_isminf(a), vcast_vd_d(0), u);
   return u;
 }
@@ -879,7 +880,7 @@ static INLINE vdouble xexp10(vdouble a) {
 static INLINE vdouble xexpm1(vdouble a) {
   vdouble2 d = add2_ds(expk2(dd(a, vcast_vd_d(0))), vcast_vd_d(-1.0));
   vdouble x = d.x + d.y;
-  x = vsel(vmask_ispinf(a), vcast_vd_d(INFINITY), x);
+  x = vsel(vmask_ispinf(a), vcast_vd_d(rtengine::RT_INFINITY), x);
   x = vsel(vmask_isminf(a), vcast_vd_d(-1), x);
   return x;
 }
@@ -888,9 +889,9 @@ static INLINE vdouble xlog10(vdouble a) {
   vdouble2 d = mul_dd(logk(a), dd(vcast_vd_d(0.43429448190325176116), vcast_vd_d(6.6494347733425473126e-17)));
   vdouble x = d.x + d.y;
 
-  x = vsel(vmask_ispinf(a), vcast_vd_d(INFINITY), x);
-  x = vsel(vmask_gt(vcast_vd_d(0), a), vcast_vd_d(NAN), x);
-  x = vsel(vmask_eq(a, vcast_vd_d(0)), vcast_vd_d(-INFINITY), x);
+  x = vsel(vmask_ispinf(a), vcast_vd_d(rtengine::RT_INFINITY), x);
+  x = vsel(vmask_gt(vcast_vd_d(0), a), vcast_vd_d(rtengine::RT_NAN), x);
+  x = vsel(vmask_eq(a, vcast_vd_d(0)), vcast_vd_d(-rtengine::RT_INFINITY), x);
 
   return x;
 }
@@ -899,9 +900,9 @@ static INLINE vdouble xlog1p(vdouble a) {
   vdouble2 d = logk2(add2_ss(a, vcast_vd_d(1)));
   vdouble x = d.x + d.y;
 
-  x = vsel(vmask_ispinf(a), vcast_vd_d(INFINITY), x);
-  x = vsel(vmask_gt(vcast_vd_d(-1), a), vcast_vd_d(NAN), x);
-  x = vsel(vmask_eq(a, vcast_vd_d(-1)), vcast_vd_d(-INFINITY), x);
+  x = vsel(vmask_ispinf(a), vcast_vd_d(rtengine::RT_INFINITY), x);
+  x = vsel(vmask_gt(vcast_vd_d(-1), a), vcast_vd_d(rtengine::RT_NAN), x);
+  x = vsel(vmask_eq(a, vcast_vd_d(-1)), vcast_vd_d(-rtengine::RT_INFINITY), x);
 
   return x;
 }
@@ -1005,7 +1006,7 @@ static INLINE vfloat xsinf(vfloat d) {
   vint2 q;
   vfloat u, s;
 
-  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)M_1_PI)));
+  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)rtengine::RT_1_PI)));
 
   u = vcast_vf_vi2(q);
   d = vmlaf(u, vcast_vf_f(-PI4_Af*4), d);
@@ -1031,7 +1032,7 @@ static INLINE vfloat xcosf(vfloat d) {
   vint2 q;
   vfloat u, s;
 
-  q = vrint_vi2_vf(vsubf(vmulf(d, vcast_vf_f((float)M_1_PI)), vcast_vf_f(0.5f)));
+  q = vrint_vi2_vf(vsubf(vmulf(d, vcast_vf_f((float)rtengine::RT_1_PI)), vcast_vf_f(0.5f)));
   q = vaddi2(vaddi2(q, q), vcast_vi2_i(1));
 
   u = vcast_vf_vi2(q);
@@ -1060,7 +1061,7 @@ static INLINE vfloat2 xsincosf(vfloat d) {
   vfloat u, s, t, rx, ry;
   vfloat2 r;
 
-  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)M_2_PI)));
+  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)rtengine::RT_2_PI)));
 
   s = d;
 
@@ -1100,8 +1101,8 @@ static INLINE vfloat2 xsincosf(vfloat d) {
   r.y = vreinterpret_vf_vm(vxorm(vandm(m, vreinterpret_vm_vf(vcast_vf_f(-0.0))), vreinterpret_vm_vf(r.y)));
 
   m = vmaskf_isinf(d);
-  r.x = vself(m, vcast_vf_f(NAN), r.x);
-  r.y = vself(m, vcast_vf_f(NAN), r.y);
+  r.x = vself(m, vcast_vf_f(rtengine::RT_NAN), r.x);
+  r.y = vself(m, vcast_vf_f(rtengine::RT_NAN), r.y);
 
   return r;
 }
@@ -1111,7 +1112,7 @@ static INLINE vfloat xtanf(vfloat d) {
   vmask m;
   vfloat u, s, x;
 
-  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)(2 * M_1_PI))));
+  q = vrint_vi2_vf(vmulf(d, vcast_vf_f((float)(2 * rtengine::RT_1_PI))));
 
   x = d;
 
@@ -1165,7 +1166,7 @@ static INLINE vfloat xatanf(vfloat s) {
 
   t = vaddf(s, vmulf(s, vmulf(t, u)));
 
-  t = vself(vmaski2_eq(vandi2(q, vcast_vi2_i(1)), vcast_vi2_i(1)), vsubf(vcast_vf_f((float)(M_PI/2)), t), t);
+  t = vself(vmaski2_eq(vandi2(q, vcast_vi2_i(1)), vcast_vi2_i(1)), vsubf(vcast_vf_f((float)(rtengine::RT_PI/2)), t), t);
   t = vself(vmaski2_eq(vandi2(q, vcast_vi2_i(2)), vcast_vi2_i(2)), vnegf(t), t);
 
   return t;
@@ -1197,7 +1198,7 @@ static INLINE vfloat atan2kf(vfloat y, vfloat x) {
   u = vmlaf(u, t, vcast_vf_f(-0.333331018686294555664062f));
 
   t = vaddf(s, vmulf(s, vmulf(t, u)));
-  t = vaddf(t, vmulf(vcast_vf_vi2(q), vcast_vf_f((float)(M_PI/2))));
+  t = vaddf(t, vmulf(vcast_vf_vi2(q), vcast_vf_f((float)(rtengine::RT_PI/2))));
 
   return t;
 }
@@ -1206,9 +1207,9 @@ static INLINE vfloat xatan2f(vfloat y, vfloat x) {
   vfloat r = atan2kf(vabsf(y), x);
 
   r = vmulsignf(r, x);
-  r = vself(vorm(vmaskf_isinf(x), vmaskf_eq(x, vcast_vf_f(0.0f))), vsubf(vcast_vf_f((float)(M_PI/2)), visinf2f(x, vmulsignf(vcast_vf_f((float)(M_PI/2)), x))), r);
-  r = vself(vmaskf_isinf(y), vsubf(vcast_vf_f((float)(M_PI/2)), visinf2f(x, vmulsignf(vcast_vf_f((float)(M_PI/4)), x))), r);
-  r = vself(vmaskf_eq(y, vcast_vf_f(0.0f)), vselfzero(vmaskf_eq(vsignf(x), vcast_vf_f(-1.0f)), vcast_vf_f((float)M_PI)), r);
+  r = vself(vorm(vmaskf_isinf(x), vmaskf_eq(x, vcast_vf_f(0.0f))), vsubf(vcast_vf_f((float)(rtengine::RT_PI/2)), visinf2f(x, vmulsignf(vcast_vf_f((float)(rtengine::RT_PI/2)), x))), r);
+  r = vself(vmaskf_isinf(y), vsubf(vcast_vf_f((float)(rtengine::RT_PI/2)), visinf2f(x, vmulsignf(vcast_vf_f((float)(rtengine::RT_PI/4)), x))), r);
+  r = vself(vmaskf_eq(y, vcast_vf_f(0.0f)), vselfzero(vmaskf_eq(vsignf(x), vcast_vf_f(-1.0f)), vcast_vf_f((float)rtengine::RT_PI)), r);
 
   return vself(vorm(vmaskf_isnan(x), vmaskf_isnan(y)), vcast_vf_f(NANf), vmulsignf(r, y));
 }
@@ -1230,7 +1231,7 @@ static INLINE vfloat xacosf(vfloat d) {
   x = vmulf(x, y);
   x = vsqrtf(x);
   x = vmulsignf(atan2kf(x, vabsf(d)), d);
-  y = (vfloat)vandm(vmaskf_lt(d, vcast_vf_f(0.0f)), (vmask)vcast_vf_f((float)M_PI));
+  y = (vfloat)vandm(vmaskf_lt(d, vcast_vf_f(0.0f)), (vmask)vcast_vf_f((float)rtengine::RT_PI));
   x = vaddf(x, y);
   return x;
 }

--- a/rtengine/utils.cc
+++ b/rtengine/utils.cc
@@ -245,4 +245,19 @@ bool hasPngExtension(const Glib::ustring& filename)
    return getFileExtension(filename) == "png";
 }
 
+void swab(const void* from, void* to, ssize_t n)
+{
+    // Adapted from glibc
+    const char* char_from = static_cast<const char*>(from);
+    char* char_to = static_cast<char*>(to);
+
+    n &= ~static_cast<ssize_t>(1);
+
+    while (n > 1) {
+        const char b0 = char_from[--n], b1 = char_from[--n];
+        char_to[n] = b0;
+        char_to[n + 1] = b1;
+    }
+}
+
 }

--- a/rtengine/utils.h
+++ b/rtengine/utils.h
@@ -52,4 +52,6 @@ bool hasTiffExtension(const Glib::ustring& filename);
 // Return true if file has .png extension (ignoring case)
 bool hasPngExtension(const Glib::ustring& filename);
 
+void swab(const void* from, void* to, ssize_t n);
+
 }

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -2293,7 +2293,7 @@ void CropWindow::drawStraightenGuide (Cairo::RefPtr<Cairo::Context> cr)
     if (action_x != press_x || action_y != press_y) {
         double arg = (press_x - action_x) / sqrt(double((press_x - action_x) * (press_x - action_x) + (press_y - action_y) * (press_y - action_y)));
         double sol1, sol2;
-        double pi = M_PI;
+        double pi = rtengine::RT_PI;
 
         if (press_y > action_y) {
             sol1 = acos(arg) * 180 / pi;

--- a/rtgui/edit.cc
+++ b/rtgui/edit.cc
@@ -191,7 +191,7 @@ void Circle::drawOuterGeometry(Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer
             center_ += objectBuffer->getDataProvider()->posScreen + objectBuffer->getDataProvider()->deltaScreen;
         }
 
-        cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*M_PI);
+        cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*rtengine::RT_PI);
         cr->stroke();
     }
 }
@@ -225,7 +225,7 @@ void Circle::drawInnerGeometry(Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer
         }
 
         if (filled && state != INSENSITIVE) {
-            cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*M_PI);
+            cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*rtengine::RT_PI);
 
             if (innerLineWidth > 0.) {
                 cr->fill_preserve();
@@ -234,7 +234,7 @@ void Circle::drawInnerGeometry(Cairo::RefPtr<Cairo::Context> &cr, ObjectMOBuffer
                 cr->fill();
             }
         } else if (innerLineWidth > 0.) {
-            cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*M_PI);
+            cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0., 2.*rtengine::RT_PI);
 
             if (state == INSENSITIVE) {
                 std::valarray<double> ds(1);
@@ -274,7 +274,7 @@ void Circle::drawToMOChannel (Cairo::RefPtr<Cairo::Context> &cr, unsigned short 
         } else {
             cr->set_source_rgba (0., 0., 0., (id + 1) / 65535.);
         }
-        cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0, 2.*M_PI);
+        cr->arc(center_.x + 0.5, center_.y + 0.5, radius_, 0, 2.*rtengine::RT_PI);
 
         if (filled) {
             if (innerLineWidth > 0.) {

--- a/rtgui/filebrowserentry.cc
+++ b/rtgui/filebrowserentry.cc
@@ -714,7 +714,7 @@ void FileBrowserEntry::drawStraightenGuide (Cairo::RefPtr<Cairo::Context> cr)
     if (action_x != press_x || action_y != press_y) {
         double arg = (press_x - action_x) / sqrt(double((press_x - action_x) * (press_x - action_x) + (press_y - action_y) * (press_y - action_y)));
         double sol1, sol2;
-        double pi = M_PI;
+        double pi = rtengine::RT_PI;
 
         if (press_y > action_y) {
             sol1 = acos(arg) * 180 / pi;

--- a/rtgui/gradient.cc
+++ b/rtgui/gradient.cc
@@ -424,7 +424,7 @@ bool Gradient::button1Pressed(const int modifierKey)
 
             draggedPoint = currPos - centerPos;
             // compute the projected value of the dragged point
-            draggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*M_PI);
+            draggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*rtengine::RT_PI);
 
             if (lastObject == 3) {
                 draggedFeatherOffset = -draggedFeatherOffset;
@@ -526,7 +526,7 @@ bool Gradient::drag1(const int modifierKey)
         currPos.y = p;
 
         draggedPoint = currPos - centerPos;
-        double currDraggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*M_PI);
+        double currDraggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*rtengine::RT_PI);
 
         if (lastObject == 2)
             // Dragging the upper feather bar

--- a/rtgui/lockablecolorpicker.cc
+++ b/rtgui/lockablecolorpicker.cc
@@ -124,13 +124,13 @@ void LockableColorPicker::updateBackBuffer ()
         // black background of the whole color picker
         bbcr->set_line_width (0.);
         bbcr->set_source_rgba (0., 0., 0., opacity);
-        bbcr->arc_negative (center, center, center, 0., (double)M_PI);
+        bbcr->arc_negative (center, center, center, 0., (double)rtengine::RT_PI);
         bbcr->line_to (0, 2. * center + textHeight);
-        bbcr->arc_negative (2. * textPadding, 2. * center + textHeight, 2. * textPadding, (double)M_PI, (double)M_PI / 2.);
+        bbcr->arc_negative (2. * textPadding, 2. * center + textHeight, 2. * textPadding, (double)rtengine::RT_PI, (double)rtengine::RT_PI / 2.);
         bbcr->line_to (textWidth, 2. * center + textHeight + 2. * textPadding);
-        bbcr->arc_negative (textWidth, 2. * center + textHeight, 2. * textPadding, (double)M_PI / 2., 0.);
+        bbcr->arc_negative (textWidth, 2. * center + textHeight, 2. * textPadding, (double)rtengine::RT_PI / 2., 0.);
         bbcr->line_to (textWidth + 2. * textPadding, 2. * center + 2. * textPadding);
-        bbcr->arc_negative (textWidth, 2. * center + 2. * textPadding, 2. * textPadding, 0., (double)M_PI * 1.5);
+        bbcr->arc_negative (textWidth, 2. * center + 2. * textPadding, 2. * textPadding, 0., (double)rtengine::RT_PI * 1.5);
         bbcr->line_to (2. * center, 2. * center);
         bbcr->close_path();
         bbcr->set_line_join (Cairo::LINE_JOIN_BEVEL);
@@ -138,13 +138,13 @@ void LockableColorPicker::updateBackBuffer ()
         bbcr->fill ();
 
         // light grey circle around the color mark
-        bbcr->arc (center, center, center - circlePadding / 2., 0., 2. * (double)M_PI);
+        bbcr->arc (center, center, center - circlePadding / 2., 0., 2. * (double)rtengine::RT_PI);
         bbcr->set_source_rgb (0.75, 0.75, 0.75);
         bbcr->set_line_width (circlePadding - 2.);
         bbcr->stroke ();
 
         // spot disc with picked color
-        bbcr->arc (center, center, center - circlePadding, 0., 2. * (double)M_PI);
+        bbcr->arc (center, center, center - circlePadding, 0., 2. * (double)rtengine::RT_PI);
         bbcr->set_source_rgb (rpreview, gpreview, bpreview);  // <- set the picker color here
         bbcr->set_line_width (0.);
         bbcr->fill();
@@ -223,7 +223,7 @@ void LockableColorPicker::updateBackBuffer ()
         float center = (float)size / 2.f + circlePadding;
 
         // light grey circle around the color mark
-        bbcr->arc (center, center, center - circlePadding / 2., 0., 2. * (double)M_PI);
+        bbcr->arc (center, center, center - circlePadding / 2., 0., 2. * (double)rtengine::RT_PI);
         bbcr->set_source_rgba (0., 0., 0., opacity);
         bbcr->set_line_width(circlePadding);
         bbcr->stroke_preserve();

--- a/rtgui/mydiagonalcurve.cc
+++ b/rtgui/mydiagonalcurve.cc
@@ -479,12 +479,12 @@ void MyDiagonalCurve::draw (int handle)
             double x = double(graphX + 1) + double((graphW - 2) * curve.x.at(i)); // project (curve.x.at(i), 0, 1, graphW);
             double y = double(graphY - 1) - double((graphH - 2) * curve.y.at(i)); // project (curve.y.at(i), 0, 1, graphH);
 
-            cr->arc (x, y, RADIUS + 0.5, 0, 2 * M_PI);
+            cr->arc (x, y, RADIUS + 0.5, 0, 2 * rtengine::RT_PI);
             cr->fill ();
 
             if (i == edited_point) {
                 cr->set_line_width(2.);
-                cr->arc (x, y, RADIUS + 3.5, 0, 2 * M_PI);
+                cr->arc (x, y, RADIUS + 3.5, 0, 2 * rtengine::RT_PI);
                 cr->stroke();
                 cr->set_line_width(1.);
             }

--- a/rtgui/myflatcurve.cc
+++ b/rtgui/myflatcurve.cc
@@ -454,13 +454,13 @@ void MyFlatCurve::draw ()
             double x = double(graphX + 1) + innerW * curve.x.at(i); // project (curve.x.at(i), 0, 1, graphW);
             double y = double(graphY - 1) - innerH * curve.y.at(i); // project (curve.y.at(i), 0, 1, graphH);
 
-            cr->arc (x, y, (double)RADIUS, 0, 2 * M_PI);
+            cr->arc (x, y, (double)RADIUS, 0, 2 * rtengine::RT_PI);
             cr->fill ();
 
             if (i == edited_point) {
                 cr->set_source_rgb (1.0, 0.0, 0.0);
                 cr->set_line_width(2.);
-                cr->arc (x, y, RADIUS + 3.5, 0, 2 * M_PI);
+                cr->arc (x, y, RADIUS + 3.5, 0, 2 * rtengine::RT_PI);
                 cr->stroke();
                 cr->set_line_width(1.);
             }

--- a/rtgui/thumbbrowserentrybase.cc
+++ b/rtgui/thumbbrowserentrybase.cc
@@ -404,10 +404,10 @@ void ThumbBrowserEntryBase::drawFrame (Cairo::RefPtr<Cairo::Context> cr, const G
     if (selected || framed) {
         cr->set_antialias (Cairo::ANTIALIAS_SUBPIXEL);
         cr->move_to (radius, 0);
-        cr->arc (exp_width - 1 - radius, radius, radius, -M_PI / 2, 0);
-        cr->arc (exp_width - 1 - radius, exp_height - 1 - radius, radius, 0, M_PI / 2);
-        cr->arc (radius, exp_height - 1 - radius, radius, M_PI / 2, M_PI);
-        cr->arc (radius, radius, radius, M_PI, -M_PI / 2);
+        cr->arc (exp_width - 1 - radius, radius, radius, -rtengine::RT_PI / 2, 0);
+        cr->arc (exp_width - 1 - radius, exp_height - 1 - radius, radius, 0, rtengine::RT_PI / 2);
+        cr->arc (radius, exp_height - 1 - radius, radius, rtengine::RT_PI / 2, rtengine::RT_PI);
+        cr->arc (radius, radius, radius, rtengine::RT_PI, -rtengine::RT_PI / 2);
         cr->close_path ();
 
         if (selected) {
@@ -424,10 +424,10 @@ void ThumbBrowserEntryBase::drawFrame (Cairo::RefPtr<Cairo::Context> cr, const G
     if (framed) {
         cr->set_antialias (Cairo::ANTIALIAS_SUBPIXEL);
         cr->move_to (+2 + 0.5 + radius, +2 + 0.5);
-        cr->arc (-2 + 0.5 + exp_width - 1 - radius, +2 + 0.5 + radius, radius, -M_PI / 2, 0);
-        cr->arc (-2 + 0.5 + exp_width - 1 - radius, -2 + 0.5 + exp_height - 1 - radius, radius, 0, M_PI / 2);
-        cr->arc (+2 + 0.5 + radius, -2 + exp_height - 1 - radius, radius, M_PI / 2, M_PI);
-        cr->arc (+2 + 0.5 + radius, +2 + radius, radius, M_PI, -M_PI / 2);
+        cr->arc (-2 + 0.5 + exp_width - 1 - radius, +2 + 0.5 + radius, radius, -rtengine::RT_PI / 2, 0);
+        cr->arc (-2 + 0.5 + exp_width - 1 - radius, -2 + 0.5 + exp_height - 1 - radius, radius, 0, rtengine::RT_PI / 2);
+        cr->arc (+2 + 0.5 + radius, -2 + exp_height - 1 - radius, radius, rtengine::RT_PI / 2, rtengine::RT_PI);
+        cr->arc (+2 + 0.5 + radius, +2 + radius, radius, rtengine::RT_PI, -rtengine::RT_PI / 2);
         cr->close_path ();
         cr->set_source_rgb (fg.get_red_p(), fg.get_green_p(), fg.get_blue_p());
         cr->set_line_width (2.0);


### PR DESCRIPTION
I propose changing the default `-std=` compiler flag from the non-standard `gnu++11` to `c++11`. Our code is fully C++11 compliant and that should be reflected in the C++ standard we choose as default.

Furthermore there's an ambiguity as we make people use `-DCMAKE_CXX_FLAGS="-std=c++11"` when this is already handled (differently) in `CMakeLists.txt`. See the [pixls.us](https://discuss.pixls.us/t/rawtherapee-5-and-dcmake-cxx-flags/3145/3) discussion. You also see it in `AboutThisBuild.txt`:

```
Build flags: -std=c++11 -Wno-deprecated-declarations -Wno-unused-result -std=gnu++11 -march=native -Werror=unused-label -fopenmp -Werror=unknown-pragmas -O3 -DNDEBUG
```

This commit changes `-std=gnu++11` to `-std=c++11` and builds fine without `-DCMAKE_CXX_FLAGS="-std=c++11"`.

Best
Flössie