### PR TITLE
Added support for autodetecting the system monitor color profile also on Linux

### DIFF
--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -304,57 +304,6 @@ public:
         }
     }
 
-    void findDefaultMonitorProfile()
-    {
-        // Determine the first monitor default profile of operating system, if selected
-
-        defaultMonitorProfile.clear();
-
-    #ifdef WIN32
-        // Get current main monitor. Could be fine tuned to get the current windows monitor(multi monitor setup),
-        // but problem is that we live in RTEngine with no GUI window to query around
-        HDC hDC = GetDC(nullptr);
-
-        if (hDC != nullptr) {
-            if (SetICMMode(hDC, ICM_ON)) {
-                char profileName[MAX_PATH + 1];
-                DWORD profileLength = MAX_PATH;
-
-                if (GetICMProfileA(hDC, &profileLength, profileName)) {
-                    defaultMonitorProfile = Glib::ustring(profileName);
-                    defaultMonitorProfile = Glib::path_get_basename(defaultMonitorProfile);
-                    size_t pos = defaultMonitorProfile.rfind(".");
-
-                    if (pos != Glib::ustring::npos) {
-                        defaultMonitorProfile = defaultMonitorProfile.substr(0, pos);
-                    }
-                }
-
-                // might fail if e.g. the monitor has no profile
-            }
-
-            ReleaseDC(NULL, hDC);
-        }
-
-    #else
-    // TODO: Add other OS specific code here
-    #endif
-
-        if (options.rtSettings.verbose) {
-            printf("Default monitor profile is: %s\n", defaultMonitorProfile.c_str());
-        }
-    }
-
-    cmsHPROFILE getDefaultMonitorProfile()
-    {
-        return getProfile(defaultMonitorProfile);
-    }
-
-    Glib::ustring getDefaultMonitorProfileName() const
-    {
-        return defaultMonitorProfile;
-    }
-
     cmsHPROFILE workingSpace(const Glib::ustring& name) const
     {
         const ProfileMap::const_iterator r = wProfiles.find(name);
@@ -626,21 +575,6 @@ rtengine::ICCStore* rtengine::ICCStore::getInstance()
 void rtengine::ICCStore::init(const Glib::ustring& usrICCDir, const Glib::ustring& stdICCDir, bool loadAll)
 {
     implementation->init(usrICCDir, stdICCDir, loadAll);
-}
-
-void rtengine::ICCStore::findDefaultMonitorProfile()
-{
-    implementation->findDefaultMonitorProfile();
-}
-
-cmsHPROFILE rtengine::ICCStore::getDefaultMonitorProfile() const
-{
-    return implementation->getDefaultMonitorProfile();
-}
-
-Glib::ustring rtengine::ICCStore::getDefaultMonitorProfileName() const
-{
-    return implementation->getDefaultMonitorProfileName();
 }
 
 cmsHPROFILE rtengine::ICCStore::workingSpace(const Glib::ustring& name) const

--- a/rtengine/iccstore.h
+++ b/rtengine/iccstore.h
@@ -68,11 +68,6 @@ public:
 
     void init(const Glib::ustring& usrICCDir, const Glib::ustring& stdICCDir, bool loadAll);
 
-    // Main monitors standard profile name, from OS
-    void          findDefaultMonitorProfile();
-    cmsHPROFILE   getDefaultMonitorProfile() const;
-    Glib::ustring getDefaultMonitorProfileName() const;
-
     cmsHPROFILE      workingSpace(const Glib::ustring& name) const;
     cmsHPROFILE      workingSpaceGamma(const Glib::ustring& name) const;
     TMatrix          workingSpaceMatrix(const Glib::ustring& name) const;

--- a/rtengine/init.cc
+++ b/rtengine/init.cc
@@ -41,7 +41,6 @@ int init (const Settings* s, Glib::ustring baseDir, Glib::ustring userSettingsDi
 {
     settings = s;
     ICCStore::getInstance()->init (s->iccDirectory, Glib::build_filename (baseDir, "iccprofiles"), loadAll);
-    ICCStore::getInstance()->findDefaultMonitorProfile();
     DCPStore::getInstance()->init (Glib::build_filename (baseDir, "dcpprofiles"), loadAll);
 
     CameraConstantsStore::getInstance ()->init (baseDir, userSettingsDir);

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -105,7 +105,7 @@ bool find_default_monitor_profile(GdkWindow *rootwin, Glib::ustring &defprof, Gl
     // * Copyright (C) 2006 John Ellis
     // * Copyright (C) 2008 - 2016 The Geeqie Team
     // 
-    guchar *prof;
+    guchar *prof = NULL;
     gint proflen;
     GdkAtom type = GDK_NONE;
     gint format = 0;

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -105,7 +105,7 @@ bool find_default_monitor_profile(GdkWindow *rootwin, Glib::ustring &defprof, Gl
     // * Copyright (C) 2006 John Ellis
     // * Copyright (C) 2008 - 2016 The Geeqie Team
     // 
-    guchar *prof = NULL;
+    guchar *prof = nullptr;
     gint proflen;
     GdkAtom type = GDK_NONE;
     gint format = 0;

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -112,7 +112,7 @@ bool find_default_monitor_profile(GdkWindow *rootwin, Glib::ustring &defprof, Gl
     if (gdk_property_get(rootwin, gdk_atom_intern("_ICC_PROFILE", FALSE), GDK_NONE, 0, 64 * 1024 * 1024, FALSE, &type, &format, &proflen, &prof) && proflen > 0) {
         cmsHPROFILE p = cmsOpenProfileFromMem(prof, proflen);
         if (p) {
-            defprofname = "GDK_ICC_PROFILE";
+            defprofname = "from GDK";
             defprof = Glib::build_filename(Options::rtdir, "GDK_ICC_PROFILE.icc");
             if (cmsSaveProfileToFile(p, defprof.c_str())) {
                 cmsCloseProfile(p);

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -756,11 +756,11 @@ Gtk::Widget* Preferences::getColorManagementPanel ()
     setExpandAlignProperties(monBPC, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     monBPC->set_active (true);
 
-#if defined(WIN32) // Auto-detection not implemented for Linux, see issue 851
+//#if defined(WIN32) // Auto-detection not implemented for Linux, see issue 851
     cbAutoMonProfile = Gtk::manage (new Gtk::CheckButton (M("PREFERENCES_AUTOMONPROFILE")));
     setExpandAlignProperties(cbAutoMonProfile, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     autoMonProfileConn  = cbAutoMonProfile->signal_toggled().connect (sigc::mem_fun(*this, &Preferences::autoMonProfileToggled));
-#endif
+//#endif
 
     int row = 0;
     gmonitor->attach (*mplabel, 0, row, 1, 1);
@@ -772,18 +772,18 @@ Gtk::Widget* Preferences::getColorManagementPanel ()
     gmonitor->attach (*monProfile, 1, row, 1, 1);
 #endif
     ++row;
-#if defined(WIN32)
+//#if defined(WIN32)
     gmonitor->attach (*cbAutoMonProfile, 1, row, 1, 1);
     ++row;
-#endif
+//#endif
     gmonitor->attach (*milabel, 0, row, 1, 1);
     gmonitor->attach (*monIntent, 1, row, 1, 1);
     ++row;
     gmonitor->attach (*monBPC, 0, row, 2, 1);
 
-#if defined(WIN32)
+//#if defined(WIN32)
     autoMonProfileToggled();
-#endif
+//#endif
 
     fmonitor->add(*gmonitor);
 
@@ -830,9 +830,9 @@ Gtk::Widget* Preferences::getColorManagementPanel ()
     ++row;
     gprinter->attach (*prtBPC, 0, row, 2, 1);
 
-#if defined(WIN32)
+//#if defined(WIN32)
     autoMonProfileToggled();
-#endif
+//#endif
 
     fprinter->add(*gprinter);
 
@@ -1677,9 +1677,9 @@ void Preferences::storePreferences ()
         break;
     }
     moptions.rtSettings.monitorBPC = monBPC->get_active ();
-#if defined(WIN32)
+//#if defined(WIN32)
     moptions.rtSettings.autoMonitorProfile  = cbAutoMonProfile->get_active ();
-#endif
+//#endif
 #endif
 
     moptions.rtSettings.iccDirectory        = iccDir->get_filename ();
@@ -1825,9 +1825,9 @@ void Preferences::fillPreferences ()
         break;
     }
     monBPC->set_active (moptions.rtSettings.monitorBPC);
-#if defined(WIN32)
+//#if defined(WIN32)
     cbAutoMonProfile->set_active(moptions.rtSettings.autoMonitorProfile);
-#endif
+//#endif
 #endif
 
     if (Glib::file_test (moptions.rtSettings.iccDirectory, Glib::FILE_TEST_IS_DIR)) {
@@ -2033,12 +2033,12 @@ void Preferences::savePressed () {
 }
 */
 
-#if defined(WIN32)
+//#if defined(WIN32)
 void Preferences::autoMonProfileToggled ()
 {
     monProfile->set_sensitive(!cbAutoMonProfile->get_active());
 }
-#endif
+//#endif
 /*
 void Preferences::autocielabToggled () {
 //  cbAutocielab->set_sensitive(cbAutocielab->get_active());


### PR DESCRIPTION
Code borrowed from Geeqie.

Works fine here, but please test in other environments, particularly on Windows since I don't have that (to make sure I did not break anything there)
