### PR TITLE
Queue state verbose, fixes #4058

### DIFF
--- a/rtdata/languages/Catala
+++ b/rtdata/languages/Catala
@@ -7,6 +7,7 @@ ABOUT_TAB_RELEASENOTES;Notes de la versió
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Restaura predeterminats
 BATCHQUEUE_AUTOSTART;Auto engega
+BATCHQUEUE_AUTOSTARTHINT;Inicia processat automàticament en rebre un nou treball
 BATCH_PROCESSING;Processament per lots
 CURVEEDITOR_CURVE;Corba
 CURVEEDITOR_CURVES;Corbes
@@ -148,12 +149,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Mostra imatges no recentment desades.\nDrec
 FILEBROWSER_SHOWTRASHHINT;Veure què hi ha a la paperera.\nDrecera: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Mostra imatges sense etiqueta de color.\nDrecera: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Mostra imatges sense rang.\nDrecera: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Inicia procés
-FILEBROWSER_STARTPROCESSINGHINT;Inicia el processament de les imatges de la cua
-FILEBROWSER_STOPPROCESSING;Atura processament
-FILEBROWSER_STOPPROCESSINGHINT;Atura processament d'imatges de la cua
 FILEBROWSER_THUMBSIZE;Tamany minifoto
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Inicia processat automàticament en rebre un nou treball
 FILEBROWSER_ZOOMINHINT;Engrandir minifoto.\nDrecera: <b>+</b>
 FILEBROWSER_ZOOMOUTHINT;Reduïr minifoto.\nDrecera: <b>-</b>
 GENERAL_ABOUT;Respecte a
@@ -955,6 +951,7 @@ ZOOMPANEL_ZOOMOUT;Allunya\nDrecera: <b>-</b>
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1421,6 +1418,12 @@ ZOOMPANEL_ZOOMOUT;Allunya\nDrecera: <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Chinese (Simplified)
+++ b/rtdata/languages/Chinese (Simplified)
@@ -168,10 +168,6 @@ FILEBROWSER_SHOWRANK5HINT;显示5星图片
 FILEBROWSER_SHOWRECENTLYSAVEDHINT;显示保存的图片\n快捷: <b>Alt-7</b>
 FILEBROWSER_SHOWTRASHHINT;显示垃圾箱内容
 FILEBROWSER_SHOWUNRANKHINT;显示未评星图片
-FILEBROWSER_STARTPROCESSING;开始处理
-FILEBROWSER_STARTPROCESSINGHINT;开始处理或保存队列中的图片
-FILEBROWSER_STOPPROCESSING;停止处理
-FILEBROWSER_STOPPROCESSINGHINT;停止处理图片
 FILEBROWSER_THUMBSIZE;缩略图大小
 FILEBROWSER_ZOOMINHINT;增大缩略图
 FILEBROWSER_ZOOMOUTHINT;减小缩略图
@@ -1030,6 +1026,8 @@ ZOOMPANEL_ZOOMOUT;缩放拉远\n快捷键: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1062,7 +1060,6 @@ ZOOMPANEL_ZOOMOUT;缩放拉远\n快捷键: <b>-</b>
 !FILEBROWSER_SHOWORIGINALHINT;Show only original images.\n\nWhen several images exist with the same filename but different extensions, the one considered original is the one whose extension is nearest the top of the parsed extensions list in Preferences > File Browser > Parsed Extensions.
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !GENERAL_SLIDER;Slider
 !GIMP_PLUGIN_INFO;Welcome to the RawTherapee GIMP plugin!\nOnce you are done editing, simply close the main RawTherapee window and the image will be automatically imported in GIMP.
@@ -1490,6 +1487,12 @@ ZOOMPANEL_ZOOMOUT;缩放拉远\n快捷键: <b>-</b>
 !PREFERENCES_AUTOSAVE_TP_OPEN;Automatically save tools collapsed/expanded\nstate before exiting
 !PREFERENCES_BEHADDALLHINT;Set all parameters to the <b>Add</b> mode.\nAdjustments of parameters in the batch tool panel will be <b>deltas</b> to the stored values.
 !PREFERENCES_BEHSETALLHINT;Set all parameters to the <b>Set</b> mode.\nAdjustments of parameters in the batch tool panel will be <b>absolute</b>, the actual values will be displayed.
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CUSTPROFBUILDHINT;Executable (or script) file called when a new initial processing profile should be generated for an image.\n\nThe path of the communication file (*.ini style, a.k.a. "Keyfile") is added as a command line parameter. It contains various parameters required for the scripts and image Exif to allow a rules-based processing profile generation.\n\n<b>WARNING:</b> You are responsible for using double quotes where necessary if you're using paths containing spaces.
 !PREFERENCES_DIRECTORIES;Directories
 !PREFERENCES_EDITORCMDLINE;Custom command line

--- a/rtdata/languages/Chinese (Traditional)
+++ b/rtdata/languages/Chinese (Traditional)
@@ -3,6 +3,7 @@
 
 ADJUSTER_RESET_TO_DEFAULT;重置預設參數
 BATCHQUEUE_AUTOSTART;Auto start
+BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives
 CURVEEDITOR_LINEAR;線性
 CURVEEDITOR_LOADDLGLABEL;正載入曲線...
 CURVEEDITOR_SAVEDLGLABEL;正儲存曲線...
@@ -60,12 +61,7 @@ FILEBROWSER_SHOWRANK4HINT;Show images ranked as 4 star
 FILEBROWSER_SHOWRANK5HINT;Show images ranked as 5 star
 FILEBROWSER_SHOWTRASHHINT;Show content of the trash
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing/saving of images in the queue
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing of images
 FILEBROWSER_THUMBSIZE;Thumb. size
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size
 GENERAL_ABOUT;關於
@@ -435,6 +431,7 @@ TP_WBALANCE_TEMPERATURE;色溫
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -1155,6 +1152,12 @@ TP_WBALANCE_TEMPERATURE;色溫
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Czech
+++ b/rtdata/languages/Czech
@@ -47,6 +47,7 @@ ABOUT_TAB_RELEASENOTES;Poznámky k vydání
 ABOUT_TAB_SPLASH;Úvodní obrazovka
 ADJUSTER_RESET_TO_DEFAULT;Vrátit se k původnímu
 BATCHQUEUE_AUTOSTART;Automatický start
+BATCHQUEUE_AUTOSTARTHINT;Automatické spuštění zpracování po vložení nové úlohy.
 BATCHQUEUE_DESTFILENAME;Cesta a název souboru
 BATCH_PROCESSING;Dávkové zpracování
 CURVEEDITOR_AXIS_IN;Vstup:
@@ -235,12 +236,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Ukázat neuložené obrázky.\nZkratka: <b>
 FILEBROWSER_SHOWTRASHHINT;Ukázat obsah koše.\nZkratka: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Ukázat obrázky bez barevného štítku.\nZkratka: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Ukázat nehodnocené obrázky.\nZkratka: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Spustit zpracování
-FILEBROWSER_STARTPROCESSINGHINT;Spustit zpracování obrázků ve frontě.\n\nZkratka: <b>Ctrl</b>+<b>s</b>
-FILEBROWSER_STOPPROCESSING;Zastavit zpracovávaní
-FILEBROWSER_STOPPROCESSINGHINT;Zastavit zpracování obrázků ve frontě.\n\nZkratka: <b>Ctrl</b>+<b>s</b>
 FILEBROWSER_THUMBSIZE;Velikost náhledu
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Automatické spuštění zpracování po vložení nové úlohy.
 FILEBROWSER_UNRANK_TOOLTIP;Zrušit hodnocení.\nZkratka: <b>Shift - 0</b>
 FILEBROWSER_ZOOMINHINT;Zvětšit velikosti náhledů.\n\nZkratky:\n<b>+</b> - režim více karet editoru,\n<b>Alt-+</b> - režim jedné karty editoru.
 FILEBROWSER_ZOOMOUTHINT;Zmenšit velikosti náhledů.\n\nZkratky:\n<b>-</b> - režim více karet editoru,\n<b>Alt--</b> - režim jedné karty editoru.
@@ -2208,6 +2204,7 @@ ZOOMPANEL_ZOOMOUT;Oddálit\nZkratka: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !GENERAL_SLIDER;Slider
 !HISTORY_MSG_173;NR - Detail recovery
 !HISTORY_MSG_203;NR - Color space
@@ -2221,6 +2218,12 @@ ZOOMPANEL_ZOOMOUT;Oddálit\nZkratka: <b>-</b>
 !HISTORY_MSG_LOCALCONTRAST_RADIUS;Local Contrast - Radius
 !HISTORY_MSG_METADATA_MODE;Metadata copy mode
 !PARTIALPASTE_LOCALCONTRAST;Local contrast
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_EDITORCMDLINE;Custom command line
 !TP_DIRPYRDENOISE_CHROMINANCE_CURVE_TOOLTIP;Increase (multiply) the value of all chrominance sliders.\nThis curve lets you adjust the strength of chromatic noise reduction as a function of chromaticity, for instance to increase the action in areas of low saturation and to decrease it in those of high saturation.
 !TP_DIRPYRDENOISE_LABEL;Noise Reduction

