### PR TITLE
Add `IdleRegister` to deal with destruction while idle func is queued

### DIFF
--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -85,6 +85,8 @@ BatchQueue::BatchQueue (FileCatalog* aFileCatalog) : processing(nullptr), fileCa
 
 BatchQueue::~BatchQueue ()
 {
+    idle_register.destroy();
+
     MYWRITERLOCK(l, entryRW);
 
     // The listener merges parameters with old values, so delete afterwards
@@ -937,7 +939,7 @@ void BatchQueue::notifyListener (bool queueEmptied)
         }
         params->queueEmptied = queueEmptied;
         params->queueError = false;
-        add_idle (bqnotifylistenerUI, params);
+        idle_register.add(bqnotifylistenerUI, params);
     }
 }
 
@@ -967,6 +969,6 @@ void BatchQueue::error (Glib::ustring msg)
         params->queueEmptied = false;
         params->queueError = true;
         params->queueErrorMessage = msg;
-        add_idle (bqnotifylistenerUI, params);
+        idle_register.add(bqnotifylistenerUI, params);
     }
 }

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -36,37 +36,12 @@ public:
 };
 
 class FileCatalog;
-class BatchQueue  : public ThumbBrowserBase,
+
+class BatchQueue final :
+    public ThumbBrowserBase,
     public rtengine::BatchProcessingListener,
     public LWButtonListener
 {
-
-protected:
-    int getMaxThumbnailHeight() const;
-    void saveThumbnailHeight (int height);
-    int  getThumbnailHeight ();
-
-    BatchQueueEntry* processing;  // holds the currently processed image
-    FileCatalog* fileCatalog;
-    int sequence; // holds the current sequence index
-
-    Glib::ustring nameTemplate;
-
-    MyImageMenuItem* cancel;
-    MyImageMenuItem* head;
-    MyImageMenuItem* tail;
-    Gtk::MenuItem* selall;
-    Gtk::MenuItem* open;
-    Glib::RefPtr<Gtk::AccelGroup> pmaccelgroup;
-    Gtk::Menu pmenu;
-
-    BatchQueueListener* listener;
-
-    Glib::ustring autoCompleteFileName (const Glib::ustring& fileName, const Glib::ustring& format);
-    Glib::ustring getTempFilenameForParams( const Glib::ustring &filename );
-    bool saveBatchQueue ();
-    void notifyListener (bool queueEmptied);
-
 public:
     explicit BatchQueue (FileCatalog* aFileCatalog);
     ~BatchQueue ();
@@ -106,6 +81,34 @@ public:
 
     static Glib::ustring calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence = 0);
     static int calcMaxThumbnailHeight();
+
+protected:
+    int getMaxThumbnailHeight() const;
+    void saveThumbnailHeight (int height);
+    int  getThumbnailHeight ();
+
+    Glib::ustring autoCompleteFileName (const Glib::ustring& fileName, const Glib::ustring& format);
+    Glib::ustring getTempFilenameForParams( const Glib::ustring &filename );
+    bool saveBatchQueue ();
+    void notifyListener (bool queueEmptied);
+
+    BatchQueueEntry* processing;  // holds the currently processed image
+    FileCatalog* fileCatalog;
+    int sequence; // holds the current sequence index
+
+    Glib::ustring nameTemplate;
+
+    MyImageMenuItem* cancel;
+    MyImageMenuItem* head;
+    MyImageMenuItem* tail;
+    Gtk::MenuItem* selall;
+    Gtk::MenuItem* open;
+    Glib::RefPtr<Gtk::AccelGroup> pmaccelgroup;
+    Gtk::Menu pmenu;
+
+    BatchQueueListener* listener;
+
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/blackwhite.cc
+++ b/rtgui/blackwhite.cc
@@ -364,15 +364,11 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, "blackwhite", M("TP_BWMIX_LAB
 }
 BlackWhite::~BlackWhite ()
 {
+    idle_register.destroy();
+
     delete luminanceCEG;
     delete beforeCurveCEG;
     delete afterCurveCEG;
-}
-
-int BWChangedUI (void* data)
-{
-    (static_cast<BlackWhite*>(data))->BWComputed_ ();
-    return 0;
 }
 
 void BlackWhite::BWChanged  (double redbw, double greenbw, double bluebw)
@@ -380,7 +376,13 @@ void BlackWhite::BWChanged  (double redbw, double greenbw, double bluebw)
     nextredbw = redbw;
     nextgreenbw = greenbw;
     nextbluebw = bluebw;
