### PR TITLE
Font too large on Apple Retina/HiDPI & default font erroneously set to None

### DIFF
--- a/rtdata/options/options.osx
+++ b/rtdata/options/options.osx
@@ -24,7 +24,8 @@ PathTemplate=%p1/converted/%f
 CustomProfileBuilder=
 
 [GUI]
-Font=Sans 12
+FontFamily=Arial Regular
+FontSize=12
 
 # Set here an absolute or relative path (to the rawtherapee.exe file) to the directory containing your own profiles.
 # If MultiUser=true, each user will have their own "options" file, and can set a common or different absolu path

--- a/rtdata/options/options.osx
+++ b/rtdata/options/options.osx
@@ -23,10 +23,6 @@ PathTemplate=%p1/converted/%f
 # Parameters: <Path to raw/JPG> <Path to default profile> <fNumber> <expose in seconds> <focal length in mm> <ISO> <Lens> <Camera>
 CustomProfileBuilder=
 
-[GUI]
-FontFamily=Arial Regular
-FontSize=12
-
 # Set here an absolute or relative path (to the rawtherapee.exe file) to the directory containing your own profiles.
 # If MultiUser=true, each user will have their own "options" file, and can set a common or different absolu path
 #Directory=profiles
@@ -40,3 +36,7 @@ FontSize=12
 
 # Default profile name (without extension) to use for standard (8bits) images
 #ImgDefault=Neutral
+
+[GUI]
+FontFamily=Helvetica Regular
+CPFontFamily=Helvetica Regular

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -254,6 +254,15 @@ RTWindow *create_rt_window()
         Gtk::Settings::get_for_screen(screen)->property_gtk_theme_name() = "Adwaita";
         Gtk::Settings::get_for_screen(screen)->property_gtk_application_prefer_dark_theme() = true;
 
+#if defined(__APPLE__)
+        double resolution = screen->get_resolution ();
+        printf("Screen resolution is %.1f", (float)resolution);
+
+        // This will force screen resolution regarding font, but I don't think it's compliant with Gtk guidelines...
+        // Do not confuse with screen scaling, where everything is scaled up !
+        screen->set_resolution (96.);
+#endif
+
         Glib::RefPtr<Glib::Regex> regex = Glib::Regex::create(THEMEREGEXSTR, Glib::RegexCompileFlags::REGEX_CASELESS);
         Glib::ustring filename = Glib::build_filename(argv0, "themes", options.theme + ".css");
         if (!regex->match(options.theme + ".css") || !Glib::file_test(filename, Glib::FILE_TEST_EXISTS)) {

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -255,9 +255,6 @@ RTWindow *create_rt_window()
         Gtk::Settings::get_for_screen(screen)->property_gtk_application_prefer_dark_theme() = true;
 
 #if defined(__APPLE__)
-        double resolution = screen->get_resolution ();
-        printf("Screen resolution is %.1f", (float)resolution);
-
         // This will force screen resolution regarding font, but I don't think it's compliant with Gtk guidelines...
         // Do not confuse with screen scaling, where everything is scaled up !
         screen->set_resolution (96.);


### PR DESCRIPTION
@Hombre57's patch for font issues https://github.com/Beep6581/RawTherapee/issues/3984