--- a/rtdata/languages/Dansk
+++ b/rtdata/languages/Dansk
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Vis billeder vurderet med 4 stjerner
 FILEBROWSER_SHOWRANK5HINT;Vis billeder vurderet med 5 stjerner
 FILEBROWSER_SHOWTRASHHINT;Vis indhold i papirkurven
 FILEBROWSER_SHOWUNRANKHINT;Vis billeder uden vurdering
-FILEBROWSER_STARTPROCESSING;Begynd bearbejdning
-FILEBROWSER_STARTPROCESSINGHINT;Begynd at bearbejde/gemme billeder i køen
-FILEBROWSER_STOPPROCESSING;Stop bearbejdning
-FILEBROWSER_STOPPROCESSINGHINT;Stop bearbejdningen af billeder
 FILEBROWSER_THUMBSIZE;Miniaturestr.
 FILEBROWSER_ZOOMINHINT;Gør miniaturer større
 FILEBROWSER_ZOOMOUTHINT;Gør miniaturer mindre
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Deutsch
+++ b/rtdata/languages/Deutsch
@@ -56,6 +56,7 @@ ABOUT_TAB_RELEASENOTES;Versionshinweise
 ABOUT_TAB_SPLASH;Startbild
 ADJUSTER_RESET_TO_DEFAULT;Standard wiederherstellen
 BATCHQUEUE_AUTOSTART;Automatisch starten
+BATCHQUEUE_AUTOSTARTHINT;Bei neuem Job die Verarbeitung automatisch starten
 BATCHQUEUE_DESTFILENAME;Pfad und Dateiname
 BATCH_PROCESSING;Stapelverarbeitung
 CURVEEDITOR_AXIS_IN;x:
@@ -244,12 +245,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Nur nicht gespeicherte Bilder anzeigen\nTas
 FILEBROWSER_SHOWTRASHHINT;Inhalt des Papierkorbs anzeigen\nTaste: <b>Strg</b> + <b>t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Nur unmarkierte Bilder anzeigen\nTaste: <b>Alt</b> + <b>0</b>
 FILEBROWSER_SHOWUNRANKHINT;Nur unbewertete Bilder anzeigen\nTaste: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Verarbeitung starten
-FILEBROWSER_STARTPROCESSINGHINT;Verarbeitung und Speicherung der\nBilder starten.\nTaste: <b>Strg</b> + <b>s</b>
-FILEBROWSER_STOPPROCESSING;Verarbeitung stoppen
-FILEBROWSER_STOPPROCESSINGHINT;Verarbeitung der Bilder abbrechen.\nTaste: <b>Strg</b> + <b>s</b>
 FILEBROWSER_THUMBSIZE;Miniaturbildgröße
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Bei neuem Job die Verarbeitung automatisch starten
 FILEBROWSER_UNRANK_TOOLTIP;Bewertung entfernen\nTaste: <b>Umschalt</b> + <b>0</b>
 FILEBROWSER_ZOOMINHINT;Miniaturbilder vergrößern\n\nIm Multi-Reitermodus:\nTaste: <b>+</b>\nIm Ein-Reitermodus:\nTaste:  <b>Alt</b> <b>+</b>
 FILEBROWSER_ZOOMOUTHINT;Miniaturbilder verkleinern\n\nIm Multi-Reitermodus:\nTaste: <b>-</b>\nIm Ein-Reitermodus:\nTaste:  <b>Alt</b> <b>-</b>
@@ -2230,12 +2226,19 @@ ZOOMPANEL_ZOOMOUT;Herauszoomen\nTaste: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !GENERAL_SLIDER;Slider
 !HISTORY_MSG_173;NR - Detail recovery
 !HISTORY_MSG_203;NR - Color space
 !HISTORY_MSG_256;NR - Median - Type
 !HISTORY_MSG_297;NR - Mode
 !HISTORY_MSG_METADATA_MODE;Metadata copy mode
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_EDITORCMDLINE;Custom command line
 !TP_DIRPYRDENOISE_CHROMINANCE_CURVE_TOOLTIP;Increase (multiply) the value of all chrominance sliders.\nThis curve lets you adjust the strength of chromatic noise reduction as a function of chromaticity, for instance to increase the action in areas of low saturation and to decrease it in those of high saturation.
 !TP_DIRPYRDENOISE_LABEL;Noise Reduction

--- a/rtdata/languages/English (UK)
+++ b/rtdata/languages/English (UK)
@@ -117,7 +117,9 @@ TP_WBALANCE_EQBLUERED_TOOLTIP;Allows to deviate from the normal behaviour of "wh
 !ABOUT_TAB_SPLASH;Splash
 !ADJUSTER_RESET_TO_DEFAULT;Reset to default
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -301,12 +303,7 @@ TP_WBALANCE_EQBLUERED_TOOLTIP;Allows to deviate from the normal behaviour of "wh
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWTRASHHINT;Show contents of trash.\nShortcut: <b>Ctrl-t</b>
 !FILEBROWSER_SHOWUNRANKHINT;Show unranked images.\nShortcut: <b>0</b>
-!FILEBROWSER_STARTPROCESSING;Start processing
-!FILEBROWSER_STARTPROCESSINGHINT;Start processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
-!FILEBROWSER_STOPPROCESSING;Stop processing
-!FILEBROWSER_STOPPROCESSINGHINT;Stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !FILEBROWSER_THUMBSIZE;Thumbnail size
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILEBROWSER_ZOOMINHINT;Increase thumbnail size.\n\nShortcuts:\n<b>+</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>+</b> - Single Editor Tab Mode.
 !FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size.\n\nShortcuts:\n<b>-</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>-</b> - Single Editor Tab Mode.
@@ -1049,6 +1046,12 @@ TP_WBALANCE_EQBLUERED_TOOLTIP;Allows to deviate from the normal behaviour of "wh
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/English (US)
+++ b/rtdata/languages/English (US)
@@ -10,7 +10,9 @@
 !ABOUT_TAB_SPLASH;Splash
 !ADJUSTER_RESET_TO_DEFAULT;Reset to default
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -198,12 +200,7 @@
 !FILEBROWSER_SHOWTRASHHINT;Show contents of trash.\nShortcut: <b>Ctrl-t</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
 !FILEBROWSER_SHOWUNRANKHINT;Show unranked images.\nShortcut: <b>0</b>
-!FILEBROWSER_STARTPROCESSING;Start processing
-!FILEBROWSER_STARTPROCESSINGHINT;Start processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
-!FILEBROWSER_STOPPROCESSING;Stop processing
-!FILEBROWSER_STOPPROCESSINGHINT;Stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !FILEBROWSER_THUMBSIZE;Thumbnail size
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILEBROWSER_ZOOMINHINT;Increase thumbnail size.\n\nShortcuts:\n<b>+</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>+</b> - Single Editor Tab Mode.
 !FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size.\n\nShortcuts:\n<b>-</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>-</b> - Single Editor Tab Mode.
@@ -977,6 +974,12 @@
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Espanol
+++ b/rtdata/languages/Espanol
@@ -68,6 +68,7 @@ ABOUT_TAB_RELEASENOTES;Notas de la versión
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Restablece los valores predeterminados
 BATCHQUEUE_AUTOSTART;Inicio automático
+BATCHQUEUE_AUTOSTARTHINT;Iniciar automáticamente el procesamiento en cuanto llega un nuevo trabajo
 BATCHQUEUE_DESTFILENAME;Ruta y nombre del archivo
 BATCH_PROCESSING;Proceso por lotes
 CURVEEDITOR_CURVE;Curva
@@ -230,12 +231,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Mostrar imágenes no guardadas recientement
 FILEBROWSER_SHOWTRASHHINT;Mostrar el contenido de la papelera.\nAtajo: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Mostrar imágenes sin etiqueta de color.\nAtajo: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Mostrar imágenes sin rango.\nAtajo: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Iniciar procesamiento
-FILEBROWSER_STARTPROCESSINGHINT;Iniciar el procesamiento de imágenes en la cola
-FILEBROWSER_STOPPROCESSING;Parar procesamiento
-FILEBROWSER_STOPPROCESSINGHINT;Parar el procesamiento de imágenes en la cola
 FILEBROWSER_THUMBSIZE;Tamaño miniatura
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Iniciar automáticamente el procesamiento en cuanto llega un nuevo trabajo
 FILEBROWSER_UNRANK_TOOLTIP;Sin Rango\nAtajo<b>Shift - 0</b>
 FILEBROWSER_ZOOMINHINT;Agrandar miniatura.\nAtajo: <b>+</b>\n\nAtajo en modo editor simple: <b>Alt-+</b>
 FILEBROWSER_ZOOMOUTHINT;Reducir miniatura.\nAtajo: <b>-</b>\n\nAtajo en modo editor simple: <b>Alt--</b>