-    add_idle (BWChangedUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<BlackWhite*>(data)->BWComputed_();
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool BlackWhite::BWComputed_ ()

--- a/rtgui/blackwhite.h
+++ b/rtgui/blackwhite.h
@@ -28,10 +28,64 @@
 #include "mycurve.h"
 #include "colorprovider.h"
 
-class BlackWhite : public ToolParamBlock, public AdjusterListener, public FoldableToolPanel, public rtengine::AutoBWListener, public CurveListener, public ColorProvider
+class BlackWhite final :
+    public ToolParamBlock,
+    public AdjusterListener,
+    public FoldableToolPanel,
+    public rtengine::AutoBWListener,
+    public CurveListener,
+    public ColorProvider
 {
+public:
 
-protected:
+    BlackWhite ();
+    ~BlackWhite ();
+
+    void read            (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
+    void write           (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
+    void setDefaults     (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
+    void setBatchMode    (bool batchMode);
+    void autoOpenCurve   ();
+    void setEditProvider (EditDataProvider *provider);
+
+    void autoch_toggled  ();
+    void neutral_pressed ();
+
+    void updateRGBLabel      ();
+    void adjusterChanged     (Adjuster* a, double newval);
+    void setAdjusterBehavior (bool bwadd, bool bwgadd);
+    void trimValues          (rtengine::procparams::ProcParams* pp);
+    void enabledcc_toggled   ();
+    void enabledChanged      ();
+    void methodChanged       ();
+    void filterChanged       ();
+    void settingChanged      ();
+    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
+    void BWChanged           (double redbw, double greenbw, double bluebw);
+    bool BWComputed_         ();
+    void curveChanged        (CurveEditor* ce);
+    void curveMode1Changed   ();
+    bool curveMode1Changed_  ();
+    void curveMode1Changed2  ();
+    bool curveMode1Changed2_ ();
+    void algoChanged         ();
+
+    Glib::ustring getSettingString ();
+    Glib::ustring getFilterString  ();
+    Glib::ustring getalgoString  ();
+
+private:
+    void showLuminance();
+    void hideLuminance();
+    void showFilter();
+    void hideFilter();
+    void showEnabledCC();
+    void hideEnabledCC();
+    void showMixer(int nChannels, bool RGBIsSensitive = true);
+    void hideMixer();
+    void showGamma();
+    void hideGamma();
+
     FlatCurveEditor*     luminanceCurve;
     Gtk::HSeparator*     luminanceSep;
     CurveEditorGroup*    luminanceCEG;
@@ -85,55 +139,7 @@ protected:
     double nextgreenbw;
     double nextbluebw;
 
-    void showLuminance();
-    void hideLuminance();
-    void showFilter();
-    void hideFilter();
-    void showEnabledCC();
-    void hideEnabledCC();
-    void showMixer(int nChannels, bool RGBIsSensitive = true);
-    void hideMixer();
-    void showGamma();
-    void hideGamma();
-
-public:
-
-    BlackWhite ();
-    ~BlackWhite ();
-
-    void read            (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
-    void write           (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
-    void setDefaults     (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
-    void setBatchMode    (bool batchMode);
-    void autoOpenCurve   ();
-    void setEditProvider (EditDataProvider *provider);
-
-    void autoch_toggled  ();
-    void neutral_pressed ();
-
-    void updateRGBLabel      ();
-    void adjusterChanged     (Adjuster* a, double newval);
-    void setAdjusterBehavior (bool bwadd, bool bwgadd);
-    void trimValues          (rtengine::procparams::ProcParams* pp);
-    void enabledcc_toggled   ();
-    void enabledChanged      ();
-    void methodChanged       ();
-    void filterChanged       ();
-    void settingChanged      ();
-    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
-    void BWChanged           (double redbw, double greenbw, double bluebw);
-    bool BWComputed_         ();
-    void curveChanged        (CurveEditor* ce);
-    void curveMode1Changed   ();
-    bool curveMode1Changed_  ();
-    void curveMode1Changed2  ();
-    bool curveMode1Changed2_ ();
-    void algoChanged         ();
-
-    Glib::ustring getSettingString ();
-    Glib::ustring getFilterString  ();
-    Glib::ustring getalgoString  ();
-
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -19,6 +19,7 @@
 #include "cachemanager.h"
 
 #include <memory>
+#include <iostream>
 
 #include <glib/gstdio.h>
 #include <giomm.h>

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -424,6 +424,8 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel(this, "colorappearance",
 
 ColorAppearance::~ColorAppearance ()
 {
+    idle_register.destroy();
+
     delete curveEditorG;
     delete curveEditorG2;
     delete curveEditorG3;
@@ -1002,15 +1004,17 @@ void ColorAppearance::setDefaults (const ProcParams* defParams, const ParamsEdit
 
     }
 }
-int autoCamChangedUI (void* data)
-{
-    (static_cast<ColorAppearance*>(data))->autoCamComputed_ ();
-    return 0;
-}
+
 void ColorAppearance::autoCamChanged (double ccam)
 {
     nextCcam = ccam;
-    add_idle (autoCamChangedUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<ColorAppearance*>(data)->autoCamComputed_();
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool ColorAppearance::autoCamComputed_ ()
@@ -1023,15 +1027,17 @@ bool ColorAppearance::autoCamComputed_ ()
 
     return false;
 }
-int adapCamChangedUI (void* data)
-{
-    (static_cast<ColorAppearance*>(data))->adapCamComputed_ ();
-    return 0;
-}
+
 void ColorAppearance::adapCamChanged (double cadap)
 {
     nextCadap = cadap;
-    add_idle (adapCamChangedUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<ColorAppearance*>(data)->adapCamComputed_();
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool ColorAppearance::adapCamComputed_ ()

--- a/rtgui/colorappearance.h
+++ b/rtgui/colorappearance.h
@@ -28,10 +28,61 @@
 #include "guiutils.h"
 #include "colorprovider.h"
 
-class ColorAppearance : public ToolParamBlock, public AdjusterListener, public FoldableToolPanel, public rtengine::AutoCamListener, public CurveListener,  public ColorProvider
+class ColorAppearance final :
+    public ToolParamBlock,
+    public AdjusterListener,
+    public FoldableToolPanel,
+    public rtengine::AutoCamListener,
+    public CurveListener,
+    public ColorProvider
 {
+public:
+    ColorAppearance ();
+    ~ColorAppearance ();
 
-protected:
+    void read           (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
+    void write          (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
+    void setDefaults    (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
+    void setBatchMode   (bool batchMode);
+    void adjusterChanged     (Adjuster* a, double newval);
+    void adjusterAutoToggled (Adjuster* a, bool newval);
+//    void adjusterAdapToggled (Adjuster* a, bool newval);
+    void enabledChanged      ();
+    void surroundChanged     ();
+    void wbmodelChanged      ();
+    void algoChanged         ();
+    void surrsource_toggled  ();
+    void gamut_toggled       ();
+//   void badpix_toggled       ();
+    void datacie_toggled     ();
+    void tonecie_toggled     ();
+//    void sharpcie_toggled     ();
+    void autoCamChanged (double ccam);
+    bool autoCamComputed_ ();
+    void adapCamChanged (double cadap);
+    bool adapCamComputed_ ();
+
+    void curveChanged        (CurveEditor* ce);
+    void curveMode1Changed   ();
+    bool curveMode1Changed_  ();
+    void curveMode2Changed   ();
+    bool curveMode2Changed_  ();
+    void curveMode3Changed   ();
+    bool curveMode3Changed_  ();
+
+    void expandCurve         (bool isExpanded);
+    bool isCurveExpanded     ();
+    void autoOpenCurve       ();
+
+    void setAdjusterBehavior (bool degreeadd, bool adapscenadd, bool adaplumadd, bool badpixsladd, bool jlightadd, bool chromaadd, bool contrastadd, bool rstprotectionadd, bool qbrightadd, bool qcontrastadd, bool schromaadd, bool mchromaadd, bool colorhadd);
+    void trimValues          (rtengine::procparams::ProcParams* pp);
+    void updateCurveBackgroundHistogram (LUTu & histToneCurve, LUTu & histLCurve, LUTu & histCCurve,/* LUTu & histCLurve, LUTu & histLLCurve,*/ LUTu & histLCAM, LUTu & histCCAM, LUTu & histRed, LUTu & histGreen, LUTu & histBlue, LUTu & histLuma, LUTu & histLRETI);
+    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller *caller);
+
+private:
+    bool bgTTipQuery(int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
+    bool srTTipQuery(int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
+
     Glib::RefPtr<Gtk::Tooltip> bgTTips;
     Glib::RefPtr<Gtk::Tooltip> srTTips;
     Glib::RefPtr<Gdk::Pixbuf> bgPixbuf;
@@ -83,56 +134,10 @@ protected:
     bool lastAutoAdapscen;
     bool lastsurr;
     bool lastgamut;
-//  bool lastbadpix;
     bool lastdatacie;
     bool lasttonecie;
-// bool lastsharpcie;
-    bool bgTTipQuery(int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
-    bool srTTipQuery(int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
 
-public:
-
-    ColorAppearance ();
-    ~ColorAppearance ();
-
-    void read           (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
-    void write          (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
-    void setDefaults    (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
-    void setBatchMode   (bool batchMode);
-    void adjusterChanged     (Adjuster* a, double newval);
-    void adjusterAutoToggled (Adjuster* a, bool newval);
-//    void adjusterAdapToggled (Adjuster* a, bool newval);
-    void enabledChanged      ();
-    void surroundChanged     ();
-    void wbmodelChanged      ();
-    void algoChanged         ();
-    void surrsource_toggled  ();
-    void gamut_toggled       ();
-//   void badpix_toggled       ();
-    void datacie_toggled     ();
-    void tonecie_toggled     ();
-//    void sharpcie_toggled     ();
-    void autoCamChanged (double ccam);
-    bool autoCamComputed_ ();
-    void adapCamChanged (double cadap);
-    bool adapCamComputed_ ();
-
-    void curveChanged        (CurveEditor* ce);
-    void curveMode1Changed   ();
-    bool curveMode1Changed_  ();
-    void curveMode2Changed   ();
-    bool curveMode2Changed_  ();
-    void curveMode3Changed   ();
-    bool curveMode3Changed_  ();
-
-    void expandCurve         (bool isExpanded);
-    bool isCurveExpanded     ();
-    void autoOpenCurve       ();
-
-    void setAdjusterBehavior (bool degreeadd, bool adapscenadd, bool adaplumadd, bool badpixsladd, bool jlightadd, bool chromaadd, bool contrastadd, bool rstprotectionadd, bool qbrightadd, bool qcontrastadd, bool schromaadd, bool mchromaadd, bool colorhadd);
-    void trimValues          (rtengine::procparams::ProcParams* pp);
-    void updateCurveBackgroundHistogram (LUTu & histToneCurve, LUTu & histLCurve, LUTu & histCCurve,/* LUTu & histCLurve, LUTu & histLLCurve,*/ LUTu & histLCAM, LUTu & histCCAM, LUTu & histRed, LUTu & histGreen, LUTu & histBlue, LUTu & histLuma, LUTu & histLRETI);
-    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller *caller);
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/colortoning.cc
+++ b/rtgui/colortoning.cc
@@ -324,6 +324,8 @@ ColorToning::ColorToning () : FoldableToolPanel(this, "colortoning", M("TP_COLOR
 
 ColorToning::~ColorToning()
 {
+    idle_register.destroy();
+
     delete colorCurveEditorG;
     delete opacityCurveEditorG;
     delete clCurveEditorG;
@@ -650,19 +652,18 @@ void ColorToning::adjusterChanged (ThresholdAdjuster* a, double newBottom, doubl
                                 Glib::ustring::compose(Glib::ustring(M("TP_COLORTONING_HUE") + ": %1" + "\n" + M("TP_COLORTONING_STRENGTH") + ": %2"), int(newTop), int(newBottom)));
 }
 
-int CTChanged_UI (void* data)
-{
-    (static_cast<ColorToning*>(data))->CTComp_ ();
-    return 0;
-}
-
-
 void ColorToning::autoColorTonChanged(int bwct, int satthres, int satprot)
 {
     nextbw = bwct;
     nextsatth = satthres;
     nextsatpr = satprot;
-    add_idle (CTChanged_UI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<ColorToning*>(data)->CTComp_();
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool ColorToning::CTComp_ ()

--- a/rtgui/colortoning.h
+++ b/rtgui/colortoning.h
@@ -13,12 +13,43 @@
 #include "thresholdadjuster.h"
 #include "colorprovider.h"
 
-class ColorToning : public ToolParamBlock, public FoldableToolPanel,  public rtengine::AutoColorTonListener, public CurveListener, public ColorProvider,
-    public ThresholdAdjusterListener, public AdjusterListener
+class ColorToning final :
+    public ToolParamBlock,
+    public FoldableToolPanel,
+    public rtengine::AutoColorTonListener,
+    public CurveListener,
+    public ColorProvider,
+    public ThresholdAdjusterListener,
+    public AdjusterListener
 {
+public:
+    ColorToning ();
+    ~ColorToning();
+    void read                  (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
+    void write                 (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
+    void setBatchMode          (bool batchMode);
+    void setDefaults           (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
+    void trimValues            (rtengine::procparams::ProcParams* pp);
+    void adjusterChanged       (Adjuster* a, double newval);
+    void adjusterChanged       (ThresholdAdjuster* a, double newBottom, double newTop);
+    void setAdjusterBehavior   (bool splitAdd, bool satThresholdAdd, bool satOpacityAdd, bool strprotectAdd, bool balanceAdd);
+    void neutral_pressed       ();
+    //void neutralCurves_pressed ();
+    void autoColorTonChanged   (int bwct, int satthres, int satprot);
+    bool CTComp_               ();
 
-protected:
-    //Gtk::HSeparator* splitSep;
+    void enabledChanged        ();
+    void curveChanged          (CurveEditor* ce);
+    void autosatChanged        ();
+    void autoOpenCurve         ();
+    void methodChanged         ();
+    void twocolorChanged       (bool changedbymethod);
+    void twoColorChangedByGui  ();
+    void lumamodeChanged       ();
+
+    void colorForValue         (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
+
+private:
     Gtk::HSeparator* satLimiterSep;
     Gtk::HSeparator* colorSep;
     CurveEditorGroup* colorCurveEditorG;
@@ -57,7 +88,6 @@ protected:
     Gtk::Image* irg;
 
     Gtk::Button* neutral;
-    //Gtk::Button* neutralCurves;
     Gtk::HBox* neutrHBox;
     Gtk::HBox* chromaHbox;
     Gtk::Label* chroLabel;
@@ -75,32 +105,7 @@ protected:
     bool lastLumamode;
     sigc::connection lumamodeConn;
 
-public:
-    ColorToning ();
-    ~ColorToning();
-    void read                  (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
-    void write                 (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
-    void setBatchMode          (bool batchMode);
-    void setDefaults           (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
-    void trimValues            (rtengine::procparams::ProcParams* pp);
-    void adjusterChanged       (Adjuster* a, double newval);
-    void adjusterChanged       (ThresholdAdjuster* a, double newBottom, double newTop);
-    void setAdjusterBehavior   (bool splitAdd, bool satThresholdAdd, bool satOpacityAdd, bool strprotectAdd, bool balanceAdd);
-    void neutral_pressed       ();
-    //void neutralCurves_pressed ();
-    void autoColorTonChanged   (int bwct, int satthres, int satprot);
-    bool CTComp_               ();
-
-    void enabledChanged        ();
-    void curveChanged          (CurveEditor* ce);
-    void autosatChanged        ();
-    void autoOpenCurve         ();
-    void methodChanged         ();
-    void twocolorChanged       (bool changedbymethod);
-    void twoColorChangedByGui  ();
-    void lumamodeChanged       ();
-
-    void colorForValue         (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/crop.h
+++ b/rtgui/crop.h
@@ -33,44 +33,20 @@ public:
     virtual void cropSelectRequested() = 0;
 };
 
-class CropRatio
-{
-
-public:
+struct CropRatio {
     Glib::ustring label;
     double value;
 };
 
-class Crop : public ToolParamBlock, public CropGUIListener, public FoldableToolPanel, public rtengine::SizeListener
+class Crop final :
+    public ToolParamBlock,
+    public CropGUIListener,
+    public FoldableToolPanel,
+    public rtengine::SizeListener
 {
-protected:
-    Gtk::CheckButton* fixr;
-    MyComboBoxText* ratio;
-    MyComboBoxText* orientation;
-    MyComboBoxText* guide;
-    Gtk::Button* selectCrop;
-    CropPanelListener* clistener;
-    int opt;
-    MySpinButton* x;
-    MySpinButton* y;
-    MySpinButton* w;
-    MySpinButton* h;
-    MySpinButton* ppi;
-    Gtk::Label* sizecm;
-    Gtk::Label* sizein;
-    Gtk::VBox* ppibox;
-    Gtk::VBox* sizebox;
-    int maxw, maxh;
-    double nx, ny;
-    int nw, nh;
-    int lastRotationDeg;
-    sigc::connection xconn, yconn, wconn, hconn, fconn, rconn, oconn, gconn;
-    bool wDirty, hDirty, xDirty, yDirty, lastFixRatio;
-    void adjustCropToRatio();
-    std::vector<CropRatio>   cropratio;
-
 public:
-    Crop ();
+    Crop();
+    ~Crop();
 
     void read           (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
     void write          (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
@@ -116,6 +92,34 @@ public:
     void hFlipCrop          ();
     void vFlipCrop          ();
     void rotateCrop         (int deg, bool hflip, bool vflip);
+
+private:
+    Gtk::CheckButton* fixr;
+    MyComboBoxText* ratio;
+    MyComboBoxText* orientation;
+    MyComboBoxText* guide;
+    Gtk::Button* selectCrop;
+    CropPanelListener* clistener;
+    int opt;
+    MySpinButton* x;
+    MySpinButton* y;
+    MySpinButton* w;
+    MySpinButton* h;
+    MySpinButton* ppi;
+    Gtk::Label* sizecm;
+    Gtk::Label* sizein;
+    Gtk::VBox* ppibox;
+    Gtk::VBox* sizebox;
+    int maxw, maxh;
+    double nx, ny;
+    int nw, nh;
+    int lastRotationDeg;
+    sigc::connection xconn, yconn, wconn, hconn, fconn, rconn, oconn, gconn;
+    bool wDirty, hDirty, xDirty, yDirty, lastFixRatio;
+    void adjustCropToRatio();
+    std::vector<CropRatio>   cropratio;
+
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/crophandler.h
+++ b/rtgui/crophandler.h
@@ -36,56 +36,15 @@ public:
     virtual void setDisplayPosition  (int x, int y) {}
 };
 
-class CropHandler;
-struct CropHandlerIdleHelper {
-    CropHandler* cropHandler;
-    bool destroyed;
-    int pending;
-};
-
 /**
  *  This class handle the displayed part of the image, ask for the initial data and process it so it can display it.
  *  Its position on the preview is handled not set by this class but by the CropHandlerListener (i.e. CropWindow) with which it works closely.
  */
-class CropHandler : public rtengine::DetailedCropListener, public rtengine::SizeListener
+class CropHandler final :
+    public rtengine::DetailedCropListener,
+    public rtengine::SizeListener
 {
-
-    friend int createpixbufs (void* data);
-
-protected:
-    int zoom;               // scale factor (e.g. 5 if 1:5 scale) ; if 1:1 scale and bigger, factor is multiplied by 1000  (i.e. 1000 for 1:1 scale, 2000 for 2:1, etc...)
-    int ww, wh;             // size of the crop's canvas on the screen ; might be bigger than the displayed image, but not smaller
-    int imx, imy, imw, imh; // this is a copy of the cropwindow's parameters
-    int cax, cay;           // clamped crop anchor's coordinate, i.e. point of the image that coincide to the center of the display area, expressed in image coordinates; cannot be outside the image's bounds; but if cax==cay==-1, designate the center of the image
-    int cx, cy, cw, ch;     // position and size of the requested crop ; position expressed in image coordinates, so cx and cy might be negative and cw and ch higher than the image's 1:1 size
-    int cropX, cropY, cropW, cropH; // cropPixbuf's displayed area (position and size), i.e. coordinates in 1:1 scale, i.e. cx, cy, cw & ch trimmed to the image's bounds
-    bool enabled;
-    unsigned char* cropimg;
-    unsigned char* cropimgtrue;
-    int cropimg_width, cropimg_height, cix, ciy, ciw, cih, cis;
-    bool initial;
-    bool isLowUpdatePriority;
-
-    rtengine::StagedImageProcessor* ipc;
-    rtengine::DetailedCrop* crop;
-
-    CropDisplayHandler* displayHandler;
-    CropHandlerIdleHelper* chi;
-
-    void    compDim ();
-
 public:
-
-    void    update  ();
-
-
-    rtengine::procparams::CropParams cropParams;
-    rtengine::procparams::ColorManagementParams colorParams;
-    Glib::RefPtr<Gdk::Pixbuf> cropPixbuf;
-    Glib::RefPtr<Gdk::Pixbuf> cropPixbuftrue;
-
-    MyMutex cimg;
-
     CropHandler ();
     ~CropHandler ();
 
@@ -127,6 +86,46 @@ public:
     bool    getWindow (int& cwx, int& cwy, int& cww, int& cwh, int& cskip);
     // SizeListener interface
     void    sizeChanged  (int w, int h, int ow, int oh);
+
+    void    update  ();
+
+
+    rtengine::procparams::CropParams cropParams;
+    rtengine::procparams::ColorManagementParams colorParams;
+    Glib::RefPtr<Gdk::Pixbuf> cropPixbuf;
+    Glib::RefPtr<Gdk::Pixbuf> cropPixbuftrue;
+
+    MyMutex cimg;
+
+private:
+    struct IdleHelper {
+        CropHandler* cropHandler;
+        bool destroyed;
+        int pending;
+    };
+
+    void    compDim ();
+
+    int zoom;               // scale factor (e.g. 5 if 1:5 scale) ; if 1:1 scale and bigger, factor is multiplied by 1000  (i.e. 1000 for 1:1 scale, 2000 for 2:1, etc...)
+    int ww, wh;             // size of the crop's canvas on the screen ; might be bigger than the displayed image, but not smaller
+    int imx, imy, imw, imh; // this is a copy of the cropwindow's parameters
+    int cax, cay;           // clamped crop anchor's coordinate, i.e. point of the image that coincide to the center of the display area, expressed in image coordinates; cannot be outside the image's bounds; but if cax==cay==-1, designate the center of the image
+    int cx, cy, cw, ch;     // position and size of the requested crop ; position expressed in image coordinates, so cx and cy might be negative and cw and ch higher than the image's 1:1 size
+    int cropX, cropY, cropW, cropH; // cropPixbuf's displayed area (position and size), i.e. coordinates in 1:1 scale, i.e. cx, cy, cw & ch trimmed to the image's bounds
+    bool enabled;
+    unsigned char* cropimg;
+    unsigned char* cropimgtrue;
+    int cropimg_width, cropimg_height, cix, ciy, ciw, cih, cis;
+    bool initial;
+    bool isLowUpdatePriority;
+
+    rtengine::StagedImageProcessor* ipc;
+    rtengine::DetailedCrop* crop;
+
+    CropDisplayHandler* displayHandler;
+    IdleHelper* idle_helper;
+
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/dirbrowser.cc
+++ b/rtgui/dirbrowser.cc
@@ -18,6 +18,7 @@
  */
 #include "dirbrowser.h"
 
+#include <iostream>
 #include <cstring>
 
 #ifdef WIN32

--- a/rtgui/dirpyrdenoise.cc
+++ b/rtgui/dirpyrdenoise.cc
@@ -327,22 +327,24 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, "dirpyrdenoise", M("TP
 
 DirPyrDenoise::~DirPyrDenoise ()
 {
+    idle_register.destroy();
+
     delete NoiscurveEditorG;
     delete CCcurveEditorG;
+}
 
-}
-int chromaChangedUI (void* data)
-{
-    (static_cast<DirPyrDenoise*>(data))->chromaComputed_ ();
-    return 0;
-}
 void DirPyrDenoise::chromaChanged (double autchroma, double autred, double autblue)
 {
     nextchroma = autchroma;
-//  printf("CHROM=%f\n",nextchroma);
     nextred = autred;
     nextblue = autblue;
-    add_idle(chromaChangedUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<DirPyrDenoise*>(data)->chromaComputed_();
+        return false;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool DirPyrDenoise::chromaComputed_ ()
@@ -356,12 +358,6 @@ bool DirPyrDenoise::chromaComputed_ ()
     updateNoiseLabel ();
     return false;
 }
-int TilePrevChangedUI (void* data)
-{
-    (static_cast<DirPyrDenoise*>(data))->TilePrevComputed_ ();
-    return 0;
-}
-
 
 void DirPyrDenoise::noiseTilePrev (int tileX, int tileY, int prevX, int prevY, int sizeT, int sizeP)
 {
@@ -372,10 +368,14 @@ void DirPyrDenoise::noiseTilePrev (int tileX, int tileY, int prevX, int prevY, i
     nextsizeT = sizeT;
     nextsizeP = sizeP;
 
-    add_idle(TilePrevChangedUI, this);
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<DirPyrDenoise*>(data)->TilePrevComputed_();
+        return false;
+    };
 
-
+    idle_register.add(func, this);
 }
+
 bool DirPyrDenoise::TilePrevComputed_ ()
 {
 
@@ -385,6 +385,7 @@ bool DirPyrDenoise::TilePrevComputed_ ()
     updatePrevLabel ();
     return false;
 }
+
 void DirPyrDenoise::updateTileLabel ()
 {
     if (!batchMode) {
@@ -422,19 +423,17 @@ void DirPyrDenoise::updatePrevLabel ()
     }
 }
 
-
-int noiseChangedUI (void* data)
-{
-    (static_cast<DirPyrDenoise*>(data))->noiseComputed_ ();
-    return 0;
-}
-
-
 void DirPyrDenoise::noiseChanged (double nresid, double highresid)
 {
     nextnresid = nresid;
     nexthighresid = highresid;
-    add_idle(noiseChangedUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<DirPyrDenoise*>(data)->noiseComputed_();
+        return false;
+    };
+
+    idle_register.add(func, this);
 }
 
 bool DirPyrDenoise::noiseComputed_ ()

--- a/rtgui/dirpyrdenoise.h
+++ b/rtgui/dirpyrdenoise.h
@@ -28,10 +28,58 @@
 #include "guiutils.h"
 #include "options.h"
 
-class DirPyrDenoise : public ToolParamBlock, public AdjusterListener, public FoldableToolPanel, public rtengine::AutoChromaListener, public CurveListener, public ColorProvider
+class DirPyrDenoise final :
+    public ToolParamBlock,
+    public AdjusterListener,
+    public FoldableToolPanel,
+    public rtengine::AutoChromaListener,
+    public CurveListener,
+    public ColorProvider
 {
+public:
+    DirPyrDenoise ();
+    ~DirPyrDenoise ();
 
-protected:
+    void read           (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
+    void write          (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
+    void setDefaults    (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
+    void setBatchMode   (bool batchMode);
+    void curveChanged   (CurveEditor* ce);
+    void setEditProvider     (EditDataProvider *provider);
+    void autoOpenCurve  ();
+
+    void adjusterChanged (Adjuster* a, double newval);
+    void enabledChanged  ();
+    void enhanceChanged  ();
+    void medianChanged  ();
+    void autochromaChanged  ();
+    void chromaChanged (double autchroma, double autred, double autblue);
+    bool chromaComputed_ ();
+    void noiseChanged (double nresid, double highresid);
+    bool noiseComputed_ ();
+    void noiseTilePrev (int tileX, int tileY, int prevX, int prevY, int sizeT, int sizeP);
+    bool TilePrevComputed_ ();
+
+//    void perform_toggled  ();
+    void updateNoiseLabel      ();
+    void LmethodChanged      ();
+    void CmethodChanged      ();
+    void C2methodChanged      ();
+    void updateTileLabel      ();
+    void updatePrevLabel      ();
+
+    void dmethodChanged      ();
+    void medmethodChanged      ();
+    void methodmedChanged      ();
+    void rgbmethodChanged      ();
+    void smethodChanged      ();
+    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
+
+    void setAdjusterBehavior (bool lumaadd, bool lumdetadd, bool chromaadd, bool chromaredadd, bool chromablueadd, bool gammaadd, bool passesadd);
+    void trimValues          (rtengine::procparams::ProcParams* pp);
+    Glib::ustring getSettingString ();
+
+private:
     CurveEditorGroup* NoiscurveEditorG;
     CurveEditorGroup* CCcurveEditorG;
     Adjuster* luma;
@@ -92,50 +140,7 @@ protected:
     int nextsizeT;
     int nextsizeP;
 
-public:
-
-    DirPyrDenoise ();
-    ~DirPyrDenoise ();
-
-    void read           (const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr);
-    void write          (rtengine::procparams::ProcParams* pp, ParamsEdited* pedited = nullptr);
-    void setDefaults    (const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr);
-    void setBatchMode   (bool batchMode);
-    void curveChanged   (CurveEditor* ce);
-    void setEditProvider     (EditDataProvider *provider);
-    void autoOpenCurve  ();
-
-    void adjusterChanged (Adjuster* a, double newval);
-    void enabledChanged  ();
-    void enhanceChanged  ();
-    void medianChanged  ();
-    void autochromaChanged  ();
-    void chromaChanged (double autchroma, double autred, double autblue);
-    bool chromaComputed_ ();
-    void noiseChanged (double nresid, double highresid);
-    bool noiseComputed_ ();
-    void noiseTilePrev (int tileX, int tileY, int prevX, int prevY, int sizeT, int sizeP);
-    bool TilePrevComputed_ ();
-
-//    void perform_toggled  ();
-    void updateNoiseLabel      ();
-    void LmethodChanged      ();
-    void CmethodChanged      ();
-    void C2methodChanged      ();
-    void updateTileLabel      ();
-    void updatePrevLabel      ();
-
-    void dmethodChanged      ();
-    void medmethodChanged      ();
-    void methodmedChanged      ();
-    void rgbmethodChanged      ();
-    void smethodChanged      ();
-    virtual void colorForValue (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller);
-
-    void setAdjusterBehavior (bool lumaadd, bool lumdetadd, bool chromaadd, bool chromaredadd, bool chromablueadd, bool gammaadd, bool passesadd);
-    void trimValues          (rtengine::procparams::ProcParams* pp);
-    Glib::ustring getSettingString ();
-
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -45,102 +45,17 @@ struct EditorPanelIdleHelper {
 };
 
 class RTWindow;
-class EditorPanel : public Gtk::VBox,
+class EditorPanel final :
+    public Gtk::VBox,
     public PParamsChangeListener,
     public rtengine::ProgressListener,
     public ThumbnailListener,
     public HistoryBeforeLineListener,
     public rtengine::HistogramListener
 {
-private:
-
-    Glib::ustring lastSaveAsFileName;
-    bool realized;
-
-protected:
-    MyProgressBar  *progressLabel;
-    Gtk::ToggleButton* info;
-    Gtk::ToggleButton* hidehp;
-    Gtk::ToggleButton* tbShowHideSidePanels;
-    Gtk::ToggleButton* tbTopPanel_1;
-    Gtk::ToggleButton* tbRightPanel_1;
-    Gtk::ToggleButton* tbBeforeLock;
-    //bool bAllSidePanelsVisible;
-    Gtk::ToggleButton* beforeAfter;
-    Gtk::Paned* hpanedl;
-    Gtk::Paned* hpanedr;
-    Gtk::Image *iHistoryShow, *iHistoryHide;
-    Gtk::Image *iTopPanel_1_Show, *iTopPanel_1_Hide;
-    Gtk::Image *iRightPanel_1_Show, *iRightPanel_1_Hide;
-    Gtk::Image *iShowHideSidePanels;
-    Gtk::Image *iShowHideSidePanels_exit;
-    Gtk::Image *iBeforeLockON, *iBeforeLockOFF;
-    Gtk::VBox *leftbox;
-    Gtk::VBox *vboxright;
-
-    Gtk::Button* queueimg;
-    Gtk::Button* saveimgas;
-    Gtk::Button* sendtogimp;
-    Gtk::Button* navSync;
-    Gtk::Button* navNext;
-    Gtk::Button* navPrev;
-
-    class ColorManagementToolbar;
-    std::unique_ptr<ColorManagementToolbar> colorMgmtToolBar;
-
-    ImageAreaPanel* iareapanel;
-    PreviewHandler* previewHandler;
-    PreviewHandler* beforePreviewHandler;   // for the before-after view
-    Navigator* navigator;
-    ImageAreaPanel* beforeIarea;    // for the before-after view
-    Gtk::VBox* beforeBox;
-    Gtk::VBox* afterBox;
-    Gtk::Label* beforeLabel;
-    Gtk::Label* afterLabel;
-    Gtk::HBox* beforeAfterBox;
-    Gtk::HBox* beforeHeaderBox;
-    Gtk::HBox* afterHeaderBox;
-
-    Gtk::Frame* ppframe;
-    ProfilePanel* profilep;
-    History* history;
-    HistogramPanel* histogramPanel;
-    ToolPanelCoordinator* tpc;
-    RTWindow* parent;
-    //SaveAsDialog* saveAsDialog;
-    BatchToolPanelCoordinator* btpCoordinator;
-    FilePanel* fPanel;
-
-    bool firstProcessingDone;
-
-    Thumbnail* openThm;  // may get invalid on external delete event
-    Glib::ustring fname;  // must be saved separately
-
-    rtengine::InitialImage* isrc;
-    rtengine::StagedImageProcessor* ipc;
-    rtengine::StagedImageProcessor* beforeIpc;    // for the before-after view
-
-    EditorPanelIdleHelper* epih;
-
-    void close ();
-
-    BatchQueueEntry*    createBatchQueueEntry ();
-    bool                idle_imageSaved (ProgressConnector<int> *pc, rtengine::IImage16* img, Glib::ustring fname, SaveFormat sf);
-    bool                idle_saveImage (ProgressConnector<rtengine::IImage16*> *pc, Glib::ustring fname, SaveFormat sf);
-    bool                idle_sendToGimp ( ProgressConnector<rtengine::IImage16*> *pc, Glib::ustring fname);
-    bool                idle_sentToGimp (ProgressConnector<int> *pc, rtengine::IImage16* img, Glib::ustring filename);
-    int err;
-
-    time_t processingStartedTime;
-
-    sigc::connection ShowHideSidePanelsconn;
-
-    bool isProcessing;
-
-
 public:
     explicit EditorPanel (FilePanel* filePanel = nullptr);
-    virtual ~EditorPanel ();
+    ~EditorPanel ();
 
     void open (Thumbnail* tmb, rtengine::InitialImage* isrc);
     void setAspect ();
@@ -214,7 +129,93 @@ public:
     void updateTabsUsesIcons (bool useIcons);
     void updateHistogramPosition (int oldPosition, int newPosition);
 
-    Gtk::Paned *catalogPane;
+    Gtk::Paned* catalogPane;
+
+private:
+    void close ();
+
+    BatchQueueEntry*    createBatchQueueEntry ();
+    bool                idle_imageSaved (ProgressConnector<int> *pc, rtengine::IImage16* img, Glib::ustring fname, SaveFormat sf);
+    bool                idle_saveImage (ProgressConnector<rtengine::IImage16*> *pc, Glib::ustring fname, SaveFormat sf);
+    bool                idle_sendToGimp ( ProgressConnector<rtengine::IImage16*> *pc, Glib::ustring fname);
+    bool                idle_sentToGimp (ProgressConnector<int> *pc, rtengine::IImage16* img, Glib::ustring filename);
+
+    Glib::ustring lastSaveAsFileName;
+    bool realized;
+
+    MyProgressBar  *progressLabel;
+    Gtk::ToggleButton* info;
+    Gtk::ToggleButton* hidehp;
+    Gtk::ToggleButton* tbShowHideSidePanels;
+    Gtk::ToggleButton* tbTopPanel_1;
+    Gtk::ToggleButton* tbRightPanel_1;
+    Gtk::ToggleButton* tbBeforeLock;
+    //bool bAllSidePanelsVisible;
+    Gtk::ToggleButton* beforeAfter;
+    Gtk::Paned* hpanedl;
+    Gtk::Paned* hpanedr;
+    Gtk::Image *iHistoryShow, *iHistoryHide;
+    Gtk::Image *iTopPanel_1_Show, *iTopPanel_1_Hide;
+    Gtk::Image *iRightPanel_1_Show, *iRightPanel_1_Hide;
+    Gtk::Image *iShowHideSidePanels;
+    Gtk::Image *iShowHideSidePanels_exit;
+    Gtk::Image *iBeforeLockON, *iBeforeLockOFF;
+    Gtk::VBox *leftbox;
+    Gtk::VBox *vboxright;
+
+    Gtk::Button* queueimg;
+    Gtk::Button* saveimgas;
+    Gtk::Button* sendtogimp;
+    Gtk::Button* navSync;
+    Gtk::Button* navNext;
+    Gtk::Button* navPrev;
+
+    class ColorManagementToolbar;
+    std::unique_ptr<ColorManagementToolbar> colorMgmtToolBar;
+
+    ImageAreaPanel* iareapanel;
+    PreviewHandler* previewHandler;
+    PreviewHandler* beforePreviewHandler;   // for the before-after view
+    Navigator* navigator;
+    ImageAreaPanel* beforeIarea;    // for the before-after view
+    Gtk::VBox* beforeBox;
+    Gtk::VBox* afterBox;
+    Gtk::Label* beforeLabel;
+    Gtk::Label* afterLabel;
+    Gtk::HBox* beforeAfterBox;
+    Gtk::HBox* beforeHeaderBox;
+    Gtk::HBox* afterHeaderBox;
+
+    Gtk::Frame* ppframe;
+    ProfilePanel* profilep;
+    History* history;
+    HistogramPanel* histogramPanel;
+    ToolPanelCoordinator* tpc;
+    RTWindow* parent;
+    //SaveAsDialog* saveAsDialog;
+    BatchToolPanelCoordinator* btpCoordinator;
+    FilePanel* fPanel;
+
+    bool firstProcessingDone;
+
+    Thumbnail* openThm;  // may get invalid on external delete event
+    Glib::ustring fname;  // must be saved separately
+
+    rtengine::InitialImage* isrc;
+    rtengine::StagedImageProcessor* ipc;
+    rtengine::StagedImageProcessor* beforeIpc;    // for the before-after view
+
+    EditorPanelIdleHelper* epih;
+
+    int err;
+
+    time_t processingStartedTime;
+
+    sigc::connection ShowHideSidePanelsconn;
+
+    bool isProcessing;
+
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -22,12 +22,6 @@
 #include "inspector.h"
 #include "placesbrowser.h"
 
-int FilePanelInitUI (void* data)
-{
-    (static_cast<FilePanel*>(data))->init ();
-    return 0;
-}
-
 FilePanel::FilePanel () : parent(nullptr)
 {
 
@@ -143,13 +137,21 @@ FilePanel::FilePanel () : parent(nullptr)
     fileCatalog->setFileSelectionChangeListener (tpc);
 
     fileCatalog->setFileSelectionListener (this);
-    add_idle (FilePanelInitUI, this);
+
+    const auto func = [](gpointer data) -> gboolean {
+        static_cast<FilePanel*>(data)->init();
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 
     show_all ();
 }
 
 FilePanel::~FilePanel ()
 {
+    idle_register.destroy();
+
     rightNotebookSwitchConn.disconnect();
 
     if (inspectorPanel) {

--- a/rtgui/filepanel.h
+++ b/rtgui/filepanel.h
@@ -33,38 +33,12 @@
 #include "progressconnector.h"
 
 class RTWindow;
-class FilePanel : public Gtk::HPaned,
+
+class FilePanel final :
+    public Gtk::HPaned,
     public FileSelectionListener,
     public PParamsChangeListener
 {
-
-protected:
-    //DirBrowser* dirBrowser;
-    PlacesBrowser* placesBrowser;
-    RecentBrowser* recentBrowser;
-    // FileCatalog* fileCatalog;   // filecatalog is the file browser with the button bar above it
-
-    Inspector* inspectorPanel;
-    Gtk::VPaned* tpcPaned;
-    BatchToolPanelCoordinator* tpc;
-    History* history;
-    //FilterPanel* filterPanel;
-    RTWindow* parent;
-    Gtk::Notebook* rightNotebook;
-    sigc::connection rightNotebookSwitchConn;
-
-    struct pendingLoad {
-        bool complete;
-        ProgressConnector<rtengine::InitialImage*> *pc;
-        Thumbnail *thm;
-    };
-    MyMutex pendingLoadMutex;
-    std::vector<struct pendingLoad*> pendingLoads;
-
-    int error;
-
-    void on_NB_switch_page(Gtk::Widget* page, guint page_num);
-
 public:
     FilePanel ();
     ~FilePanel ();
@@ -107,6 +81,32 @@ public:
     bool handleShortcutKey (GdkEventKey* event);
     void updateTPVScrollbar (bool hide);
     void updateTabsUsesIcons (bool useIcons);
+
+private:
+    void on_NB_switch_page(Gtk::Widget* page, guint page_num);
+
+    PlacesBrowser* placesBrowser;
+    RecentBrowser* recentBrowser;
+
+    Inspector* inspectorPanel;
+    Gtk::VPaned* tpcPaned;
+    BatchToolPanelCoordinator* tpc;
+    History* history;
+    RTWindow* parent;
+    Gtk::Notebook* rightNotebook;
+    sigc::connection rightNotebookSwitchConn;
+
+    struct pendingLoad {
+        bool complete;
+        ProgressConnector<rtengine::InitialImage*> *pc;
+        Thumbnail *thm;
+    };
+    MyMutex pendingLoadMutex;
+    std::vector<struct pendingLoad*> pendingLoads;
+
+    int error;
+
+    IdleRegister idle_register;
 };
 
 #endif

--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -43,6 +43,53 @@ guint add_idle (GSourceFunc function, gpointer data)
     //gtk_main_iteration_do(false);
 }
 
+IdleRegister::~IdleRegister()
+{
+    destroy();
+}
+
+void IdleRegister::add(GSourceFunc function, gpointer data)
+{
+    struct DataWrapper {
+        IdleRegister* const self;
+        GSourceFunc function;
+        gpointer data;
+    };
+
+    const auto dispatch = [](gpointer data) -> gboolean {
+        DataWrapper* const data_wrapper = static_cast<DataWrapper*>(data);
+
+        if (!data_wrapper->function(data_wrapper->data)) {
+            data_wrapper->self->mutex.lock();
+            data_wrapper->self->ids.erase(data_wrapper);
+            data_wrapper->self->mutex.unlock();
+
+            delete data_wrapper;
+            return FALSE;
+        }
+
+        return TRUE;
+    };
+
+    DataWrapper* const data_wrapper = new DataWrapper{
+        this,
+        function,
+        data
+    };
+
+    mutex.lock();
+    ids[data_wrapper] = add_idle(dispatch, data_wrapper);
+    mutex.unlock();
+}
+
+void IdleRegister::destroy()
+{
+    mutex.lock();
+    for (const auto id : ids) {
+        g_source_remove(id.second);
+    }
+    mutex.unlock();
+}
 
 /*
 gboolean giveMeAGo(void* data) {

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -19,9 +19,7 @@
 #ifndef __GUI_UTILS_
 #define __GUI_UTILS_
 
-#include <iostream>
-#include <set>
-#include <sstream>
+#include <map>
 
 #include <gtkmm.h>
 

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -19,13 +19,19 @@
 #ifndef __GUI_UTILS_
 #define __GUI_UTILS_
 
-#include <gtkmm.h>
-#include <cairomm/cairomm.h>
-#include "../rtengine/rtengine.h"
-#include "../rtengine/coord.h"
-#include "rtimage.h"
-#include <sstream>
 #include <iostream>
+#include <set>
+#include <sstream>
+
+#include <gtkmm.h>
+
+#include <cairomm/cairomm.h>
+
+#include "../rtengine/coord.h"
+#include "../rtengine/noncopyable.h"
+#include "../rtengine/rtengine.h"
+
+#include "rtimage.h"
 
 Glib::ustring escapeHtmlChars(const Glib::ustring &src);
 bool removeIfThere (Gtk::Container* cont, Gtk::Widget* w, bool increference = true);
@@ -39,6 +45,20 @@ gboolean acquireGUI(void* data);
 void setExpandAlignProperties(Gtk::Widget *widget, bool hExpand, bool vExpand, enum Gtk::Align hAlign, enum Gtk::Align vAlign);
 
 guint add_idle (GSourceFunc function, gpointer data);
+
+class IdleRegister final :
+    public rtengine::NonCopyable
+{
+public:
+    ~IdleRegister();
+
+    void add(GSourceFunc function, gpointer data);
+    void destroy();
+
+private:
+    std::map<void*, guint> ids;
+    MyMutex mutex;
+};
 
 // TODO: The documentation says gdk_threads_enter and gdk_threads_leave should be replaced
 // by g_main_context_invoke(), g_idle_add() and related functions, but this will require more extensive changes.

--- a/rtgui/resize.cc
+++ b/rtgui/resize.cc
@@ -118,7 +118,7 @@ Resize::Resize () : FoldableToolPanel(this, "resize", M("TP_RESIZE_LABEL"), fals
 
 Resize::~Resize ()
 {
-
+    idle_register.destroy();
     delete scale;
     delete sizeBox;
 }
@@ -352,68 +352,76 @@ void Resize::sizeChanged (int mw, int mh, int ow, int oh)
 
 void Resize::setDimensions ()
 {
+    const auto func = [](gpointer data) -> gboolean {
+        Resize* const self = static_cast<Resize*>(data);
 
-    int refw, refh;
+        self->wconn.block(true);
+        self->hconn.block(true);
+        self->scale->block(true);
 
-    wconn.block (true);
-    hconn.block (true);
-    scale->block(true);
+        int refw, refh;
 
-    if (appliesTo->get_active_row_number() == 0 && cropw) {
-        // Applies to Cropped area
-        refw = cropw;
-        refh = croph;
-    } else {
-        // Applies to Full image or crop is disabled
-        refw = maxw;
-        refh = maxh;
-    }
-
-    GThreadLock lock;
-    w->set_range (32, 4 * refw);
-    h->set_range (32, 4 * refh);
-
-    double tmpScale;
-
-    switch (spec->get_active_row_number()) {
-    case (0):   // Scale mode
-        w->set_value((double)((int)( (double)(refw) * scale->getValue() + 0.5) ));
-        h->set_value((double)((int)( (double)(refh) * scale->getValue() + 0.5) ));
-        break;
-
-    case (1):   // Width mode
-        tmpScale = w->get_value() / (double)refw;
-        scale->setValue (tmpScale);
-        h->set_value((double)((int)( (double)(refh) * tmpScale + 0.5) ));
-        break;
-
-    case (2):   // Height mode
-        tmpScale = h->get_value() / (double)refh;
-        scale->setValue (tmpScale);
-        w->set_value((double)((int)( (double)(refw) * tmpScale + 0.5) ));
-        break;
-
-    case (3): { // Bounding box mode
-        double wSliderValue = w->get_value();
-        double hSliderValue = h->get_value();
-
-        if ( (wSliderValue / hSliderValue) < ((double)refw / (double)refh)) {
-            tmpScale = wSliderValue / (double)refw;
+        if (self->appliesTo->get_active_row_number() == 0 && self->cropw) {
+            // Applies to Cropped area
+            refw = self->cropw;
+            refh = self->croph;
         } else {
-            tmpScale = hSliderValue / (double)refh;
+            // Applies to Full image or crop is disabled
+            refw = self->maxw;
+            refh = self->maxh;
         }
 
-        scale->setValue (tmpScale);
-        break;
-    }
+        self->w->set_range(32, 4 * refw);
+        self->h->set_range(32, 4 * refh);
 
-    default:
-        break;
-    }
+        switch (self->spec->get_active_row_number()) {
+            case 0: {
+                // Scale mode
+                self->w->set_value(static_cast<double>(static_cast<int>(static_cast<double>(refw) * self->scale->getValue() + 0.5)));
+                self->h->set_value(static_cast<double>(static_cast<int>(static_cast<double>(refh) * self->scale->getValue() + 0.5)));
+                break;
+            }
 
-    scale->block(false);
-    wconn.block (false);
-    hconn.block (false);
+            case 1: {
+                // Width mode
+                const double tmp_scale = self->w->get_value() / static_cast<double>(refw);
+                self->scale->setValue(tmp_scale);
+                self->h->set_value(static_cast<double>(static_cast<int>(static_cast<double>(refh) * tmp_scale + 0.5)));
+                break;
+            }
+
+            case 2: {
+                // Height mode
+                const double tmp_scale = self->h->get_value() / static_cast<double>(refh);
+                self->scale->setValue(tmp_scale);
+                self->w->set_value(static_cast<double>(static_cast<int>(static_cast<double>(refw) * tmp_scale + 0.5)));
+                break;
+            }
+
+            case 3: {
+                // Bounding box mode
+                const double tmp_scale =
+                    self->w->get_value() / self->h->get_value() < static_cast<double>(refw) / static_cast<double>(refh)
+                        ? self->w->get_value() / static_cast<double>(refw)
+                        : self->h->get_value() / static_cast<double>(refh);
+
+                self->scale->setValue(tmp_scale);
+                break;
+            }
+
+            default: {
+                break;
+            }
+        }
+
+        self->scale->block(false);
+        self->wconn.block(false);
+        self->hconn.block(false);
+
+        return FALSE;
+    };
+
+    idle_register.add(func, this);
 }
 
 void Resize::fitBoxScale()

--- a/rtgui/resize.h
+++ b/rtgui/resize.h
@@ -25,25 +25,13 @@
 #include "toolpanel.h"
 #include "guiutils.h"
 
-class Resize : public ToolParamBlock, public AdjusterListener, public FoldableToolPanel, public rtengine::SizeListener
+class Resize final :
+    public ToolParamBlock,
+    public AdjusterListener,
+    public FoldableToolPanel,
+    public rtengine::SizeListener
 {
-
-protected:
-    Adjuster*          scale;
-    Gtk::VBox*         sizeBox;
-    MyComboBoxText*    appliesTo;
-    MyComboBoxText*    method;
-    MyComboBoxText*    spec;
-    MySpinButton*      w;
-    MySpinButton*      h;
-    int                maxw, maxh;
-    int                cropw, croph;
-    sigc::connection   sconn, aconn, wconn, hconn;
-    bool               wDirty, hDirty;
-    ToolParamBlock*    packBox;
-
 public:
-
     Resize ();
     ~Resize ();
 
@@ -75,6 +63,20 @@ private:
     int getComputedHeight ();
     void notifyBBox ();
     void updateGUI ();
+
+    Adjuster*          scale;
+    Gtk::VBox*         sizeBox;
+    MyComboBoxText*    appliesTo;
+    MyComboBoxText*    method;
+    MyComboBoxText*    spec;
+    MySpinButton*      w;
+    MySpinButton*      h;
+    int                maxw, maxh;
+    int                cropw, croph;
+    sigc::connection   sconn, aconn, wconn, hconn;
+    bool               wDirty, hDirty;
+    ToolParamBlock*    packBox;
+    IdleRegister       idle_register;
 };
 
 #endif


### PR DESCRIPTION
This adds a little helper class to `guiutils.*` that unregisters
in-flight idle functions queued by `IdleRegister::add()`. It's best
to call `IdleRegister::destroy()` in the destructor of the class
owning the `IdleRegister` instance. Otherwise make sure, it is the
last member which will be deleted first.

`Resize` now makes use of this new facility in `setDimensions()`, which
also fixes #3673.