### PR TITLE
improve readability of the partial profile paste dialog under the default theme

### DIFF
--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -836,5 +836,5 @@ paned.vertical > separator {
 }
 
 #PartialPasteHeaderSep {
-    color: #D8D8D8;
+    background-color: #D8D8D8;
 }

--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -826,3 +826,15 @@ paned.vertical > separator {
 #RightNotebook scrolledwindow {
     padding: 4px;
 }
+
+
+/* make the "partial profile" dialog a little bit more readable */
+#PartialPasteHeader {
+    margin: 1.5em 0 0 0;
+    padding: 0;
+    font-weight: bold;
+}
+
+#PartialPasteHeaderSep {
+    color: #D8D8D8;
+}

--- a/rtdata/themes/RawTherapee-GTK3-_19.css
+++ b/rtdata/themes/RawTherapee-GTK3-_19.css
@@ -487,3 +487,16 @@ GtkNotebook {
 .tooltip {
     padding: 0;
 }
+
+
+/* make the "partial profile" dialog a little bit more readable */
+#PartialPasteHeader {
+    margin: 1.5em 0 0 0;
+    padding: 0;
+    font-weight: bold;
+    color: #363636;
+}
+
+#PartialPasteHeaderSep {
+    color: #D8D8D8;
+}


### PR DESCRIPTION
The partial profile paste dialog is a bit cluttered with RT's default GTK3 theme. This tries to make it a bit more readable. 
Current look:
![before](https://cloud.githubusercontent.com/assets/11982086/23118205/92715ffa-f753-11e6-9a7d-45a74178d766.png)

After the patch:
![after](https://cloud.githubusercontent.com/assets/11982086/23118211/9b857608-f753-11e6-8f26-2e166c6f0a82.png)

Warning: tested only on gtkmm V3.18.0