@@ -1491,6 +1487,7 @@ ZOOMPANEL_ZOOMOUT;Reducir Zoom\nAtajo: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1784,6 +1781,12 @@ ZOOMPANEL_ZOOMOUT;Reducir Zoom\nAtajo: <b>-</b>
 !PREFERENCES_CLUTSCACHE;HaldCLUT Cache
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Euskara
+++ b/rtdata/languages/Euskara
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Show images ranked as 4 star
 FILEBROWSER_SHOWRANK5HINT;Show images ranked as 5 star
 FILEBROWSER_SHOWTRASHHINT;Show content of the trash
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing/saving of images in the queue
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing of images
 FILEBROWSER_THUMBSIZE;Thumb. size
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;Tenperatura
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;Tenperatura
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;Tenperatura
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Francais
+++ b/rtdata/languages/Francais
@@ -7,6 +7,7 @@ ABOUT_TAB_RELEASENOTES;Notes de version
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Réglages par défaut
 BATCHQUEUE_AUTOSTART;Démarrage auto
+BATCHQUEUE_AUTOSTARTHINT;Démarrer automatiquement le traitement à l'arrivée d'une nouvelle tâche
 BATCHQUEUE_DESTFILENAME;Chemin et nom de fichier
 BATCH_PROCESSING;Traitement par lot
 CURVEEDITOR_AXIS_IN;E:
@@ -195,12 +196,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT; Afficher les images non sauvegardées réc
 FILEBROWSER_SHOWTRASHHINT;Voir le contenu de la corbeille\nRaccourci: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Afficher les images sans label de couleur\nRaccourci: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Voir les images sans étoile\nRaccourci: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Démarrer le traitement
-FILEBROWSER_STARTPROCESSINGHINT;Démarre le traitement/sauvegarde des images dans la file
-FILEBROWSER_STOPPROCESSING;Arrêter le traitement
-FILEBROWSER_STOPPROCESSINGHINT;Arrête le traitement des images
 FILEBROWSER_THUMBSIZE;Taille vign.
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Démarrer automatiquement le traitement à l'arrivée d'une nouvelle tâche
 FILEBROWSER_UNRANK_TOOLTIP;Effacer le rang\nRaccourci: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Augmenter la taille des vignettes.\nRaccourci: <b>+</b>\n\nRaccourcis dans le mode Éditeur Unique:  <b>Alt-+</b>
 FILEBROWSER_ZOOMOUTHINT;Diminuer la taille des vignettes.\nRaccourci: <b>-</b>\n\nRaccourcis dans le mode Éditeur Unique:  <b>Alt--</b>
@@ -2167,6 +2163,7 @@ ZOOMPANEL_ZOOMOUT;Zoom Arrière\nRaccourci: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !GENERAL_SLIDER;Slider
 !HISTORY_MSG_173;NR - Detail recovery
 !HISTORY_MSG_203;NR - Color space
@@ -2182,6 +2179,12 @@ ZOOMPANEL_ZOOMOUT;Zoom Arrière\nRaccourci: <b>-</b>
 !HISTORY_MSG_LOCALCONTRAST_RADIUS;Local Contrast - Radius
 !HISTORY_MSG_METADATA_MODE;Metadata copy mode
 !PARTIALPASTE_LOCALCONTRAST;Local contrast
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_EDITORCMDLINE;Custom command line
 !TP_DIRPYRDENOISE_CHROMINANCE_CURVE_TOOLTIP;Increase (multiply) the value of all chrominance sliders.\nThis curve lets you adjust the strength of chromatic noise reduction as a function of chromaticity, for instance to increase the action in areas of low saturation and to decrease it in those of high saturation.
 !TP_DIRPYRDENOISE_LABEL;Noise Reduction

--- a/rtdata/languages/Greek
+++ b/rtdata/languages/Greek
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Show images ranked as 4 star
 FILEBROWSER_SHOWRANK5HINT;Show images ranked as 5 star
 FILEBROWSER_SHOWTRASHHINT;Show content of the trash
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing/saving of images in the queue
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing of images
 FILEBROWSER_THUMBSIZE;Thumb. size
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size
@@ -425,7 +421,9 @@ TP_WBALANCE_TEMPERATURE;Θερμοκρασία
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -556,7 +554,6 @@ TP_WBALANCE_TEMPERATURE;Θερμοκρασία
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1152,6 +1149,12 @@ TP_WBALANCE_TEMPERATURE;Θερμοκρασία
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Hebrew
+++ b/rtdata/languages/Hebrew
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Show images ranked as 4 star
 FILEBROWSER_SHOWRANK5HINT;Show images ranked as 5 star
 FILEBROWSER_SHOWTRASHHINT;Show content of the trash
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing/saving of images in the queue
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing of images
 FILEBROWSER_THUMBSIZE;Thumb. size
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;מידת חום
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;מידת חום
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;מידת חום
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Italiano
+++ b/rtdata/languages/Italiano
@@ -11,6 +11,7 @@ ABOUT_TAB_RELEASENOTES;Note di rilascio
 ABOUT_TAB_SPLASH;Emblema
 ADJUSTER_RESET_TO_DEFAULT;Ripristina
 BATCHQUEUE_AUTOSTART;Autoavvia
+BATCHQUEUE_AUTOSTARTHINT;Inizia a sviluppare automaticamente quando un nuovo lavoro viene accodato
 BATCHQUEUE_DESTFILENAME;Percorso e nome file
 BATCH_PROCESSING;Sviluppo in serie
 CURVEEDITOR_CURVE;Curva
@@ -174,12 +175,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Mostra le immagini non salvate.\nScorciatoi
 FILEBROWSER_SHOWTRASHHINT;Mostra il contenuto del cestino.\nScorciatoia: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Mostra le immagini senza etichetta colorata.\nScorciatoia: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Mostra le immagini non classificate.\nScorciatoia: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Comincia a sviluppare
-FILEBROWSER_STARTPROCESSINGHINT;Inizia a sviluppare le immagini nella Coda.
-FILEBROWSER_STOPPROCESSING;Ferma lo sviluppo
-FILEBROWSER_STOPPROCESSINGHINT;Ferma lo sviluppo delle immagini nella Coda.
 FILEBROWSER_THUMBSIZE;Dimensione miniature
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Inizia a sviluppare automaticamente quando un nuovo lavoro viene accodato
 FILEBROWSER_UNRANK_TOOLTIP;Nessun Punteggio.\nScorciatoia: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Aumenta la dimensione delle miniature.\n\nScorciatoie:\n<b>+</b> - Modalità a Schede Multiple,\n<b>Alt</b>-<b>+</b> - Modalità a Schede Singole.
 FILEBROWSER_ZOOMOUTHINT;Diminuisci la dimensione delle miniature.\n\nScorciatoie:\n<b>-</b> - Modalità a Schede Multiple,\n<b>Alt</b>-<b>-</b> - Modalità a Schede Singole.
@@ -1326,6 +1322,7 @@ ZOOMPANEL_ZOOMOUT;Rimpicciolisci.\nScorciatoia: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1656,6 +1653,12 @@ ZOOMPANEL_ZOOMOUT;Rimpicciolisci.\nScorciatoia: <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Japanese
+++ b/rtdata/languages/Japanese
@@ -40,6 +40,7 @@ ABOUT_TAB_RELEASENOTES;リリースノート
 ABOUT_TAB_SPLASH;スプラッシュ
 ADJUSTER_RESET_TO_DEFAULT;デフォルト値に戻す
 BATCHQUEUE_AUTOSTART;オートスタート
+BATCHQUEUE_AUTOSTARTHINT;新しいrawファイルが送られて来たら自動的に現像処理を開始します
 BATCHQUEUE_DESTFILENAME;パスとファイル名
 BATCH_PROCESSING;バッチ処理
 CURVEEDITOR_AXIS_IN;I:
@@ -210,12 +211,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;最近保存されていない画像を表�
 FILEBROWSER_SHOWTRASHHINT;ゴミ箱の内容を表示\nショートカット: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;カラー・ラベルのない画像を表示\nショートカット: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;ランクなし画像を表示\nショートカット:  <b>0</b>
-FILEBROWSER_STARTPROCESSING;処理開始
-FILEBROWSER_STARTPROCESSINGHINT;キューにある画像の処理を開始\n\nショートカット:<b>Ctrl</b>+<b>s</b>
-FILEBROWSER_STOPPROCESSING;処理中止
-FILEBROWSER_STOPPROCESSINGHINT;キューにある画像の処理を中止\n\nショートカット:<b>Ctrl</b>+<b>s</b>
 FILEBROWSER_THUMBSIZE;サムネイルのサイズ
