### PR TITLE
Fix crash on empty command line arguments

### DIFF
--- a/rtgui/main-cli.cc
+++ b/rtgui/main-cli.cc
@@ -285,8 +285,7 @@ bool dontLoadCache ( int argc, char **argv )
 #if ECLIPSE_ARGS
         currParam = currParam.substr (1, currParam.length() - 2);
 #endif
-
-        if ( currParam.at (0) == '-' && currParam.at (1) == 'q' ) {
+        if ( currParam.length() > 1 && currParam.at(0) == '-' && currParam.at(1) == 'q' ) {
             return true;
         }
     }
@@ -317,6 +316,9 @@ int processLineParams ( int argc, char **argv )
 
     for ( int iArg = 1; iArg < argc; iArg++) {
         Glib::ustring currParam (argv[iArg]);
+        if ( currParam.empty() ) {
+            continue;
+        }
 #if ECLIPSE_ARGS
         currParam = currParam.substr (1, currParam.length() - 2);
 #endif

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -122,6 +122,9 @@ int processLineParams ( int argc, char **argv )
 {
     for ( int iArg = 1; iArg < argc; iArg++) {
         Glib::ustring currParam (argv[iArg]);
+        if ( currParam.empty() ) {
+            continue;
+        }
 #if ECLIPSE_ARGS
         currParam = currParam.substr (1, currParam.length() - 2);
 #endif
@@ -697,4 +700,3 @@ int main (int argc, char **argv)
 
     return ret;
 }
-


### PR DESCRIPTION
Command-line arguments can be empty, as in `rawtherapee-cli ''`.

Without this patch, RT crashes when parsing the command line above:

> terminate called after throwing an instance of 'std::out_of_range'                   
> what():  basic_string::at: __n (which is 0) >= this->size() (which is 0)           


The issue is very noticeable when scripting RawTherapee (at least with Bash). For example, if you have a call like `rawtherapee-cli $RT_PARAMS $FILENAME` in your script, an empty string is added to the argument list if $RT_PARAMS is empty.