### PR TITLE
Load & save PP3 files with data type information (Issue #3980).

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -29,6 +29,7 @@ Developement contributors, in last name alphabetical order:
   Jan Rinze
   Ben S.
   Andrey Skvortsov
+  Lukas Stratmann
   Fabio Suprani
   Anders Torger
   Ingo Weyrich

--- a/rtengine/CMakeLists.txt
+++ b/rtengine/CMakeLists.txt
@@ -80,6 +80,7 @@ set(RTENGINESOURCEFILES
     ipwavelet.cc
     jdatasrc.cc
     jpeg_ijg/jpeg_memsrc.cc
+    keyfile_wrapper.cc
     klt/convolve.cc
     klt/error.cc
     klt/klt.cc

--- a/rtengine/keyfile_wrapper.cc
+++ b/rtengine/keyfile_wrapper.cc
@@ -1,0 +1,199 @@
+#include "keyfile_wrapper.h"
+#include <string>
+#include <sstream>
+
+#include <iostream>
+
+namespace rtengine {
+    
+    const Glib::ustring KeyFileWrapper::INT64_PREFIX("int64");
+    
+    const Glib::ustring KeyFileWrapper::UINT64_PREFIX("uint64");
+    
+    const Glib::ustring KeyFileWrapper::BOOL_LIST_PREFIX("bools");
+    
+    const Glib::ustring KeyFileWrapper::INT_LIST_PREFIX("ints");
+    
+    const Glib::ustring KeyFileWrapper::DOUBLE_LIST_PREFIX("doubles");
+    
+    const Glib::ustring KeyFileWrapper::STRING_LIST_PREFIX("strings");
+    
+    KeyFileWrapper::KeyFileWrapper() {
+        // nothing to do here yet
+    }
+    
+    Glib::KeyFile& KeyFileWrapper::getKeyFile() {
+        return keyFile;
+    }
+    
+    /**
+     * Extracts the string between the first opening and the last closing parenthesis.
+     * Example: `extract_from_parentheses("data(Hello world!)")` should return
+     * "Hello world!".
+     */
+    bool KeyFileWrapper::extract_from_parentheses(
+            const std::string& s,
+            std::string& target,
+            std::string open_bracket,
+            std::string close_bracket
+    ) {
+        size_t pos_open = s.find_first_of(open_bracket);
+        size_t pos_close = s.find_last_of(close_bracket);
+        if (pos_open == std::string::npos || pos_close == std::string::npos) {
+            return false;
+        }
+        target = s.substr(pos_open + 1, pos_close - pos_open - 1);
+        return true;
+    }
+    
+    Glib::ustring KeyFileWrapper::read_string_list(const Glib::ustring& in) {
+        std::istringstream string_list_stream(in);
+        std::ostringstream out;
+        
+        std::string extracted_item;
+        for (std::string item; std::getline(string_list_stream, item, ';');) {
+            // TODO: Respect escape sequences like "\;"! (Not needed in current version of RT)
+            extract_from_parentheses(item, extracted_item, "\"", "\"");
+            out << extracted_item << ';';
+        }
+        
+        return out.str();
+    }
+    
+    bool KeyFileWrapper::load_from_data(const Glib::ustring& data) {
+        std::istringstream data_in(data);
+        std::ostringstream data_out;
+        
+        /* Prepare data: Omit everything that's not standard key file syntax. */
+        std::string key, value_in, value_out;
+        for (std::string line; std::getline(data_in, line);) {
+            if (line.find_first_not_of("\t\n\v\f\r") == std::string::npos) {
+                continue;
+            }
+            
+            std::istringstream line_stream(line);
+            if (!std::getline(line_stream, key, '=') ||
+                !std::getline(line_stream, value_in, '=') ||
+                (line.size() > 0 && line[0] == '#')
+            ) {
+                // Line cannot be split into key/value or line is a comment.
+                data_out << line << std::endl;
+                continue;
+            }
+            
+            // Whitespace around '=' should be ignored.
+            // Remove leading/trailing whitespace for easier comparison.
+            value_in = g_strstrip(&value_in[0]);
+            
+            if (value_in.size() > 0 && value_in[0] == '"' &&
+                extract_from_parentheses(value_in, value_out, "\"", "\"")
+            ) {
+                // value_in is formatted as string
+                data_out << key << '=' << value_out << std::endl;
+                continue;
+            }
+            
+            if (extract_from_parentheses(value_in, value_out)) {
+                // value_in is of the form "data_type(content)"
+                if (!value_in.compare(0, STRING_LIST_PREFIX.size(), STRING_LIST_PREFIX)) {
+                    // content in parentheses is a list of strings, strings still need to be extracted
+                    data_out << key << '=' << read_string_list(value_out) << std::endl;
+                    continue;
+                }
+                data_out << key << '=' << value_out << std::endl;
+                continue;
+            }
+            
+            // value_in is a regular int, boolean, or a legacy value (e.g. string without quotation marks).
+            data_out << key << '=' << value_in << std::endl;
+        }
+        
+        /* Now data_out should look exactly like any other key file content. */
+        return keyFile.load_from_data(data_out.str());
+    }
+    
+    Glib::ustring KeyFileWrapper::to_data() {
+        return keyFile.to_data();
+    }
+    
+    void KeyFileWrapper::set_boolean(const Glib::ustring& group_name, const Glib::ustring& key, bool value) {
+        /* Booleans are stored unchanged. */
+        keyFile.set_boolean(group_name, key, value);
+    }
+    
+    void KeyFileWrapper::set_double(const Glib::ustring& group_name, const Glib::ustring& key, double value) {
+        /* Doubles must contain a decimal point. */
+        std::ostringstream ss;
+        ss << std::showpoint << value;
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_integer(const Glib::ustring& group_name, const Glib::ustring& key, int value) {
+        /* Integers are stored unchanged. */
+        keyFile.set_integer(group_name, key, value);
+    }
+    
+    void KeyFileWrapper::set_int64(const Glib::ustring& group_name, const Glib::ustring& key, gint64 value) {
+        /* 64-bit integers must be enclosed with "int64()". */
+        std::ostringstream ss;
+        ss << INT64_PREFIX << '(' << value << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_uint64(const Glib::ustring& group_name, const Glib::ustring& key, guint64 value) {
+        /* 64-bit integers must be enclosed with "int64()". */
+        std::ostringstream ss;
+        ss << UINT64_PREFIX << '(' << value << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_string(const Glib::ustring& group_name, const Glib::ustring& key, const Glib::ustring& string) {
+        /* Strings must be surrounded with quotation marks. */
+        std::ostringstream ss;
+        ss << "\"" << string << "\"";
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_boolean_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<bool>&  list) {
+        std::ostringstream ss;
+        ss << BOOL_LIST_PREFIX << '(';
+        ss << std::boolalpha;
+        for (const bool& b : list) {
+            ss << b << ";";
+        }
+        ss << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_double_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<double>&  list) {
+        std::ostringstream ss;
+        ss << DOUBLE_LIST_PREFIX << '(';
+        ss << std::showpoint;
+        for (const double& d : list) {
+            ss << d << ";";
+        }
+        ss << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_integer_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<int>&  list) {
+        std::ostringstream ss;
+        ss << INT_LIST_PREFIX << '(';
+        for (const int& i : list) {
+            ss << i << ";";
+        }
+        ss << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+    void KeyFileWrapper::set_string_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<Glib::ustring>&  list) {
+        std::ostringstream ss;
+        ss << STRING_LIST_PREFIX << '(';
+        for (const Glib::ustring& s : list) {
+            ss << "\"" << s << "\";";
+        }
+        ss << ')';
+        keyFile.set_string(group_name, key, ss.str());
+    }
+    
+}

--- a/rtengine/keyfile_wrapper.h
+++ b/rtengine/keyfile_wrapper.h
@@ -16,8 +16,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef _MYFILE_
-#define _MYFILE_
+#ifndef _KEYFILEWRAPPER_
+#define _KEYFILEWRAPPER_
 
 #include <glib.h>
 #include <glibmm.h>

--- a/rtengine/keyfile_wrapper.h
+++ b/rtengine/keyfile_wrapper.h
@@ -1,0 +1,144 @@
+/*
+ *  This file is part of RawTherapee.
+ *
+ *  Copyright (c) 2004-2010 Gabor Horvath <hgabor@rawtherapee.com>
+ *
+ *  RawTherapee is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RawTherapee is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef _MYFILE_
+#define _MYFILE_
+
+#include <glib.h>
+#include <glibmm.h>
+#include <vector>
+
+namespace rtengine {
+
+    /**
+     * This is a wrapper class for the GNOME glibmm Glib::KeyFile class
+     * that reads and outputs strongly typed key files.
+     * 
+     * Key files saved with the original Glib::KeyFile class do not allow foreign
+     * applications to determine the data type of a given key-value pair.
+     * For example, saving an integer with value 42 would yield the same result
+     * as saving the string "42".
+     * This wrapper class makes the following changes to the syntax of key files:
+     * 
+     * @code
+     * # Strings must be enclosed in quotation marks.
+     * # (Inner quotation marks need not be escaped, for now.)
+     * StringKey="StringValue"
+     * # Regular integers are unchanged.
+     * IntKey=42
+     * # Booleans are unchanged.
+     * BoolKey=true
+     * # Double values must contain a decimal point. The decimal point need not be
+     * # followed by another digit.
+     * DoubleKey=42.
+     * # 64-bit integers are marked as follows:
+     * Int64Key=int64(42)
+     * # Similarly, all remaining data types are clearly marked:
+     * Uint64Key=uint64(42)
+     * BoolListKey=bools(true;false;true;)
+     * IntListKey=ints(4;2;42;)
+     * DoubleListKey=doubles(4.0;2.0;42.0;)
+     * StringListKey=strings("a";"b";)
+     * @endcode
+     */
+    class KeyFileWrapper {
+    public:
+        static const Glib::ustring
+                INT64_PREFIX,
+                UINT64_PREFIX,
+                BOOL_LIST_PREFIX,
+                INT_LIST_PREFIX,
+                DOUBLE_LIST_PREFIX,
+                STRING_LIST_PREFIX;
+        
+        /**
+         * Creates a new, empty KeyFileWrapper object.
+         */
+        KeyFileWrapper();
+        
+        KeyFileWrapper(const KeyFileWrapper&) = delete;
+        KeyFileWrapper& operator=(const KeyFileWrapper&) = delete;
+        
+        /** 
+         * Provides access to the wrapped key file.
+         * Note that, due to the changes to the syntax, only the getters
+         * for strings, booleans, doubles, and integers will work on this object
+         * as before.
+         * @return The wrapped KeyFile
+         */
+        Glib::KeyFile& getKeyFile();
+        
+        /** Loads a KeyFile from memory
+         * @param data The data to use as a KeyFile
+         * @param flags Bitwise combination of the flags to use for the KeyFile
+         * @return true if the KeyFile was successfully loaded, false otherwise
+         * @throw Glib::KeyFileError
+         */
+        bool load_from_data(const Glib::ustring& data);
+        
+        /** Outputs the KeyFile as a string
+         * @return A string object holding the contents of KeyFile
+         * @throw Glib::KeyFileError
+         */
+        Glib::ustring to_data();
+        
+        void set_boolean(const Glib::ustring& group_name, const Glib::ustring& key, bool value);
+        
+        void set_double(const Glib::ustring& group_name, const Glib::ustring& key, double value);
+        
+        void set_integer(const Glib::ustring& group_name, const Glib::ustring& key, int value);
+
+        void set_int64(const Glib::ustring& group_name, const Glib::ustring& key, gint64 value);
+        
+        void set_uint64(const Glib::ustring& group_name, const Glib::ustring& key, guint64 value);
+        
+        void set_string(const Glib::ustring& group_name, const Glib::ustring& key, const Glib::ustring& string);
+        
+        void set_boolean_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<bool>&  list);
+        
+        void set_double_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<double>&  list);
+        
+        void set_integer_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<int>&  list);
+        
+        void set_string_list(const Glib::ustring& group_name, const Glib::ustring& key, const std::vector<Glib::ustring>&  list);
+    private:
+        Glib::KeyFile keyFile;
+        
+        /**
+         * Returns the substring between the outermost parentheses.
+         * Example: `extract_from_parentheses("ints(3;4;5;)")` would return "3;4;5;"
+         */
+        static bool extract_from_parentheses(
+                const std::string& s,
+                std::string& target,
+                std::string open_bracket="(",
+                std::string close_bracket=")"
+        );
+        
+        /**
+         * Converts a string list like
+         * `"a";"hello";"world";`
+         * to a Glib::KeyFile conformant string list like
+         * `a;hello;world`.
+         */
+        static Glib::ustring read_string_list(const Glib::ustring& in);
+    };
+
+}
+
+#endif

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -18,6 +18,7 @@
  */
 #include <glib/gstdio.h>
 #include "procparams.h"
+#include "keyfile_wrapper.h"
 #include "rt_math.h"
 #include "curves.h"
 #include "../rtgui/multilangmgr.h"
@@ -1386,7 +1387,8 @@ int ProcParams::save (const Glib::ustring &fname, const Glib::ustring &fname2, b
 
     try {
 
-        Glib::KeyFile keyFile;
+        // Use a wrapper class for Glib::KeyFile to make data types unambiguous in the PP3.
+        KeyFileWrapper keyFile;
 
         keyFile.set_string  ("Version", "AppVersion", APPVERSION);
         keyFile.set_integer ("Version", "Version",    PPVERSION);
@@ -3614,7 +3616,8 @@ int ProcParams::load (const Glib::ustring &fname, ParamsEdited* pedited)
         return 1;
     }
 
-    Glib::KeyFile keyFile;
+    // Must use wrapper for loading strongly typed PP3 files (after version 326).
+    KeyFileWrapper keyFileWrapper;
 
     try {
 
@@ -3637,11 +3640,12 @@ int ProcParams::load (const Glib::ustring &fname, ParamsEdited* pedited)
 
         delete [] buffer;
 
-        if (!keyFile.load_from_data (ostr.str())) {
+        if (!keyFileWrapper.load_from_data (ostr.str())) {
             return 1;
         }
 
         fclose (f);
+        Glib::KeyFile& keyFile(keyFileWrapper.getKeyFile());
 
         // load tonecurve:
 

--- a/rtgui/ppversion.h
+++ b/rtgui/ppversion.h
@@ -2,11 +2,13 @@
 #define _PPVERSION_
 
 // This number has to be incremented whenever the PP3 file format is modified or the behaviour of a tool changes
-#define PPVERSION 326
+#define PPVERSION 327
 #define PPVERSION_AEXP 301 //value of PPVERSION when auto exposure algorithm was modified
 
 /*
   Log of version changes
+   327  2017-07-31
+        Syntax of PP3 files now includes information about data types.
    326  2015-07-26
         [Exposure] Added 'Perceptual' tone curve mode
    325  2015-07-23


### PR DESCRIPTION
I changed the PP3 format to include information about the data type for each key/value pair as outlined in issue #3980.

Specifics from the new KeyFileWrapper class documentation:

Key files saved with the original Glib::KeyFile class do not allow foreign
applications to determine the data type of a given key-value pair.
For example, saving an integer with value 42 would yield the same result
as saving the string "42".
This wrapper class makes the following changes to the syntax of key files:

```
# Strings must be enclosed in quotation marks.
# (Inner quotation marks need not be escaped, for now.)
StringKey="StringValue"
# Regular integers are unchanged.
IntKey=42
# Booleans are unchanged.
BoolKey=true
# Double values must contain a decimal point. The decimal point need not be
# followed by another digit.
DoubleKey=42.
# 64-bit integers are marked as follows:
Int64Key=int64(42)
# Similarly, all remaining data types are clearly marked:
Uint64Key=uint64(42)
BoolListKey=bools(true;false;true;)
IntListKey=ints(4;2;42;)
DoubleListKey=doubles(4.0;2.0;42.0;)
StringListKey=strings("a";"b";)
```