### PR TITLE
include string header for colortemp.h

### DIFF
--- a/rtengine/colortemp.h
+++ b/rtengine/colortemp.h
@@ -21,6 +21,7 @@
 
 #include <cmath>
 #include <map>
+#include <string>
 
 namespace rtengine
 {


### PR DESCRIPTION
To fix mac clang compilation ```error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    std::string method;```