### PR TITLE
License file for libiomp5.dylib

### DIFF
--- a/licenses/osx_libiomp5_LICENSE.txt
+++ b/licenses/osx_libiomp5_LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2013-2016, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of Intel Corporation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -159,7 +159,7 @@ mkdir -p "${RESOURCES}/share/lensfun"
 cp /opt/local/share/lensfun/version_1/* "${RESOURCES}/share/lensfun"
 
 # Copy the libiomp5 license into the app bundle
-cp "${PROJECT_SOURCE_DATA_DIR}/licenses/osx_libiomp5_LICENSE.txt" "${RESOURCES}"
+cp "${PROJECT_SOURCE_DIR}/licenses/osx_libiomp5_LICENSE.txt" "${RESOURCES}"
 
 # Install names
 find -E "${CONTENTS}" -type f -regex '.*/(rawtherapee-cli|rawtherapee|.*\.(dylib|so))' | while read -r x; do

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -158,6 +158,9 @@ ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/icons/Adwaita/index.theme
 mkdir -p "${RESOURCES}/share/lensfun"
 cp /opt/local/share/lensfun/version_1/* "${RESOURCES}/share/lensfun"
 
+# Copy the libiomp5 license into the app bundle
+cp "${PROJECT_SOURCE_DATA_DIR}/licenses/osx_libiomp5_LICENSE.txt" "${RESOURCES}"
+
 # Install names
 find -E "${CONTENTS}" -type f -regex '.*/(rawtherapee-cli|rawtherapee|.*\.(dylib|so))' | while read -r x; do
     msg "Modifying install names: ${x}"


### PR DESCRIPTION
To prevent a crash during quit on mac, Intel's OSS libiomp5 is used in place of the older libomp provided by clang. This is the license file provided by Intel to cover the binary's redistribution. For even more info, see: https://github.com/Beep6581/RawTherapee/issues/3971