### PR TITLE
LCP tweaks

### DIFF
--- a/rtengine/lcp.cc
+++ b/rtengine/lcp.cc
@@ -28,10 +28,17 @@
 #include <shlobj.h>
 #endif
 
+#include "settings.h"
 
 using namespace std;
 using namespace rtengine;
 
+
+namespace rtengine {
+
+extern const Settings* settings;
+
+}
 
 LCPModelCommon::LCPModelCommon() :
     foc_len_x(-1.0f),
@@ -603,7 +610,9 @@ void LCPProfile::calcParams(int mode, float focalLength, float focusDist, float 
 
         //printf("LCP mode=%i, dist: %g found frames: Fno %g-%g; FocLen %g-%g; Dist %g-%g with weight %g\n", mode, focusDist, pLow->aperture, pHigh->aperture, pLow->focLen, pHigh->focLen, pLow->focDist, pHigh->focDist, facLow);
     } else {
-        printf("Error: LCP file contained no %s parameters\n", mode == 0 ? "vignette" : mode == 1 ? "distortion" : "CA" );
+        if (settings->verbose) {
+            printf("Error: LCP file contained no %s parameters\n", mode == 0 ? "vignette" : mode == 1 ? "distortion" : "CA" );
+        }
     }
 }
 

--- a/rtgui/lensgeom.cc
+++ b/rtgui/lensgeom.cc
@@ -119,28 +119,3 @@ void LensGeometry::setBatchMode (bool batchMode)
     removeIfThere (this, autoCrop);
 }
 
-void LensGeometry::disableAutoFillIfActive ()
-{
-    const auto func = [](gpointer data) -> gboolean {
-        GThreadLock lock; // Is this really needed?
-
-        LensGeometry* const instance = static_cast<LensGeometry*>(data);
-
-        if (!instance->batchMode) {
-            if (instance->fill->get_active()) {
-                instance->fillConn.block(true);
-                instance->fill->set_active(false);
-
-                if (instance->listener) {
-                    instance->listener->panelChanged (EvTransAutoFill, M("GENERAL_DISABLED"));
-                }
-
-                instance->fillConn.block(false);
-            }
-        }
-
-        return FALSE;
-    };
-
-    idle_register.add(func, this);
-}

--- a/rtgui/lensgeom.h
+++ b/rtgui/lensgeom.h
@@ -54,7 +54,6 @@ public:
     {
         rlistener = l;
     }
-    void disableAutoFillIfActive ();
 
 private:
     IdleRegister idle_register;

--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -48,7 +48,10 @@ LensProfilePanel::LensProfilePanel () : FoldableToolPanel(this, "lensprof", M("T
         fcbLCPFile->set_show_hidden(true);  // ProgramData is hidden on Windows
 #endif
         fcbLCPFile->set_current_folder(defDir);
+    } else if (!options.lastLensProfileDir.empty()) {
+        fcbLCPFile->set_current_folder(options.lastLensProfileDir);
     }
+    bindCurrentFolder(*fcbLCPFile, options.lastLensProfileDir);
 
     hbLCPFile->pack_start(*fcbLCPFile);
 
@@ -89,8 +92,9 @@ void LensProfilePanel::read(const rtengine::procparams::ProcParams* pp, const Pa
             fcbLCPFile->unselect_filename(fname);
         } else {
             Glib::ustring lastFolder = fcbLCPFile->get_current_folder();
-            fcbLCPFile->set_filename("");
             fcbLCPFile->set_current_folder(lastFolder);
+            fcbLCPFile->set_filename(lastFolder + "/.");
+            bindCurrentFolder(*fcbLCPFile, options.lastLensProfileDir);
         }
 
         updateDisabled(false);

--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -144,10 +144,6 @@ void LensProfilePanel::write( rtengine::procparams::ProcParams* pp, ParamsEdited
 
 void LensProfilePanel::onLCPFileChanged()
 {
-
-    // Disable Auto-Fill when enabling LCP Distortion Correction, #1791
-    lensgeomLcpFill->disableAutoFillIfActive();
-
     lcpFileChanged = true;
     updateDisabled(lcpStore->isValidLCPFileName(fcbLCPFile->get_filename()));
 
@@ -170,12 +166,6 @@ void LensProfilePanel::onLCPFileReset()
 
 void LensProfilePanel::onUseDistChanged()
 {
-
-    // Disable Auto-Fill when enabling LCP Distortion Correction, #1791
-    if (ckbUseDist->get_active()) {
-        lensgeomLcpFill->disableAutoFillIfActive();
-    }
-
     useDistChanged = true;
 
     if (listener) {

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -711,6 +711,7 @@ void Options::setDefaults ()
     lastVibranceCurvesDir = "";
     lastProfilingReferenceDir = "";
     lastBWCurvesDir = "";
+    lastLensProfileDir = "";
     maxRecentFolders = 15;
 }
 
@@ -1806,6 +1807,7 @@ int Options::readFromFile (Glib::ustring fname)
                 safeDirGet (keyFile, "Dialogs", "LastToneCurvesDir", lastToneCurvesDir);
                 safeDirGet (keyFile, "Dialogs", "LastVibranceCurvesDir", lastVibranceCurvesDir);
                 safeDirGet (keyFile, "Dialogs", "LastProfilingReferenceDir", lastProfilingReferenceDir);
+                safeDirGet (keyFile, "Dialogs", "LastLensProfileDir", lastLensProfileDir);
             }
 
 // --------------------------------------------------------------------------------------------------------
@@ -2162,6 +2164,7 @@ int Options::saveToFile (Glib::ustring fname)
         keyFile.set_string ("Dialogs", "LastToneCurvesDir", lastToneCurvesDir);
         keyFile.set_string ("Dialogs", "LastVibranceCurvesDir", lastVibranceCurvesDir);
         keyFile.set_string ("Dialogs", "LastProfilingReferenceDir", lastProfilingReferenceDir);
+        keyFile.set_string ("Dialogs", "LastLensProfileDir", lastLensProfileDir);
 
         keyData = keyFile.to_data ();
 

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -306,6 +306,7 @@ public:
     Glib::ustring lastVibranceCurvesDir;
     Glib::ustring lastProfilingReferenceDir;
     Glib::ustring lastBWCurvesDir;
+    Glib::ustring lastLensProfileDir;
 
     size_t maxRecentFolders;                   // max. number of recent folders stored in options file
     std::vector<Glib::ustring> recentFolders;  // List containing all recent folders


### PR DESCRIPTION
A couple of tweaks to the UI for Lens Correction Profiles.
The most significant one is the removal of the workaround for #1791 (#3318), since now that bug has been fixed (see #3765) 