### PR TITLE
re-enable dcraw code for reading lossy DNG files

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -9,6 +9,7 @@
 /*RT*/#define NO_JASPER
 /*RT*/#define LOCALTIME
 /*RT*/#define DJGPP
+/*RT*/#include <jpeglib.h>
 
 #include "opthelper.h"
 
@@ -2604,7 +2605,7 @@ void CLASS kodak_radc_load_raw()
 
 #ifdef NO_JPEG
 void CLASS kodak_jpeg_load_raw() {}
-void CLASS lossy_dng_load_raw() {}
+// RT void CLASS lossy_dng_load_raw() {}
 #else
 
 METHODDEF(boolean)
@@ -2661,6 +2662,7 @@ void CLASS kodak_jpeg_load_raw()
 }
 
 void CLASS gamma_curve (double pwr, double ts, int mode, int imax);
+/*RT*/#endif
 
 void CLASS lossy_dng_load_raw()
 {
@@ -2704,7 +2706,8 @@ void CLASS lossy_dng_load_raw()
     fseek (ifp, save+=4, SEEK_SET);
     if (tile_length < INT_MAX)
       fseek (ifp, get4(), SEEK_SET);
-    jpeg_stdio_src (&cinfo, ifp);
+    /*RT jpeg_stdio_src (&cinfo, ifp); */
+    /*RT*/jpeg_mem_src(&cinfo, fdata(ftell(ifp), ifp), ifp->size - ftell(ifp));
     jpeg_read_header (&cinfo, TRUE);
     jpeg_start_decompress (&cinfo);
     buf = (*cinfo.mem->alloc_sarray)
@@ -2724,7 +2727,7 @@ void CLASS lossy_dng_load_raw()
   jpeg_destroy_decompress (&cinfo);
   maximum = 0xffff;
 }
-#endif
+// RT #endif
 
 void CLASS kodak_dc120_load_raw()
 {
@@ -9525,8 +9528,8 @@ dng_skip:
   }
 #endif
 #ifdef NO_JPEG
-  if (load_raw == &CLASS kodak_jpeg_load_raw ||
-      load_raw == &CLASS lossy_dng_load_raw) {
+  if (load_raw == &CLASS kodak_jpeg_load_raw /* RT ||
+      load_raw == &CLASS lossy_dng_load_raw*/) {
     fprintf (stderr,_("%s: You must link dcraw with %s!!\n"),
 	ifname, "libjpeg");
     is_raw = 0;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -9,7 +9,7 @@
 /*RT*/#define NO_JASPER
 /*RT*/#define LOCALTIME
 /*RT*/#define DJGPP
-/*RT*/#include <jpeglib.h>
+/*RT*/#include "jpeg.h"
 
 #include "opthelper.h"
 
@@ -2707,7 +2707,7 @@ void CLASS lossy_dng_load_raw()
     if (tile_length < INT_MAX)
       fseek (ifp, get4(), SEEK_SET);
     /*RT jpeg_stdio_src (&cinfo, ifp); */
-    /*RT*/jpeg_mem_src(&cinfo, fdata(ftell(ifp), ifp), ifp->size - ftell(ifp));
+    /*RT*/jpeg_memory_src(&cinfo, fdata(ftell(ifp), ifp), ifp->size - ftell(ifp));
     jpeg_read_header (&cinfo, TRUE);
     jpeg_start_decompress (&cinfo);
     buf = (*cinfo.mem->alloc_sarray)
@@ -2727,7 +2727,7 @@ void CLASS lossy_dng_load_raw()
   jpeg_destroy_decompress (&cinfo);
   maximum = 0xffff;
 }
-// RT #endif
+/*RT #endif */
 
 void CLASS kodak_dc120_load_raw()
 {


### PR DESCRIPTION
The relevant dcraw code was #ifdef'd out, but reenabling it seems easy and working.
