### PR TITLE
Variadic template version of `rtengine::(min|max)()`

### DIFF
--- a/rtengine/rt_math.h
+++ b/rtengine/rt_math.h
@@ -27,57 +27,68 @@ constexpr float RT_PI_F_2 = RT_PI_2;
 constexpr float RT_INFINITY_F = std::numeric_limits<float>::infinity();
 constexpr float RT_NAN_F = std::numeric_limits<float>::quiet_NaN();
 
-template <typename T>
-inline T SQR (T x)
+template<typename T>
+constexpr T SQR(T x)
 {
-//      return std::pow(x,2); Slower than:
     return x * x;
 }
 
 template<typename T>
-inline const T& min(const T& a, const T& b)
+constexpr const T& min(const T& a)
 {
-    return std::min(a, b);
+    return a;
+}
+
+template<typename T>
+constexpr const T& min(const T& a, const T& b)
+{
+    return a < b ? a : b;
 }
 
 template<typename T, typename... ARGS>
-inline const T& min(const T& a, const T& b, const ARGS&... args)
+constexpr const T& min(const T& a, const T& b, const ARGS&... args)
 {
-    return min(min(a, b), args...);
+    return min(min(a, b), min(args...));
 }
 
 template<typename T>
-inline const T& max(const T& a, const T& b)
+constexpr const T& max(const T& a)
 {
-    return std::max(a, b);
+    return a;
+}
+
+template<typename T>
+constexpr const T& max(const T& a, const T& b)
+{
+    return a < b ? b : a;
 }
 
 template<typename T, typename... ARGS>
-inline const T& max(const T& a, const T& b, const ARGS&... args)
+constexpr const T& max(const T& a, const T& b, const ARGS&... args)
 {
-    return max(max(a, b), args...);
+    return max(max(a, b), max(args...));
 }
 
 template<typename T>
-inline const T& LIM(const T& a, const T& b, const T& c)
+constexpr const T& LIM(const T& a, const T& b, const T& c)
 {
-    return std::max(b, std::min(a, c));
+    return max(b, min(a, c));
 }
 
 template<typename T>
-inline T LIM01(const T& a)
+constexpr T LIM01(const T& a)
 {
-    return std::max(T(0), std::min(a, T(1)));
+    return max(T(0), min(a, T(1)));
 }
 
 template<typename T>
-inline T CLIP(const T& a)
+constexpr T CLIP(const T& a)
 {
     return LIM(a, static_cast<T>(0), static_cast<T>(MAXVAL));
 }
 
 template<typename T>
-inline T intp(T a, T b, T c)
+constexpr T intp(T a, T b, T c)
 {
     // calculate a * b + (1 - a) * c
     // following is valid:
@@ -101,13 +112,13 @@ inline T norm2(const T& x, const T& y)
 template< typename T >
 inline T norminf(const T& x, const T& y)
 {
-    return std::max(std::abs(x), std::abs(y));
+    return max(std::abs(x), std::abs(y));
 }
 
-inline int float2uint16range(float d) // clips input to [0;65535] and rounds
+constexpr int float2uint16range(float d)
 {
-    d = CLIP(d); // clip to [0;65535]
-    return d + 0.5f;
+    // clips input to [0;65535] and rounds
+    return CLIP(d) + 0.5f;
 }
 
 constexpr std::uint8_t uint16ToUint8Rounded(std::uint16_t i)

--- a/rtengine/rt_math.h
+++ b/rtengine/rt_math.h
@@ -27,71 +27,57 @@ constexpr float RT_PI_F_2 = RT_PI_2;
 constexpr float RT_INFINITY_F = std::numeric_limits<float>::infinity();
 constexpr float RT_NAN_F = std::numeric_limits<float>::quiet_NaN();
 
-template <typename _Tp>
-inline _Tp SQR (_Tp x)
+template <typename T>
+inline T SQR (T x)
 {
 //      return std::pow(x,2); Slower than:
     return x * x;
 }
 
-template<typename _Tp>
-inline const _Tp& min(const _Tp& a, const _Tp& b)
+template<typename T>
+inline const T& min(const T& a, const T& b)
 {
     return std::min(a, b);
 }
 
-template<typename _Tp>
-inline const _Tp& max(const _Tp& a, const _Tp& b)
+template<typename T, typename... ARGS>
+inline const T& min(const T& a, const T& b, const ARGS&... args)
+{
+    return min(min(a, b), args...);
+}
+
+template<typename T>
+inline const T& max(const T& a, const T& b)
 {
     return std::max(a, b);
 }
 
+template<typename T, typename... ARGS>
+inline const T& max(const T& a, const T& b, const ARGS&... args)
+{
+    return max(max(a, b), args...);
+}
 
-template<typename _Tp>
-inline const _Tp& LIM(const _Tp& a, const _Tp& b, const _Tp& c)
+template<typename T>
+inline const T& LIM(const T& a, const T& b, const T& c)
 {
     return std::max(b, std::min(a, c));
 }
 
-template<typename _Tp>
-inline _Tp LIM01(const _Tp& a)
+template<typename T>
+inline T LIM01(const T& a)
 {
-    return std::max(_Tp(0), std::min(a, _Tp(1)));
+    return std::max(T(0), std::min(a, T(1)));
 }
 
-template<typename _Tp>
-inline _Tp CLIP(const _Tp& a)
+template<typename T>
+inline T CLIP(const T& a)
 {
-    return LIM(a, static_cast<_Tp>(0), static_cast<_Tp>(MAXVAL));
+    return LIM(a, static_cast<T>(0), static_cast<T>(MAXVAL));
 }
 
-
-template<typename _Tp>
-inline const _Tp& min(const _Tp& a, const _Tp& b, const _Tp& c)
-{
-    return std::min(c, std::min(a, b));
-}
-
-template<typename _Tp>
-inline const _Tp& max(const _Tp& a, const _Tp& b, const _Tp& c)
-{
-    return std::max(c, std::max(a, b));
-}
-
-template<typename _Tp>
-inline const _Tp& min(const _Tp& a, const _Tp& b, const _Tp& c, const _Tp& d)
-{
-    return std::min(d, std::min(c, std::min(a, b)));
-}
-
-template<typename _Tp>
-inline const _Tp& max(const _Tp& a, const _Tp& b, const _Tp& c, const _Tp& d)
-{
-    return std::max(d, std::max(c, std::max(a, b)));
-}
-
-template<typename _Tp>
-inline _Tp intp(_Tp a, _Tp b, _Tp c)
+template<typename T>
+inline T intp(T a, T b, T c)
 {
     // calculate a * b + (1 - a) * c
     // following is valid:


### PR DESCRIPTION
This change allows for an arbitrary number of arguments to `min()` and `max()` by using recursion on variadic template functions. The disassembly of GCC 6.3 was carefully checked for regressions, but
nothing was found other than the flipping of arguments (recursion is now `(((a,b),c),d)` and was `(d,(c,(a,b)))` before).

I also unified the common type `_Tp` to to the even more common `T`.