### PR TITLE
Pentax Pixel Shift: Added per channel brightness equalization

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -720,6 +720,7 @@ HISTORY_MSG_471;PS Motion correction
 HISTORY_MSG_472;PS Smooth transitions
 HISTORY_MSG_473;PS Use lmmse
 HISTORY_MSG_474;PS Equalize
+HISTORY_MSG_475;PS Equalize channel
 HISTORY_NEWSNAPSHOT;Add
 HISTORY_NEWSNAPSHOT_TOOLTIP;Shortcut: <b>Alt-s</b>
 HISTORY_SNAPSHOT;Snapshot
@@ -1728,6 +1729,8 @@ TP_RAW_PIXELSHIFTEPERISO;ISO adaption
 TP_RAW_PIXELSHIFTEPERISO_TOOLTIP;The default value (0.0) should work fine for base ISO.\nIncrease the value to improve motion detection for higher ISO.\nIncrease in small steps and watch the motion mask while increasing.
 TP_RAW_PIXELSHIFTEQUALBRIGHT;Equalize brightness of frames
 TP_RAW_PIXELSHIFTEQUALBRIGHT_TOOLTIP;Equalize the brightness of the frames to the brightness of the selected frame.\nIf there are overexposed areas in the frames select the brightest frame to avoid magenta colour cast in overexposed areas or enable motion correction.
+TP_RAW_PIXELSHIFTEQUALBRIGHTCHANNEL;Equalize per channel
+TP_RAW_PIXELSHIFTEQUALBRIGHTCHANNEL_TOOLTIP;Enabled: Equalize the channels (RGB) individually.\nDisabled: Use same equalization factor for all channels.
 TP_RAW_PIXELSHIFTEXP0;Experimental
 TP_RAW_PIXELSHIFTGREEN;Check green channel for motion
 TP_RAW_PIXELSHIFTHOLEFILL;Fill holes in motion mask

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -501,6 +501,7 @@ enum ProcEvent {
     EvPixelShiftSmooth = 471,
     EvPixelShiftLmmse = 472,
     EvPixelShiftEqualBright = 473,
+    EvPixelShiftEqualBrightChannel = 474,
     NUMOFEVENTS
 
 };

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -901,6 +901,7 @@ void RAWParams::BayerSensor::setPixelShiftDefaults()
     pixelShiftExp0 = false;
     pixelShiftLmmse = false;
     pixelShiftEqualBright = false;
+    pixelShiftEqualBrightChannel = false;
     pixelShiftNonGreenCross = true;
     pixelShiftNonGreenCross2 = false;
     pixelShiftNonGreenAmaze = false;
@@ -3505,6 +3506,10 @@ int ProcParams::save (const Glib::ustring &fname, const Glib::ustring &fname2, b
 
         if (!pedited || pedited->raw.bayersensor.pixelShiftEqualBright) {
             keyFile.set_boolean ("RAW Bayer", "pixelShiftEqualBright", raw.bayersensor.pixelShiftEqualBright );
+        }
+
+        if (!pedited || pedited->raw.bayersensor.pixelShiftEqualBrightChannel) {
+            keyFile.set_boolean ("RAW Bayer", "pixelShiftEqualBrightChannel", raw.bayersensor.pixelShiftEqualBrightChannel );
         }
 
         if (!pedited || pedited->raw.bayersensor.pixelShiftNonGreenCross) {
@@ -7791,6 +7796,14 @@ int ProcParams::load (const Glib::ustring &fname, ParamsEdited* pedited)
                 }
             }
 
