### PR TITLE
AppleLocale / executable loader fix

### DIFF
--- a/tools/osx/executable_loader.in
+++ b/tools/osx/executable_loader.in
@@ -48,4 +48,7 @@ esac
 #fi
 #ln -sf "${app}" /tmp
 
+AppleLocale=`defaults read -g AppleLocale`
+export LANG=${AppleLocale%@*}.UTF-8
+
 exec "${cwd}/rawtherapee-bin" "$@"


### PR DESCRIPTION
RT crashes activating the queue window or throws the`Invalid byte sequence in conversion input` error on MacOS when activating queue processing when the folder name includes international characters such as `é`.
Ref: https://github.com/Beep6581/RawTherapee/issues/4128
Ref: https://discuss.pixls.us/t/error-processing-queue-invalid-byte-sequence-in-conversion-input/1188/18