-FILEBROWSER_TOOLTIP_STOPPROCESSING;新しいrawファイルが送られて来たら自動的に現像処理を開始します
 FILEBROWSER_UNRANK_TOOLTIP;ランクなし\nショートカット: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;サムネイルサイズの拡大\nショートカット: <b>+</b>\n\nシングル・エディタ・タブのショートカット: <b>Alt-+</b>
 FILEBROWSER_ZOOMOUTHINT;サムネイルサイズの縮小\nショートカット: <b>-</b>\n\nシングル・エディタ・タブのショートカット: <b>Alt--</b>
@@ -1861,6 +1857,7 @@ ZOOMPANEL_ZOOMOUT;ズームアウト\nショートカット: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !DONT_SHOW_AGAIN;Don't show this message again.
 !DYNPROFILEEDITOR_DELETE;Delete
 !DYNPROFILEEDITOR_EDIT;Edit
@@ -2007,6 +2004,12 @@ ZOOMPANEL_ZOOMOUT;ズームアウト\nショートカット: <b>-</b>
 !PARTIALPASTE_TM_FATTAL;HDR Tone mapping
 !PREFERENCES_AUTOSAVE_TP_OPEN;Automatically save tools collapsed/expanded\nstate before exiting
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_D50_OLD;5000K
 !PREFERENCES_DIRECTORIES;Directories
 !PREFERENCES_EDITORCMDLINE;Custom command line

--- a/rtdata/languages/Latvian
+++ b/rtdata/languages/Latvian
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Rādīt attēlus ar 4 zvaigznēm
 FILEBROWSER_SHOWRANK5HINT;Rādīt attēlus ar 5 zvaigznēm
 FILEBROWSER_SHOWTRASHHINT;Rādīt atkritni
 FILEBROWSER_SHOWUNRANKHINT;Rādīt nevērtētus attēlus
-FILEBROWSER_STARTPROCESSING;Sākt apstrādi
-FILEBROWSER_STARTPROCESSINGHINT;Sākt attēlu rindas apstrādi/saglabāšanu
-FILEBROWSER_STOPPROCESSING;Apturēt apstrādi
-FILEBROWSER_STOPPROCESSINGHINT;Apturēt attēlu apstrādi
 FILEBROWSER_THUMBSIZE;Sīktēlu izmērs
 FILEBROWSER_ZOOMINHINT;Palielināt sīktēlus
 FILEBROWSER_ZOOMOUTHINT;Samazināt sīktēlus
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;Temperatūra
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;Temperatūra
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;Temperatūra
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Magyar
+++ b/rtdata/languages/Magyar
@@ -7,6 +7,7 @@ ABOUT_TAB_RELEASENOTES;Kiadási megjegyzések
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Alaphelyzetbe állítás
 BATCHQUEUE_AUTOSTART;Auto start
+BATCHQUEUE_AUTOSTARTHINT;Új kép érkezése esetén a feldolgozás automatikus indítása.
 BATCH_PROCESSING;Kötegelt feldolgozás
 CURVEEDITOR_CURVE;Görbe
 CURVEEDITOR_CURVES;Görbék
@@ -143,12 +144,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Korábban mentett képek megjelenítése.\n
 FILEBROWSER_SHOWTRASHHINT;A kuka tartalmának mutatása
 FILEBROWSER_SHOWUNCOLORHINT;Színcímke nélküli képek megjelenítése.\nGyorsbillentyű: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Meg nem jelölt képek mutatása
-FILEBROWSER_STARTPROCESSING;Feldolgozás indítása
-FILEBROWSER_STARTPROCESSINGHINT;A sorban álló képek feldolgozásának elindítása
-FILEBROWSER_STOPPROCESSING;Feldolgozás leállítása
-FILEBROWSER_STOPPROCESSINGHINT;A sorban álló képek feldolgozásának leállítása
 FILEBROWSER_THUMBSIZE;Bélyegméret
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Új kép érkezése esetén a feldolgozás automatikus indítása.
 FILEBROWSER_ZOOMINHINT;Növelés
 FILEBROWSER_ZOOMOUTHINT;Csökkentés
 GENERAL_ABOUT;Névjegy
@@ -871,6 +867,7 @@ ZOOMPANEL_ZOOMOUT;Kicsinyítés <b>-</b>
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1357,6 +1354,12 @@ ZOOMPANEL_ZOOMOUT;Kicsinyítés <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Nederlands
+++ b/rtdata/languages/Nederlands
@@ -22,6 +22,7 @@ ABOUT_TAB_RELEASENOTES;Uitgave-opmerkingen
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Terug naar beginwaarde
 BATCHQUEUE_AUTOSTART;Autostart
+BATCHQUEUE_AUTOSTARTHINT;Start verwerking automatisch wanneer nieuwe foto arriveert
 BATCHQUEUE_DESTFILENAME;Pad en bestandsnaam
 BATCH_PROCESSING;Batch-verwerking
 CURVEEDITOR_AXIS_IN;I:
@@ -208,12 +209,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Toon niet-opgeslagen/verwerkte foto's.\nSne
 FILEBROWSER_SHOWTRASHHINT;Toon inhoud prullenbak\nSneltoets: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Toon foto's zonder kleurlabel.\nSneltoets: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Toon foto's zonder sterwaardering.\nSneltoets: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Start verwerking
-FILEBROWSER_STARTPROCESSINGHINT;Start verwerking van bestanden in verwerkingsrij
-FILEBROWSER_STOPPROCESSING;Stop verwerking
-FILEBROWSER_STOPPROCESSINGHINT;Stop verwerking van bestanden in verwerkingsrij
 FILEBROWSER_THUMBSIZE;Miniaturen
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Start verwerking automatisch wanneer nieuwe foto arriveert
 FILEBROWSER_UNRANK_TOOLTIP;Verwijder sterwaardering\nSneltoets: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Groter
 FILEBROWSER_ZOOMOUTHINT;Kleiner
@@ -2125,6 +2121,7 @@ ZOOMPANEL_ZOOMOUT;Zoom uit\nSneltoets: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !DONT_SHOW_AGAIN;Don't show this message again.
 !EXIFPANEL_SHOWALL;Show all
 !GENERAL_SLIDER;Slider
@@ -2168,6 +2165,12 @@ ZOOMPANEL_ZOOMOUT;Zoom uit\nSneltoets: <b>-</b>
 !PARTIALPASTE_LOCALCONTRAST;Local contrast
 !PARTIALPASTE_TM_FATTAL;HDR Tone mapping
 !PREFERENCES_AUTOSAVE_TP_OPEN;Automatically save tools collapsed/expanded\nstate before exiting
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_D50_OLD;5000K
 !PREFERENCES_DIRECTORIES;Directories
 !PREFERENCES_EDITORCMDLINE;Custom command line

--- a/rtdata/languages/Norsk BM
+++ b/rtdata/languages/Norsk BM
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Vis bilder rangert med 4 stjerne
 FILEBROWSER_SHOWRANK5HINT;Vis bilder rangert med 5 stjerne
 FILEBROWSER_SHOWTRASHHINT;Vis innholdet i søpla
 FILEBROWSER_SHOWUNRANKHINT;Vis unrangerte bilder
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Begynn prosessering/lagring av bilder i køen
-FILEBROWSER_STOPPROCESSING;Stopp prosesseringen
-FILEBROWSER_STOPPROCESSINGHINT;Stopp prosesseringen av bilder
 FILEBROWSER_THUMBSIZE;Thumbnail størrelse
 FILEBROWSER_ZOOMINHINT;Øk thumbnail størrelse
 FILEBROWSER_ZOOMOUTHINT;Reduser thumbnail størrelse
@@ -425,7 +421,9 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -556,7 +554,6 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1152,6 +1149,12 @@ TP_WBALANCE_TEMPERATURE;Temperatur
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Polish
+++ b/rtdata/languages/Polish
@@ -15,6 +15,7 @@ ABOUT_TAB_RELEASENOTES;Notatki eksploatacyjne
 ABOUT_TAB_SPLASH;Ekran powitalny
 ADJUSTER_RESET_TO_DEFAULT;Przywróć domyślne
 BATCHQUEUE_AUTOSTART;Autostart
+BATCHQUEUE_AUTOSTARTHINT;Rozpocznij przetwarzanie automatycznie gdy pojawi się nowe zadanie.
 BATCHQUEUE_DESTFILENAME;Ścieżka i nazwa pliku
 BATCH_PROCESSING;Przetwarzanie wsadowe
 CURVEEDITOR_CURVE;Krzywa
@@ -178,12 +179,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Pokazuje niezapisane zdjęcia.\nSkrót: <b>
 FILEBROWSER_SHOWTRASHHINT;Pokazuje zawartość kosza.\nSkrót: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Pokazuje zdjęcia bez kolorowej etykiety.\nSkrót: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Pokazuje nieocenione zdjęcia.\nSkrót: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Rozpocznij przetwarzanie