+            if (keyFile.has_key ("RAW Bayer", "pixelShiftEqualBrightChannel"))  {
+                raw.bayersensor.pixelShiftEqualBrightChannel = keyFile.get_boolean("RAW Bayer", "pixelShiftEqualBrightChannel");
+
+                if (pedited) {
+                    pedited->raw.bayersensor.pixelShiftEqualBrightChannel = true;
+                }
+            }
+
             if (keyFile.has_key ("RAW Bayer", "pixelShiftNonGreenCross"))  {
                 raw.bayersensor.pixelShiftNonGreenCross = keyFile.get_boolean("RAW Bayer", "pixelShiftNonGreenCross");
 
@@ -8278,6 +8291,7 @@ bool ProcParams::operator== (const ProcParams& other)
         && raw.bayersensor.pixelShiftExp0 == other.raw.bayersensor.pixelShiftExp0
         && raw.bayersensor.pixelShiftLmmse == other.raw.bayersensor.pixelShiftLmmse
         && raw.bayersensor.pixelShiftEqualBright == other.raw.bayersensor.pixelShiftEqualBright
+        && raw.bayersensor.pixelShiftEqualBrightChannel == other.raw.bayersensor.pixelShiftEqualBrightChannel
         && raw.bayersensor.pixelShiftNonGreenCross == other.raw.bayersensor.pixelShiftNonGreenCross
         && raw.bayersensor.pixelShiftNonGreenCross2 == other.raw.bayersensor.pixelShiftNonGreenCross2
         && raw.bayersensor.pixelShiftNonGreenAmaze == other.raw.bayersensor.pixelShiftNonGreenAmaze

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1235,6 +1235,7 @@ public:
         bool pixelShiftExp0;
         bool pixelShiftLmmse;
         bool pixelShiftEqualBright;
+        bool pixelShiftEqualBrightChannel;
         bool pixelShiftNonGreenCross;
         bool pixelShiftNonGreenCross2;
         bool pixelShiftNonGreenAmaze;

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -500,7 +500,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     DEMOSAIC,         // EvPixelShiftMotionMethod
     DEMOSAIC,         // EvPixelShiftSmooth
     DEMOSAIC,         // EvPixelShiftLmmse
-    DEMOSAIC          // EvPixelShiftEqualBright
+    DEMOSAIC,         // EvPixelShiftEqualBright
+    DEMOSAIC          // EvPixelShiftEqualBrightChannel
 
 };
 

