### PR TITLE
Fix missing filename after closing save-as dialog

### DIFF
--- a/rtgui/saveasdlg.cc
+++ b/rtgui/saveasdlg.cc
@@ -299,7 +299,7 @@ void SaveAsDialog::formatChanged (Glib::ustring f)
 
 void SaveAsDialog::setInitialFileName (Glib::ustring fname)
 {
-
+    this->fname = fname;
     fchooser->set_current_name(fname);
 }
 


### PR DESCRIPTION
Currently, if you open the save as dialog, press ESC to close the dialog and then re-open it, the filename is cleared to `"."`.

This patch sets `SaveAsDlg::fname` so RT always gets the original filename back even if the dialog is dismissed.