-FILEBROWSER_STARTPROCESSINGHINT;Rozpoczyna przetwarzanie/zapisywanie plików z kolejki.
-FILEBROWSER_STOPPROCESSING;Zatrzymaj przetwarzanie
-FILEBROWSER_STOPPROCESSINGHINT;Zatrzymuje przetwarzanie zdjęć.
 FILEBROWSER_THUMBSIZE;Rozmiar minaturek
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Rozpocznij przetwarzanie automatycznie gdy pojawi się nowe zadanie.
 FILEBROWSER_UNRANK_TOOLTIP;Usuń ocenę.\nSkrót: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Zwiększa rozmiar miniaturek.\n\nSkróty:\n<b>+</b> - Tryb wielu zakładek,\n<b>Alt</b>-<b>+</b> - Tryb pojedyńczej zakładki.
 FILEBROWSER_ZOOMOUTHINT;Zmniejsza rozmiar miniaturek.\n\nSkróty:\n<b>-</b> - Tryb wielu zakładek,\n<b>Alt</b>-<b>-</b> - Tryb pojedyńczej zakładki.
@@ -1449,6 +1445,7 @@ ZOOMPANEL_ZOOMOUT;Oddal\nSkrót: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1732,6 +1729,12 @@ ZOOMPANEL_ZOOMOUT;Oddal\nSkrót: <b>-</b>
 !PREFERENCES_CLUTSCACHE;HaldCLUT Cache
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Polish (Latin Characters)
+++ b/rtdata/languages/Polish (Latin Characters)
@@ -15,6 +15,7 @@ ABOUT_TAB_RELEASENOTES;Notatki eksploatacyjne
 ABOUT_TAB_SPLASH;Ekran powitalny
 ADJUSTER_RESET_TO_DEFAULT;Przywroc domyslne
 BATCHQUEUE_AUTOSTART;Autostart
+BATCHQUEUE_AUTOSTARTHINT;Rozpocznij przetwarzanie automatycznie gdy pojawi sie nowe zadanie.
 BATCHQUEUE_DESTFILENAME;Sciezka i nazwa pliku
 BATCH_PROCESSING;Przetwarzanie wsadowe
 CURVEEDITOR_CURVE;Krzywa
@@ -178,12 +179,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Pokazuje niezapisane zdjecia.\nSkrot: <b>Al
 FILEBROWSER_SHOWTRASHHINT;Pokazuje zawartosc kosza.\nSkrot: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Pokazuje zdjecia bez kolorowej etykiety.\nSkrot: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Pokazuje nieocenione zdjecia.\nSkrot: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Rozpocznij przetwarzanie
-FILEBROWSER_STARTPROCESSINGHINT;Rozpoczyna przetwarzanie/zapisywanie plikow z kolejki.
-FILEBROWSER_STOPPROCESSING;Zatrzymaj przetwarzanie
-FILEBROWSER_STOPPROCESSINGHINT;Zatrzymuje przetwarzanie zdjec.
 FILEBROWSER_THUMBSIZE;Rozmiar minaturek
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Rozpocznij przetwarzanie automatycznie gdy pojawi sie nowe zadanie.
 FILEBROWSER_UNRANK_TOOLTIP;Usun ocene.\nSkrot: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Zwieksza rozmiar miniaturek.\n\nSkroty:\n<b>+</b> - Tryb wielu zakladek,\n<b>Alt</b>-<b>+</b> - Tryb pojedynczej zakladki.
 FILEBROWSER_ZOOMOUTHINT;Zmniejsza rozmiar miniaturek.\n\nSkroty:\n<b>-</b> - Tryb wielu zakladek,\n<b>Alt</b>-<b>-</b> - Tryb pojedynczej zakladki.
@@ -1449,6 +1445,7 @@ ZOOMPANEL_ZOOMOUT;Oddal\nSkrot: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1732,6 +1729,12 @@ ZOOMPANEL_ZOOMOUT;Oddal\nSkrot: <b>-</b>
 !PREFERENCES_CLUTSCACHE;HaldCLUT Cache
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Portugues (Brasil)
+++ b/rtdata/languages/Portugues (Brasil)
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Exibir imagens classificadas como 4 estrelas
 FILEBROWSER_SHOWRANK5HINT;Exibir imagens classificadas como 5 estrelas
 FILEBROWSER_SHOWTRASHHINT;Exibir conteúdo da lixeira
 FILEBROWSER_SHOWUNRANKHINT;Exibir imagens não classificadas
-FILEBROWSER_STARTPROCESSING;Iniciar Processamento
-FILEBROWSER_STARTPROCESSINGHINT;Iniciar processamento/salvar imagens da lista
-FILEBROWSER_STOPPROCESSING;Parar processamento
-FILEBROWSER_STOPPROCESSINGHINT;Para o processamento das imagens
 FILEBROWSER_THUMBSIZE;Tamanho das Miniaturas
 FILEBROWSER_ZOOMINHINT;Aumentar Tamanho das Miniaturas
 FILEBROWSER_ZOOMOUTHINT;Diminuir Tamanho das Miniaturas
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;Temperatura
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;Temperatura
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;Temperatura
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Russian
+++ b/rtdata/languages/Russian
@@ -13,6 +13,7 @@ ABOUT_TAB_RELEASENOTES;Примечания к выпуску
 ABOUT_TAB_SPLASH;Заставка
 ADJUSTER_RESET_TO_DEFAULT;Сбросить настройки
 BATCHQUEUE_AUTOSTART;Автостарт
+BATCHQUEUE_AUTOSTARTHINT;Автоматически запускать обработку при добавлении файла в очередь
 BATCHQUEUE_DESTFILENAME;Имя файла и путь к нему
 BATCH_PROCESSING;Пакетная обработка
 CURVEEDITOR_CURVE;Кривая
@@ -173,12 +174,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Показать изображения, с
 FILEBROWSER_SHOWTRASHHINT;Показать содержимое корзины.\nГорячая клавиша: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Показать изображения без цветовой метки.\nГорячая клавиша: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Показать изображения без рейтинга\nГорячая клавиша: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Начать обработку
-FILEBROWSER_STARTPROCESSINGHINT;Запуск обработки помещенных в очередь изображений
-FILEBROWSER_STOPPROCESSING;Остановить обработку
-FILEBROWSER_STOPPROCESSINGHINT;Отмена обработки изображений
 FILEBROWSER_THUMBSIZE;Размер эскиза
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Автоматически запускать обработку при добавлении файла в очередь
 FILEBROWSER_UNRANK_TOOLTIP;Удалить рейтинг\nГорячая клавиша: <b>Shift-~</b>
 FILEBROWSER_ZOOMINHINT;Увеличить размер эскиза\nГорячая клавиша: <b>+</b>\n\nГорячая клавиша в режиме Одиночного редактора: <b>Alt-+</b>
 FILEBROWSER_ZOOMOUTHINT;Уменьшить размер эскиза\nГорячая клавиша: <b>+</b>\n\nГорячая клавиша в режиме Одиночного редактора: <b>Alt--</b>
@@ -1262,6 +1258,7 @@ ZOOMPANEL_ZOOMOUT;Удалить <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1610,6 +1607,12 @@ ZOOMPANEL_ZOOMOUT;Удалить <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Serbian (Cyrilic Characters)
+++ b/rtdata/languages/Serbian (Cyrilic Characters)
@@ -7,6 +7,7 @@ ABOUT_TAB_RELEASENOTES;Белешке о издању
 ABOUT_TAB_SPLASH;Увод
 ADJUSTER_RESET_TO_DEFAULT;Врати на подразумевано
 BATCHQUEUE_AUTOSTART;Сам започни
+BATCHQUEUE_AUTOSTARTHINT;Покреће обраду фотографија када их закажете
 BATCHQUEUE_DESTFILENAME;Путања и име датотеке
 BATCH_PROCESSING;обрада
 CURVEEDITOR_CURVE;Кривуља
@@ -154,12 +155,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Приказује слике које ни
 FILEBROWSER_SHOWTRASHHINT;Приказује слике у смећу
 FILEBROWSER_SHOWUNCOLORHINT;Приказује слике које нису означене бојом <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Прикажи неоцењене слике
-FILEBROWSER_STARTPROCESSING;Започни обраду
-FILEBROWSER_STARTPROCESSINGHINT;Почиње обраду и чување заказаних слика
-FILEBROWSER_STOPPROCESSING;Заустави обраду
-FILEBROWSER_STOPPROCESSINGHINT;Зауставља обраду слика
 FILEBROWSER_THUMBSIZE;Преглед
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Покреће обраду фотографија када их закажете
 FILEBROWSER_UNRANK_TOOLTIP;Неоцењено.\nПречица: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Увећава преглед
 FILEBROWSER_ZOOMOUTHINT;Умањује преглед