--- a/rtgui/bayerprocess.cc
+++ b/rtgui/bayerprocess.cc
@@ -101,6 +101,11 @@ BayerProcess::BayerProcess () : FoldableToolPanel(this, "bayerprocess", M("TP_RA
     pixelShiftEqualBright->set_tooltip_text (M("TP_RAW_PIXELSHIFTEQUALBRIGHT_TOOLTIP"));
     pixelShiftFrame->pack_start(*pixelShiftEqualBright);
 
+    pixelShiftEqualBrightChannel = Gtk::manage (new CheckBox(M("TP_RAW_PIXELSHIFTEQUALBRIGHTCHANNEL"), multiImage));
+    pixelShiftEqualBrightChannel->setCheckBoxListener (this);
+    pixelShiftEqualBrightChannel->set_tooltip_text (M("TP_RAW_PIXELSHIFTEQUALBRIGHTCHANNEL_TOOLTIP"));
+    pixelShiftFrame->pack_start(*pixelShiftEqualBrightChannel);
+
     Gtk::HBox* hb3 = Gtk::manage (new Gtk::HBox ());
     hb3->pack_start (*Gtk::manage (new Gtk::Label ( M("TP_RAW_PIXELSHIFTMOTIONMETHOD") + ": ")), Gtk::PACK_SHRINK, 4);
     pixelShiftMotionMethod = Gtk::manage (new MyComboBoxText ());
@@ -372,6 +377,8 @@ void BayerProcess::read(const rtengine::procparams::ProcParams* pp, const Params
     pixelShiftSmooth->setValue (pp->raw.bayersensor.pixelShiftSmoothFactor);
     pixelShiftLmmse->setValue (pp->raw.bayersensor.pixelShiftLmmse);
     pixelShiftEqualBright->setValue (pp->raw.bayersensor.pixelShiftEqualBright);
+    pixelShiftEqualBrightChannel->set_sensitive (pp->raw.bayersensor.pixelShiftEqualBright);
+    pixelShiftEqualBrightChannel->setValue (pp->raw.bayersensor.pixelShiftEqualBrightChannel);
     pixelShiftNonGreenCross->setValue (pp->raw.bayersensor.pixelShiftNonGreenCross);
     ccSteps->setValue (pp->raw.bayersensor.ccSteps);
     lmmseIterations->setValue (pp->raw.bayersensor.lmmse_iterations);
@@ -421,6 +428,7 @@ void BayerProcess::read(const rtengine::procparams::ProcParams* pp, const Params
         pixelShiftSmooth->setEditedState ( pedited->raw.bayersensor.pixelShiftSmooth ? Edited : UnEdited);
         pixelShiftLmmse->setEdited (pedited->raw.bayersensor.pixelShiftLmmse);
         pixelShiftEqualBright->setEdited (pedited->raw.bayersensor.pixelShiftEqualBright);
+        pixelShiftEqualBrightChannel->setEdited (pedited->raw.bayersensor.pixelShiftEqualBrightChannel);
         pixelShiftNonGreenCross->setEdited (pedited->raw.bayersensor.pixelShiftNonGreenCross);
         lmmseIterations->setEditedState ( pedited->raw.bayersensor.lmmseIterations ? Edited : UnEdited);
         pixelShiftEperIso->setEditedState ( pedited->raw.bayersensor.pixelShiftEperIso ? Edited : UnEdited);
@@ -524,6 +532,7 @@ void BayerProcess::write( rtengine::procparams::ProcParams* pp, ParamsEdited* pe
     pp->raw.bayersensor.pixelShiftSmoothFactor = pixelShiftSmooth->getValue();
     pp->raw.bayersensor.pixelShiftLmmse = pixelShiftLmmse->getLastActive ();
     pp->raw.bayersensor.pixelShiftEqualBright = pixelShiftEqualBright->getLastActive ();
+    pp->raw.bayersensor.pixelShiftEqualBrightChannel = pixelShiftEqualBrightChannel->getLastActive ();
     pp->raw.bayersensor.pixelShiftNonGreenCross = pixelShiftNonGreenCross->getLastActive ();
 #ifdef PIXELSHIFTDEV
     pp->raw.bayersensor.pixelShiftStddevFactorGreen = pixelShiftStddevFactorGreen->getValue();
@@ -575,6 +584,7 @@ void BayerProcess::write( rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         pedited->raw.bayersensor.pixelShiftSmooth = pixelShiftSmooth->getEditedState();
         pedited->raw.bayersensor.pixelShiftLmmse = !pixelShiftLmmse->get_inconsistent();
         pedited->raw.bayersensor.pixelShiftEqualBright = !pixelShiftEqualBright->get_inconsistent();
+        pedited->raw.bayersensor.pixelShiftEqualBrightChannel = !pixelShiftEqualBrightChannel->get_inconsistent();
         pedited->raw.bayersensor.pixelShiftNonGreenCross = !pixelShiftNonGreenCross->get_inconsistent();
 #ifdef PIXELSHIFTDEV
         pedited->raw.bayersensor.pixelShiftStddevFactorGreen = pixelShiftStddevFactorGreen->getEditedState ();
@@ -839,8 +849,15 @@ void BayerProcess::checkBoxToggled (CheckBox* c, CheckValue newval)
             listener->panelChanged (EvPixelShiftLmmse, pixelShiftLmmse->getValueAsStr ());
         }
     } else if (c == pixelShiftEqualBright) {
+        if (!batchMode) {
+            pixelShiftEqualBrightChannel->set_sensitive(newval != CheckValue::off);
+        }
         if (listener) {
             listener->panelChanged (EvPixelShiftEqualBright, pixelShiftEqualBright->getValueAsStr ());
+        }
+    } else if (c == pixelShiftEqualBrightChannel) {
+        if (listener) {
+            listener->panelChanged (EvPixelShiftEqualBrightChannel, pixelShiftEqualBrightChannel->getValueAsStr ());
         }
     } else if (c == pixelShiftNonGreenCross) {
         if (listener) {

--- a/rtgui/bayerprocess.h
+++ b/rtgui/bayerprocess.h
@@ -51,6 +51,7 @@ protected:
     CheckBox* pixelShiftMedian;
     CheckBox* pixelShiftLmmse;
     CheckBox* pixelShiftEqualBright;
+    CheckBox* pixelShiftEqualBrightChannel;
     Adjuster* pixelShiftSmooth;
     Adjuster* pixelShiftEperIso;
     Adjuster* pixelShiftSigma;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -397,6 +397,7 @@ void ParamsEdited::set (bool v)
     raw.bayersensor.pixelShiftExp0 = v;
     raw.bayersensor.pixelShiftLmmse = v;
     raw.bayersensor.pixelShiftEqualBright = v;
+    raw.bayersensor.pixelShiftEqualBrightChannel = v;
     raw.bayersensor.pixelShiftNonGreenCross = v;
     raw.bayersensor.pixelShiftNonGreenCross2 = v;
     raw.bayersensor.pixelShiftNonGreenAmaze = v;
@@ -923,6 +924,7 @@ void ParamsEdited::initFrom (const std::vector<rtengine::procparams::ProcParams>
         raw.bayersensor.pixelShiftExp0 = raw.bayersensor.pixelShiftExp0 && p.raw.bayersensor.pixelShiftExp0 == other.raw.bayersensor.pixelShiftExp0;
         raw.bayersensor.pixelShiftLmmse = raw.bayersensor.pixelShiftLmmse && p.raw.bayersensor.pixelShiftLmmse == other.raw.bayersensor.pixelShiftLmmse;
         raw.bayersensor.pixelShiftEqualBright = raw.bayersensor.pixelShiftEqualBright && p.raw.bayersensor.pixelShiftEqualBright == other.raw.bayersensor.pixelShiftEqualBright;
+        raw.bayersensor.pixelShiftEqualBrightChannel = raw.bayersensor.pixelShiftEqualBrightChannel && p.raw.bayersensor.pixelShiftEqualBrightChannel == other.raw.bayersensor.pixelShiftEqualBrightChannel;
         raw.bayersensor.pixelShiftNonGreenCross = raw.bayersensor.pixelShiftNonGreenCross && p.raw.bayersensor.pixelShiftNonGreenCross == other.raw.bayersensor.pixelShiftNonGreenCross;
         raw.bayersensor.pixelShiftNonGreenCross2 = raw.bayersensor.pixelShiftNonGreenCross2 && p.raw.bayersensor.pixelShiftNonGreenCross2 == other.raw.bayersensor.pixelShiftNonGreenCross2;
         raw.bayersensor.pixelShiftNonGreenAmaze = raw.bayersensor.pixelShiftNonGreenAmaze && p.raw.bayersensor.pixelShiftNonGreenAmaze == other.raw.bayersensor.pixelShiftNonGreenAmaze;
@@ -2446,6 +2448,10 @@ void ParamsEdited::combine (rtengine::procparams::ProcParams& toEdit, const rten
         toEdit.raw.bayersensor.pixelShiftEqualBright = mods.raw.bayersensor.pixelShiftEqualBright;
     }
 
+    if (raw.bayersensor.pixelShiftEqualBrightChannel) {
+        toEdit.raw.bayersensor.pixelShiftEqualBrightChannel = mods.raw.bayersensor.pixelShiftEqualBrightChannel;
+    }
+
     if (raw.bayersensor.pixelShiftNonGreenCross) {
         toEdit.raw.bayersensor.pixelShiftNonGreenCross = mods.raw.bayersensor.pixelShiftNonGreenCross;
     }
@@ -2970,7 +2976,7 @@ bool RAWParamsEdited::BayerSensor::isUnchanged() const
     return  method && imageNum && dcbIterations && dcbEnhance && lmmseIterations/*&& allEnhance*/ &&  greenEq
             && pixelShiftMotion && pixelShiftMotionCorrection && pixelShiftMotionCorrectionMethod && pixelShiftStddevFactorGreen && pixelShiftStddevFactorRed && pixelShiftStddevFactorBlue && pixelShiftEperIso
             && pixelShiftNreadIso && pixelShiftPrnu && pixelShiftSigma && pixelShiftSum && pixelShiftRedBlueWeight && pixelShiftShowMotion && pixelShiftShowMotionMaskOnly
-            && pixelShiftAutomatic && pixelShiftNonGreenHorizontal && pixelShiftNonGreenVertical && pixelShiftHoleFill && pixelShiftMedian && pixelShiftMedian3 && pixelShiftNonGreenCross && pixelShiftNonGreenCross2 && pixelShiftNonGreenAmaze && pixelShiftGreen && pixelShiftBlur && pixelShiftSmooth && pixelShiftExp0 && pixelShiftLmmse && pixelShiftEqualBright
+            && pixelShiftAutomatic && pixelShiftNonGreenHorizontal && pixelShiftNonGreenVertical && pixelShiftHoleFill && pixelShiftMedian && pixelShiftMedian3 && pixelShiftNonGreenCross && pixelShiftNonGreenCross2 && pixelShiftNonGreenAmaze && pixelShiftGreen && pixelShiftBlur && pixelShiftSmooth && pixelShiftExp0 && pixelShiftLmmse && pixelShiftEqualBright && pixelShiftEqualBrightChannel
             && linenoise && exBlack0 && exBlack1 && exBlack2 && exBlack3 && exTwoGreen;
 }
 

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -718,6 +718,7 @@ public:
         bool pixelShiftExp0;
         bool pixelShiftLmmse;
         bool pixelShiftEqualBright;
+        bool pixelShiftEqualBrightChannel;
         bool pixelShiftNonGreenCross;
         bool pixelShiftNonGreenCross2;
         bool pixelShiftNonGreenAmaze;


### PR DESCRIPTION
I added an improvement for some special cases of Pixel Shift shots where the light changed from frame to frame. That happens for example when shooting at sunset/sundown or when shooting while for example a cloud hides the sun for one shot, but not all.

Here's an example which shows the improvement which is already in dev:
Left is without equalization of frame brightness, right with the current global equalization of brightness
As you can see, there are still some vertical stripes in the orange part of the right.

![ps_stripes_00](https://cloud.githubusercontent.com/assets/13733487/24877586/1185ff78-1e30-11e7-993f-626d5dc250ec.png)

I added an option to equalize the brightness per colour-channel.
Left is with global (channel independent) equalization of frame brightness, right with the new per-channel equalization.
As you can see, the stripes are almost gone.

![ps_stripes_01](https://cloud.githubusercontent.com/assets/13733487/24877728/a02c2d6a-1e30-11e7-914a-192e247f14e2.png)

If there are no objections, I would like to merge that into dev for 5.1

Ingo