@@ -1283,6 +1279,7 @@ ZOOMPANEL_ZOOMOUT;Умањује приказ слике <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1642,6 +1639,12 @@ ZOOMPANEL_ZOOMOUT;Умањује приказ слике <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Serbian (Latin Characters)
+++ b/rtdata/languages/Serbian (Latin Characters)
@@ -7,6 +7,7 @@ ABOUT_TAB_RELEASENOTES;Beleške o izdanju
 ABOUT_TAB_SPLASH;Uvod
 ADJUSTER_RESET_TO_DEFAULT;Vrati na podrazumevano
 BATCHQUEUE_AUTOSTART;Sam započni
+BATCHQUEUE_AUTOSTARTHINT;Pokreće obradu fotografija kada ih zakažete
 BATCHQUEUE_DESTFILENAME;Putanja i ime datoteke
 BATCH_PROCESSING;obrada
 CURVEEDITOR_CURVE;Krivulja
@@ -154,12 +155,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Prikazuje slike koje nisu skoro sačuvane <
 FILEBROWSER_SHOWTRASHHINT;Prikazuje slike u smeću
 FILEBROWSER_SHOWUNCOLORHINT;Prikazuje slike koje nisu označene bojom <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Prikaži neocenjene slike
-FILEBROWSER_STARTPROCESSING;Započni obradu
-FILEBROWSER_STARTPROCESSINGHINT;Počinje obradu i čuvanje zakazanih slika
-FILEBROWSER_STOPPROCESSING;Zaustavi obradu
-FILEBROWSER_STOPPROCESSINGHINT;Zaustavlja obradu slika
 FILEBROWSER_THUMBSIZE;Pregled
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Pokreće obradu fotografija kada ih zakažete
 FILEBROWSER_UNRANK_TOOLTIP;Neocenjeno.\nPrečica: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Uvećava pregled
 FILEBROWSER_ZOOMOUTHINT;Umanjuje pregled
@@ -1283,6 +1279,7 @@ ZOOMPANEL_ZOOMOUT;Umanjuje prikaz slike <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1642,6 +1639,12 @@ ZOOMPANEL_ZOOMOUT;Umanjuje prikaz slike <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Slovak
+++ b/rtdata/languages/Slovak
@@ -4,6 +4,7 @@
 
 ADJUSTER_RESET_TO_DEFAULT;Resetovať na predvolené nastavenia
 BATCHQUEUE_AUTOSTART;Auto štart
+BATCHQUEUE_AUTOSTARTHINT;Začať spracovanie automaticky, keď príde nová úloha
 BATCH_PROCESSING;Dávkové spracovanie
 CURVEEDITOR_CUSTOM;Vlastné
 CURVEEDITOR_DARKS;Tiene
@@ -75,12 +76,7 @@ FILEBROWSER_SHOWRANK4HINT;Ukázať obrázky triedy 4 hviezda
 FILEBROWSER_SHOWRANK5HINT;Ukázať obrázky triedy 5 hviezda
 FILEBROWSER_SHOWTRASHHINT;Zobraziť obsah koša
 FILEBROWSER_SHOWUNRANKHINT;Zobraziť obrázky bez triedy
-FILEBROWSER_STARTPROCESSING;Začať spracovanie
-FILEBROWSER_STARTPROCESSINGHINT;Začať spracovanie/ukladanie obrázkov v rade
-FILEBROWSER_STOPPROCESSING;Zastaviť spracovanie
-FILEBROWSER_STOPPROCESSINGHINT;Zastaviť spracovanie obrázkov
 FILEBROWSER_THUMBSIZE;Veľkosť zmenšenín
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Začať spracovanie automaticky, keď príde nová úloha
 FILEBROWSER_ZOOMINHINT;Zväčšiť veľkosť zmenšenín
 FILEBROWSER_ZOOMOUTHINT;Zmenšiť veľkosť zmenšenín
 GENERAL_ABOUT;O programe
@@ -517,6 +513,7 @@ ZOOMPANEL_ZOOMOUT;Oddialiť <b>-</b>
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_OUT;O:
@@ -1203,6 +1200,12 @@ ZOOMPANEL_ZOOMOUT;Oddialiť <b>-</b>
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Suomi
+++ b/rtdata/languages/Suomi
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Näytä 4 tähden kuvat
 FILEBROWSER_SHOWRANK5HINT;Näytä 5 tähden kuvat
 FILEBROWSER_SHOWTRASHHINT;Näytä roskakorin sisältö
 FILEBROWSER_SHOWUNRANKHINT;Näytä arvostelemattomat kuvat
-FILEBROWSER_STARTPROCESSING;Aloita käsittely
-FILEBROWSER_STARTPROCESSINGHINT;Aloita jonossa olevien kuvien käsittely
-FILEBROWSER_STOPPROCESSING;Lopeta käsittely
-FILEBROWSER_STOPPROCESSINGHINT;Lopeta jonossa olevien kuvien käsittely
 FILEBROWSER_THUMBSIZE;Esikatselun koko
 FILEBROWSER_ZOOMINHINT;Kasvata esikatselukuvien kokoa
 FILEBROWSER_ZOOMOUTHINT;Pienennä esikatselukuvien kokoa
@@ -427,7 +423,9 @@ TP_WBALANCE_TEMPERATURE;Lämpötila [K]
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -558,7 +556,6 @@ TP_WBALANCE_TEMPERATURE;Lämpötila [K]
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1154,6 +1151,12 @@ TP_WBALANCE_TEMPERATURE;Lämpötila [K]
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/Swedish
+++ b/rtdata/languages/Swedish
@@ -10,6 +10,7 @@ ABOUT_TAB_RELEASENOTES;Versionsnyheter
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Återställ till standard
 BATCHQUEUE_AUTOSTART;Autostart
+BATCHQUEUE_AUTOSTARTHINT;Starta behandlingen automatiskt när en ny bild kommer in
 BATCHQUEUE_DESTFILENAME;Sökväg och filnamn
 BATCH_PROCESSING;Batchbehandling
 CURVEEDITOR_AXIS_IN;I:
@@ -178,12 +179,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Visa bilder som inte nyligen sparats\nKortk
 FILEBROWSER_SHOWTRASHHINT;Visa innehållet i papperskorgen
 FILEBROWSER_SHOWUNCOLORHINT;Visa bilder utan färgetikett\nKortkommando: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Visa icke-betygsatta bilder
-FILEBROWSER_STARTPROCESSING;Starta behandlingen
-FILEBROWSER_STARTPROCESSINGHINT;Starta behandlingen och spara bilderna i behandlingskön
-FILEBROWSER_STOPPROCESSING;Avbryt behandlingen
-FILEBROWSER_STOPPROCESSINGHINT;Avbryt behandlingen av bilderna
 FILEBROWSER_THUMBSIZE;Miniatyrbildens storlek
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Starta behandlingen automatiskt när en ny bild kommer in
 FILEBROWSER_UNRANK_TOOLTIP;Ta bort betyg\nKortkommando: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Förstora miniatyrbilderna.\nKortkommando: <b>+</b>\nKortkommado i enkelbildsläget: <b>Alt-+</b>
 FILEBROWSER_ZOOMOUTHINT;Förminska miniatyrbilderna.\nKortkommando: <b>-</b>\nKortkommado i enkelbildsläget: <b>Alt--</b>
@@ -1869,6 +1865,7 @@ ZOOMPANEL_ZOOMOUT;Förminska.\nKortkommando: <b>-</b>
 ! Untranslated keys follow; remove the ! prefix after an entry is translated.
 !!!!!!!!!!!!!!!!!!!!!!!!!
 
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
 !CURVEEDITOR_AXIS_RIGHT_TAN;RT:
 !CURVEEDITOR_EDITPOINT_HINT;Enable edition of node in/out values.\n\nRight-click on a node to select it.\nRight-click on empty space to de-select the node.
@@ -1998,6 +1995,12 @@ ZOOMPANEL_ZOOMOUT;Förminska.\nKortkommando: <b>-</b>
 !PARTIALPASTE_TM_FATTAL;HDR Tone mapping
 !PREFERENCES_AUTOSAVE_TP_OPEN;Automatically save tools collapsed/expanded\nstate before exiting
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_D50_OLD;5000K
 !PREFERENCES_DIRECTORIES;Directories
 !PREFERENCES_EDITORCMDLINE;Custom command line

--- a/rtdata/languages/Turkish
+++ b/rtdata/languages/Turkish
@@ -58,10 +58,6 @@ FILEBROWSER_SHOWRANK4HINT;Show images ranked as 4 star
 FILEBROWSER_SHOWRANK5HINT;Show images ranked as 5 star
 FILEBROWSER_SHOWTRASHHINT;Show content of the trash
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images
-FILEBROWSER_STARTPROCESSING;Start Processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing/saving of images in the queue
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing of images
 FILEBROWSER_THUMBSIZE;Thumb. size
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size
@@ -426,7 +422,9 @@ TP_WBALANCE_TEMPERATURE;Isı
 !ABOUT_TAB_RELEASENOTES;Release Notes
 !ABOUT_TAB_SPLASH;Splash
 !BATCHQUEUE_AUTOSTART;Auto-start
+!BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 !BATCHQUEUE_DESTFILENAME;Path and file name
+!BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 !BATCH_PROCESSING;Batch Processing
 !CURVEEDITOR_AXIS_IN;I:
 !CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -557,7 +555,6 @@ TP_WBALANCE_TEMPERATURE;Isı
 !FILEBROWSER_SHOWRECENTLYSAVEDHINT;Show saved images.\nShortcut: <b>Alt-7</b>
 !FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b>
 !FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
-!FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 !FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 !FILECHOOSER_FILTER_ANY;All files
 !FILECHOOSER_FILTER_COLPROF;Color profiles
@@ -1153,6 +1150,12 @@ TP_WBALANCE_TEMPERATURE;Isı
 !PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 !PREFERENCES_CLUTSDIR;HaldCLUT directory
 !PREFERENCES_CMMBPC;Black point compensation
+!PREFERENCES_CROP;Crop editing
+!PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+!PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
+!PREFERENCES_CROP_GUIDES_FRAME;Frame
+!PREFERENCES_CROP_GUIDES_FULL;Original
+!PREFERENCES_CROP_GUIDES_NONE;None
 !PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 !PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 !PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -9,7 +9,9 @@ ABOUT_TAB_RELEASENOTES;Release Notes
 ABOUT_TAB_SPLASH;Splash
 ADJUSTER_RESET_TO_DEFAULT;Reset to default
 BATCHQUEUE_AUTOSTART;Auto-start
+BATCHQUEUE_AUTOSTARTHINT;Start processing automatically when a new job arrives.
 BATCHQUEUE_DESTFILENAME;Path and file name
+BATCHQUEUE_STARTSTOPHINT;Start or stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 BATCH_PROCESSING;Batch Processing
 CURVEEDITOR_AXIS_IN;I:
 CURVEEDITOR_AXIS_LEFT_TAN;LT:
@@ -197,12 +199,7 @@ FILEBROWSER_SHOWRECENTLYSAVEDNOTHINT;Show unsaved images.\nShortcut: <b>Alt-6</b
 FILEBROWSER_SHOWTRASHHINT;Show contents of trash.\nShortcut: <b>Ctrl-t</b>
 FILEBROWSER_SHOWUNCOLORHINT;Show images without a color label.\nShortcut: <b>Alt-0</b>
 FILEBROWSER_SHOWUNRANKHINT;Show unranked images.\nShortcut: <b>0</b>
-FILEBROWSER_STARTPROCESSING;Start processing
-FILEBROWSER_STARTPROCESSINGHINT;Start processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
-FILEBROWSER_STOPPROCESSING;Stop processing
-FILEBROWSER_STOPPROCESSINGHINT;Stop processing the images in the queue.\n\nShortcut: <b>Ctrl</b>+<b>s</b>
 FILEBROWSER_THUMBSIZE;Thumbnail size
-FILEBROWSER_TOOLTIP_STOPPROCESSING;Start processing automatically when a new job arrives.
 FILEBROWSER_UNRANK_TOOLTIP;Unrank.\nShortcut: <b>Shift-0</b>
 FILEBROWSER_ZOOMINHINT;Increase thumbnail size.\n\nShortcuts:\n<b>+</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>+</b> - Single Editor Tab Mode.
 FILEBROWSER_ZOOMOUTHINT;Decrease thumbnail size.\n\nShortcuts:\n<b>-</b> - Multiple Editor Tabs Mode,\n<b>Alt</b>-<b>-</b> - Single Editor Tab Mode.
@@ -977,11 +974,11 @@ PREFERENCES_CLUTSCACHE_LABEL;Maximum number of cached CLUTs
 PREFERENCES_CLUTSDIR;HaldCLUT directory
 PREFERENCES_CMMBPC;Black point compensation
 PREFERENCES_CROP;Crop editing
+PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
 PREFERENCES_CROP_GUIDES;Guides shown when not editing the crop
-PREFERENCES_CROP_GUIDES_NONE;None
 PREFERENCES_CROP_GUIDES_FRAME;Frame
 PREFERENCES_CROP_GUIDES_FULL;Original
-PREFERENCES_CROP_AUTO_FIT;Automatically zoom to fit the crop area
+PREFERENCES_CROP_GUIDES_NONE;None
 PREFERENCES_CURVEBBOXPOS;Position of curve copy & paste buttons
 PREFERENCES_CURVEBBOXPOS_ABOVE;Above
 PREFERENCES_CURVEBBOXPOS_BELOW;Below

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -249,6 +249,12 @@ void BatchQueuePanel::queueSizeChanged (int qsize, bool queueEmptied, bool queue
 {
     updateTab ( qsize);
 
+    if (qsize == 0 || (qsize == 1 && !fdir->get_sensitive())) {
+        qStartStop->set_sensitive(false);
+    } else {
+        qStartStop->set_sensitive(true);
+    }
+
     if (queueEmptied || queueError) {
         stopBatchProc ();
         fdir->set_sensitive (true);
@@ -283,6 +289,9 @@ void BatchQueuePanel::startBatchProc ()
     if (batchQueue->hasJobs()) {
         fdir->set_sensitive (false);
         fformat->set_sensitive (false);
+        if (batchQueue->getEntries().size() == 1) {
+            qStartStop->set_sensitive(false);
+        }
         saveOptions();
         batchQueue->startProcessing ();
     } else {

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -49,8 +49,6 @@ BatchQueuePanel::BatchQueuePanel (FileCatalog* aFileCatalog) : parent(nullptr)
     Gtk::VBox* batchQueueButtonBox = Gtk::manage (new Gtk::VBox);
     batchQueueButtonBox->set_name("BatchQueueButtons");
 
-    qLbl = Gtk::manage (new Gtk::Label(M("MAIN_FRAME_BATCHQUEUE")));
-
     qStartStop = Gtk::manage (new Gtk::Switch());
     qStartStop->set_tooltip_markup (M("BATCHQUEUE_STARTSTOPHINT"));
     qStartStopConn = qStartStop->property_active().signal_changed().connect (sigc::mem_fun(*this, &BatchQueuePanel::startOrStopBatchProc));
@@ -59,9 +57,10 @@ BatchQueuePanel::BatchQueuePanel (FileCatalog* aFileCatalog) : parent(nullptr)
     qAutoStart->set_tooltip_text (M("BATCHQUEUE_AUTOSTARTHINT"));
     qAutoStart->set_active (options.procQueueEnabled);
 
-    batchQueueButtonBox->pack_start (*qLbl, Gtk::PACK_SHRINK, 4);
     batchQueueButtonBox->pack_start (*qStartStop, Gtk::PACK_SHRINK, 4);
     batchQueueButtonBox->pack_start (*qAutoStart, Gtk::PACK_SHRINK, 4);
+    Gtk::Frame *bbox = Gtk::manage(new Gtk::Frame(M("MAIN_FRAME_BATCHQUEUE")));
+    bbox->add(*batchQueueButtonBox);
 
     // Output directory selection
     fdir = Gtk::manage (new Gtk::Frame (M("PREFERENCES_OUTDIR")));
@@ -134,7 +133,7 @@ BatchQueuePanel::BatchQueuePanel (FileCatalog* aFileCatalog) : parent(nullptr)
     pack_start (*topBox, Gtk::PACK_SHRINK);
     topBox->set_name("BatchQueueButtonsMainContainer");
 
-    topBox->pack_start (*batchQueueButtonBox, Gtk::PACK_SHRINK, 4);
+    topBox->pack_start (*bbox, Gtk::PACK_SHRINK, 4);
     topBox->pack_start (*fdir, Gtk::PACK_EXPAND_WIDGET, 4);
     topBox->pack_start (*fformat, Gtk::PACK_EXPAND_WIDGET, 4);
 

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -46,29 +46,22 @@ BatchQueuePanel::BatchQueuePanel (FileCatalog* aFileCatalog) : parent(nullptr)
 
     batchQueue = Gtk::manage( new BatchQueue(aFileCatalog) );
 
-    // construct batch queue panel with the extra "start" and "stop" button
     Gtk::VBox* batchQueueButtonBox = Gtk::manage (new Gtk::VBox);
     batchQueueButtonBox->set_name("BatchQueueButtons");
 
-    start = Gtk::manage (new Gtk::ToggleButton ());
-    stop = Gtk::manage (new Gtk::ToggleButton ());
-    autoStart = Gtk::manage (new Gtk::CheckButton (M("BATCHQUEUE_AUTOSTART")));
-    start->set_tooltip_markup (M("FILEBROWSER_STARTPROCESSINGHINT"));
-    stop->set_tooltip_markup (M("FILEBROWSER_STOPPROCESSINGHINT"));
-    autoStart->set_tooltip_text (M("FILEBROWSER_TOOLTIP_STOPPROCESSING"));
-    start->set_active (false);
-    stop->set_active (true);
-    autoStart->set_active (options.procQueueEnabled);
+    qLbl = Gtk::manage (new Gtk::Label(M("MAIN_FRAME_BATCHQUEUE")));
 
-    start->set_image (*Gtk::manage (new RTImage ("gtk-media-play.png")));
-    start->get_style_context()->add_class("BIG");
-    startConnection = start->signal_toggled().connect (sigc::mem_fun(*this, &BatchQueuePanel::startBatchProc));
-    stop->set_image (*Gtk::manage (new RTImage ("gtk-media-stop.png")));
-    stop->get_style_context()->add_class("BIG");
-    stopConnection = stop->signal_toggled().connect (sigc::mem_fun(*this, &BatchQueuePanel::stopBatchProc));
-    batchQueueButtonBox->pack_start (*start, Gtk::PACK_SHRINK, 4);
-    batchQueueButtonBox->pack_start (*stop, Gtk::PACK_SHRINK, 4);
-    batchQueueButtonBox->pack_start (*autoStart, Gtk::PACK_SHRINK, 4);
+    qStartStop = Gtk::manage (new Gtk::Switch());
+    qStartStop->set_tooltip_markup (M("BATCHQUEUE_STARTSTOPHINT"));
+    qStartStopConn = qStartStop->property_active().signal_changed().connect (sigc::mem_fun(*this, &BatchQueuePanel::startOrStopBatchProc));
+
+    qAutoStart = Gtk::manage (new Gtk::CheckButton (M("BATCHQUEUE_AUTOSTART")));
+    qAutoStart->set_tooltip_text (M("BATCHQUEUE_AUTOSTARTHINT"));
+    qAutoStart->set_active (options.procQueueEnabled);
+
+    batchQueueButtonBox->pack_start (*qLbl, Gtk::PACK_SHRINK, 4);
+    batchQueueButtonBox->pack_start (*qStartStop, Gtk::PACK_SHRINK, 4);
+    batchQueueButtonBox->pack_start (*qAutoStart, Gtk::PACK_SHRINK, 4);
 
     // Output directory selection
     fdir = Gtk::manage (new Gtk::Frame (M("PREFERENCES_OUTDIR")));
@@ -216,7 +209,7 @@ void BatchQueuePanel::updateTab (int qsize, int forceOrientation)
         if(!qsize ) {
             grid->attach_next_to(*Gtk::manage (new RTImage ("processing.png")), Gtk::POS_TOP, 1, 1);
             l = Gtk::manage (new Gtk::Label (Glib::ustring(" ") + M("MAIN_FRAME_BATCHQUEUE")) );
-        } else if( start->get_active () ) {
+        } else if (qStartStop->get_active()) {
             grid->attach_next_to(*Gtk::manage (new RTImage ("processing-play.png")), Gtk::POS_TOP, 1, 1);
             l = Gtk::manage (new Gtk::Label (Glib::ustring(" ") + M("MAIN_FRAME_BATCHQUEUE") + " [" + Glib::ustring::format( qsize ) + "]"));
         } else {
@@ -236,7 +229,7 @@ void BatchQueuePanel::updateTab (int qsize, int forceOrientation)
         if (!qsize ) {
             grid->attach_next_to(*Gtk::manage (new RTImage ("processing.png")), Gtk::POS_RIGHT, 1, 1);
             grid->attach_next_to(*Gtk::manage (new Gtk::Label (M("MAIN_FRAME_BATCHQUEUE") )), Gtk::POS_RIGHT, 1, 1);
-        } else if ( start->get_active () ) {
+        } else if (!qStartStop->get_active()) {
             grid->attach_next_to(*Gtk::manage (new RTImage ("processing-play.png")), Gtk::POS_RIGHT, 1, 1);
             grid->attach_next_to(*Gtk::manage (new Gtk::Label (M("MAIN_FRAME_BATCHQUEUE") + " [" + Glib::ustring::format( qsize ) + "]" )), Gtk::POS_RIGHT, 1, 1);
         } else {
@@ -271,15 +264,22 @@ void BatchQueuePanel::queueSizeChanged (int qsize, bool queueEmptied, bool queue
     }
 }
 
+void BatchQueuePanel::startOrStopBatchProc()
+{
+    bool state = qStartStop->get_state();
+    if (state) {
+        startBatchProc();
+    } else {
+        stopBatchProc();
+    }
+}
+
 void BatchQueuePanel::startBatchProc ()
 {
-
-    stopConnection.block (true);
-    startConnection.block (true);
-    stop->set_active (false);
-    start->set_active (true);
-    stopConnection.block (false);
-    startConnection.block (false);
+    // Update switch when queue started programmatically
+    qStartStopConn.block (true);
+    qStartStop->set_active(true);
+    qStartStopConn.block (false);
 
     if (batchQueue->hasJobs()) {
         fdir->set_sensitive (false);
@@ -295,13 +295,11 @@ void BatchQueuePanel::startBatchProc ()
 
 void BatchQueuePanel::stopBatchProc ()
 {
+    // Update switch when queue started programmatically
+    qStartStopConn.block (true);
+    qStartStop->set_active(false);
+    qStartStopConn.block (false);
 
-    stopConnection.block (true);
-    startConnection.block (true);
-    stop->set_active (true);
-    start->set_active (false);
-    stopConnection.block (false);
-    startConnection.block (false);
     updateTab (batchQueue->getEntries().size());
 }
 
@@ -310,7 +308,7 @@ void BatchQueuePanel::addBatchQueueJobs ( std::vector<BatchQueueEntry*> &entries
 
     batchQueue->addEntries (entries, head);
 
-    if (stop->get_active () && autoStart->get_active ()) {
+    if (!qStartStop->get_active() && qAutoStart->get_active()) {
         startBatchProc ();
     }
 }
@@ -318,7 +316,7 @@ void BatchQueuePanel::addBatchQueueJobs ( std::vector<BatchQueueEntry*> &entries
 bool BatchQueuePanel::canStartNext ()
 {
 
-    if (start->get_active ()) {
+    if (qStartStop->get_active()) {
         return true;
     } else {
         fdir->set_sensitive (true);
@@ -332,7 +330,7 @@ void BatchQueuePanel::saveOptions ()
 
     options.savePathTemplate    = outdirTemplate->get_text();
     options.saveUsePathTemplate = useTemplate->get_active();
-    options.procQueueEnabled    = autoStart->get_active ();
+    options.procQueueEnabled    = qAutoStart->get_active();
 }
 
 void BatchQueuePanel::pathFolderButtonPressed ()
@@ -375,7 +373,7 @@ bool BatchQueuePanel::handleShortcutKey (GdkEventKey* event)
     if (ctrl) {
         switch(event->keyval) {
         case GDK_KEY_s:
-            if (start->get_active()) {
+            if (qStartStop->get_active()) {
                 stopBatchProc();
             } else {
                 startBatchProc();

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -32,13 +32,12 @@ class BatchQueuePanel : public Gtk::VBox,
     public FormatChangeListener
 {
 
+    Gtk::Label* qLbl;
     Gtk::Button* zoomInButton;
     Gtk::Button* zoomOutButton;
-    Gtk::ToggleButton* start;
-    Gtk::ToggleButton* stop;
-    Gtk::CheckButton* autoStart;
-    sigc::connection startConnection;
-    sigc::connection stopConnection;
+    Gtk::Switch* qStartStop;
+    sigc::connection qStartStopConn;
+    Gtk::CheckButton* qAutoStart;
 
     Gtk::Entry* outdirTemplate;
     MyFileChooserButton* outdirFolder;
@@ -69,6 +68,7 @@ public:
 
     void startBatchProc ();
     void stopBatchProc ();
+    void startOrStopBatchProc();
 
     void saveOptions ();
     void pathFolderChanged ();

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -32,7 +32,6 @@ class BatchQueuePanel : public Gtk::VBox,
     public FormatChangeListener
 {
 
-    Gtk::Label* qLbl;
     Gtk::Button* zoomInButton;
     Gtk::Button* zoomOutButton;
     Gtk::Switch* qStartStop;


### PR DESCRIPTION
Improvement to the Batch Queue:
- Start Queue/Stop Queue checkboxes replaced with one swith.
- It is now immediately clear whether the queue is running or not.
- The queue is visually stopped once it is empty.
- String keys fixed to use BATCHQUEUE_ prefix instead of FILEBROWSER_.