### PR TITLE
Bugfix in LabGrid class + code refactoring

### DIFF
--- a/rtdata/languages/Francais
+++ b/rtdata/languages/Francais
@@ -1381,6 +1381,7 @@ TP_COLORTONING_HIGHLIGHT;Hautes lumières
 TP_COLORTONING_HUE;Teinte
 TP_COLORTONING_LAB;Mixage Lab
 TP_COLORTONING_LABEL;Virage Partiel
+TP_COLORTONING_LABGRID_VALUES;HL: a=%1 b=%2\nO: a=%3 b=%4
 TP_COLORTONING_LUMA;Luminance
 TP_COLORTONING_LUMAMODE;Préserver la luminance
 TP_COLORTONING_LUMAMODE_TOOLTIP;Si activé, lorsque vous changez la couleur (rouge, vert, cyan, bleu, etc.), la luminance de chaque pixel est préservé

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1407,6 +1407,7 @@ TP_COLORTONING_HUE;Hue
 TP_COLORTONING_LAB;L*a*b* blending
 TP_COLORTONING_LABEL;Color Toning
 TP_COLORTONING_LABGRID;L*a*b* color correction grid
+TP_COLORTONING_LABGRID_VALUES;HL: a=%1 b=%2\nS: a=%3 b=%4
 TP_COLORTONING_LUMA;Luminance
 TP_COLORTONING_LUMAMODE;Preserve luminance
 TP_COLORTONING_LUMAMODE_TOOLTIP;If enabled, when you change color (red, green, cyan, blue, etc.) the luminance of each pixel is preserved.

--- a/rtgui/blackwhite.cc
+++ b/rtgui/blackwhite.cc
@@ -1003,7 +1003,7 @@ void BlackWhite::autoch_toggled ()
         bool wasEnabled = disableListener();
 
         if (mixerRed->getAddMode()) {
-            mixerRed->resetValue(false);
+            mixerRed->resetValue(true);
         }
 
         if (mixerGreen->getAddMode()) {
@@ -1053,14 +1053,14 @@ void BlackWhite::autoch_toggled ()
     } else {
         if (autoch->get_active()) {
             bool wasEnabled = disableListener();
-            mixerRed->setValue(33);
-            mixerGreen->setValue(33);
-            mixerBlue->setValue(33);
-            mixerOrange->setValue(33);
-            mixerYellow->setValue(33);
-            mixerMagenta->setValue(33);
-            mixerPurple->setValue(33);
-            mixerCyan->setValue(33);
+            mixerRed->resetValue(false);
+            mixerGreen->resetValue(false);
+            mixerBlue->resetValue(false);
+            mixerOrange->resetValue(false);
+            mixerYellow->resetValue(false);
+            mixerMagenta->resetValue(false);
+            mixerPurple->resetValue(false);
+            mixerCyan->resetValue(false);
             setting->set_active (11);
             filter->set_active (0);
 

--- a/rtgui/colortoning.h
+++ b/rtgui/colortoning.h
@@ -12,6 +12,7 @@
 #include "curveeditorgroup.h"
 #include "thresholdadjuster.h"
 #include "colorprovider.h"
+#include "labgrid.h"
 
 class ColorToning final :
     public ToolParamBlock,
@@ -105,7 +106,8 @@ private:
 
     rtengine::ProcEvent EvColorToningLabGridValue;
     Gtk::Button *labgridReset;
-    Gtk::DrawingArea *labgridArea;
+    LabGrid *labgrid;
+    Gtk::HBox *labgridBox;
 
     IdleRegister idle_register;
 };

--- a/rtgui/labgrid.cc
+++ b/rtgui/labgrid.cc
@@ -41,208 +41,270 @@
 using rtengine::Color;
 
 
-bool LabGrid::notify_listener()
+bool LabGrid::notifyListener()
 {
-    if (listener_) {
-        listener_->panelChanged(evt_, Glib::ustring::compose("%1 %2 %3 %4", int(low_a_), int(low_b_), int(high_a_), int(high_b_)));
+    if (listener) {
+        listener->panelChanged(evt, Glib::ustring::compose(M("TP_COLORTONING_LABGRID_VALUES"), int(low_a), int(low_b), int(high_a), int(high_b)));
     }
     return false;
 }
-    
+
 
 LabGrid::LabGrid(rtengine::ProcEvent evt):
     Gtk::DrawingArea(),
-    evt_(evt), selected_(OFF),
-    low_a_(0.f), high_a_(0.f), low_b_(0.f), high_b_(0.f),
-    listener_(nullptr),
-    edited_(false)
+    evt(evt), litPoint(NONE),
+    low_a(0.f), high_a(0.f), low_b(0.f), high_b(0.f),
+    defaultLow_a(0.f), defaultHigh_a(0.f), defaultLow_b(0.f), defaultHigh_b(0.f),
+    listener(nullptr),
+    edited(false),
+    isDragged(false)
 {
     set_can_focus(true);
-    add_events(Gdk::EXPOSURE_MASK | Gdk::BUTTON_PRESS_MASK | Gdk::POINTER_MOTION_MASK);
+    add_events(Gdk::EXPOSURE_MASK | Gdk::BUTTON_PRESS_MASK | Gdk::BUTTON_RELEASE_MASK | Gdk::POINTER_MOTION_MASK);
+}
+
+void LabGrid::getParams(double &la, double &lb, double &ha, double &hb) const
+{
+    la = low_a;
+    ha = high_a;
+    lb = low_b;
+    hb = high_b;
 }
 
 
-void LabGrid::get_params(double &la, double &lb, double &ha, double &hb) const
+void LabGrid::setParams(double la, double lb, double ha, double hb, bool notify)
 {
-    la = low_a_;
-    ha = high_a_;
-    lb = low_b_;
-    hb = high_b_;
-}
-
-
-void LabGrid::set_params(double la, double lb, double ha, double hb, bool notify)
-{
-    low_a_ = la;
-    low_b_ = lb;
-    high_a_ = ha;
-    high_b_ = hb;
+    low_a = la;
+    low_b = lb;
+    high_a = ha;
+    high_b = hb;
     queue_draw();
     if (notify) {
-        notify_listener();
+        notifyListener();
+    }
+}
+
+void LabGrid::setDefault (double la, double lb, double ha, double hb)
+{
+    defaultLow_a = la;
+    defaultLow_b = lb;
+    defaultHigh_a = ha;
+    defaultHigh_b = hb;
+}
+
+
+void LabGrid::reset(bool toInitial)
+{
+    if (toInitial) {
+        setParams(defaultLow_a, defaultLow_b, defaultHigh_a, defaultHigh_b, true);
+    } else {
+        setParams(0., 0., 0., 0., true);
     }
 }
 
 
-void LabGrid::set_edited(bool yes)
+void LabGrid::setEdited(bool yes)
 {
-    edited_ = yes;
+    edited = yes;
 }
 
 
-bool LabGrid::get_edited() const
+bool LabGrid::getEdited() const
 {
-    return edited_;
+    return edited;
 }
 
 
-void LabGrid::set_listener(ToolPanelListener *l)
+void LabGrid::setListener(ToolPanelListener *l)
 {
-    listener_ = l;
+    listener = l;
+}
+
+
+void LabGrid::on_style_updated ()
+{
+    setDirty(true);
+    queue_draw ();
 }
 
 
 bool LabGrid::on_draw(const ::Cairo::RefPtr<Cairo::Context> &crf)
 {
-    int width = get_allocated_width();
-    int height = get_allocated_height();
-    Cairo::RefPtr<Cairo::ImageSurface> cst =
-        Cairo::ImageSurface::create(Cairo::FORMAT_ARGB32, width, height);
-    Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(cst);
-    // clear bg
-    cr->set_source_rgb(.2, .2, .2);
-    cr->paint();
-    
-    cr->translate(inset, inset);
-    cr->set_antialias(Cairo::ANTIALIAS_NONE);
-    width -= 2 * inset;
-    height -= 2 * inset;
-    // flip y:
-    cr->translate(0, height);
-    cr->scale(1., -1.);
-    const int cells = 8;
-    float step = rtengine::ColorToningParams::LABGRID_CORR_MAX / float(cells/2);
-    for (int j = 0; j < cells; j++) {
-        for (int i = 0; i < cells; i++) {
-            float R, G, B;
-            float x, y, z;
-            int ii = i - cells/2;
-            int jj = j - cells/2;
-            float a = step * (ii + 0.5);
-            float b = step * (jj + 0.5);
-            Color::Lab2XYZ(25000.f, a, b, x, y, z);
-            Color::xyz2srgb(x, y, z, R, G, B);
-            cr->set_source_rgb(R / 65535.f, G / 65535.f, B / 65535.f);
-            cr->rectangle(width * i / float(cells), height * j / float(cells), width / float(cells) - 1, height / float(cells) - 1);
-            cr->fill();
+    Gtk::Allocation allocation = get_allocation();
+    allocation.set_x(0);
+    allocation.set_y(0);
+
+    // setDrawRectangle will allocate the backbuffer Surface
+    if (setDrawRectangle(Cairo::FORMAT_ARGB32, allocation)) {
+        setDirty(true);
+    }
+
+    if (!isDirty() || !surfaceCreated()) {
+        return true;
+    }
+
+    Glib::RefPtr<Gtk::StyleContext> style = get_style_context();
+    Cairo::RefPtr<Cairo::Context> cr = getContext();
+
+    if (isDirty()) {
+        int width = allocation.get_width();
+        int height = allocation.get_height();
+
+        cr->set_line_cap(Cairo::LINE_CAP_SQUARE);
+
+        // clear background
+        cr->set_source_rgba (0., 0., 0., 0.);
+        cr->set_operator (Cairo::OPERATOR_CLEAR);
+        cr->paint ();
+        cr->set_operator (Cairo::OPERATOR_OVER);
+        style->render_background(cr, 0, 0, width, height);
+
+        // drawing the cells
+        cr->translate(inset, inset);
+        cr->set_antialias(Cairo::ANTIALIAS_NONE);
+        width -= 2 * inset;
+        height -= 2 * inset;
+        // flip y:
+        cr->translate(0, height);
+        cr->scale(1., -1.);
+        const int cells = 8;
+        float step = rtengine::ColorToningParams::LABGRID_CORR_MAX / float(cells/2);
+        for (int j = 0; j < cells; j++) {
+            for (int i = 0; i < cells; i++) {
+                float R, G, B;
+                float x, y, z;
+                int ii = i - cells/2;
+                int jj = j - cells/2;
+                float a = step * (ii + 0.5);
+                float b = step * (jj + 0.5);
+                Color::Lab2XYZ(25000.f, a, b, x, y, z);
+                Color::xyz2srgb(x, y, z, R, G, B);
+                cr->set_source_rgb(R / 65535.f, G / 65535.f, B / 65535.f);
+                cr->rectangle(width * i / float(cells), height * j / float(cells), width / float(cells) - 1, height / float(cells) - 1);
+                cr->fill();
+            }
         }
-    }
-    cr->set_antialias(Cairo::ANTIALIAS_DEFAULT);
-    float loa, hia, lob, hib;
-    loa = .5f * (width + width * low_a_ / rtengine::ColorToningParams::LABGRID_CORR_MAX);
-    hia = .5f * (width + width * high_a_ / rtengine::ColorToningParams::LABGRID_CORR_MAX);
-    lob = .5f * (height + height * low_b_ / rtengine::ColorToningParams::LABGRID_CORR_MAX);
-    hib = .5f * (height + height * high_b_ / rtengine::ColorToningParams::LABGRID_CORR_MAX);
-    cr->set_line_width(2.);
-    cr->set_source_rgb(0.6, 0.6, 0.6);
-    cr->move_to(loa, lob);
-    cr->line_to(hia, hib);
-    cr->stroke();
 
-    cr->set_source_rgb(0.1, 0.1, 0.1);
-    if (selected_ == LOW) {
-        cr->arc(loa, lob, 5, 0, 2. * rtengine::RT_PI);
-    } else {
-        cr->arc(loa, lob, 3, 0, 2. * rtengine::RT_PI);
-    }
-    cr->fill();
+        // drawing the connection line
+        cr->set_antialias(Cairo::ANTIALIAS_DEFAULT);
+        float loa, hia, lob, hib;
+        loa = .5f * (width + width * low_a / rtengine::ColorToningParams::LABGRID_CORR_MAX);
+        hia = .5f * (width + width * high_a / rtengine::ColorToningParams::LABGRID_CORR_MAX);
+        lob = .5f * (height + height * low_b / rtengine::ColorToningParams::LABGRID_CORR_MAX);
+        hib = .5f * (height + height * high_b / rtengine::ColorToningParams::LABGRID_CORR_MAX);
+        cr->set_line_width(2.);
+        cr->set_source_rgb(0.6, 0.6, 0.6);
+        cr->move_to(loa, lob);
+        cr->line_to(hia, hib);
+        cr->stroke();
 
-    cr->set_source_rgb(0.9, 0.9, 0.9);
-    if (selected_ == HIGH) {
-        cr->arc(hia, hib, 5, 0, 2. * rtengine::RT_PI);
-    } else {
-        cr->arc(hia, hib, 3, 0, 2. * rtengine::RT_PI);
-    }
-    cr->fill();
+        // drawing points
+        cr->set_source_rgb(0.1, 0.1, 0.1);
+        if (litPoint == LOW) {
+            cr->arc(loa, lob, 5, 0, 2. * rtengine::RT_PI);
+        } else {
+            cr->arc(loa, lob, 3, 0, 2. * rtengine::RT_PI);
+        }
+        cr->fill();
 
-    crf->set_source(cst, 0, 0);
-    crf->paint();
-        
-    return true;
+        cr->set_source_rgb(0.9, 0.9, 0.9);
+        if (litPoint == HIGH) {
+            cr->arc(hia, hib, 5, 0, 2. * rtengine::RT_PI);
+        } else {
+            cr->arc(hia, hib, 3, 0, 2. * rtengine::RT_PI);
+        }
+        cr->fill();
+    }
+
+    copySurface(crf);
+    return false;
 }
 
 
 bool LabGrid::on_button_press_event(GdkEventButton *event)
 {
-    if (event->button == 1 && event->type == GDK_2BUTTON_PRESS) {
-        switch (selected_) {
-        case OFF:
-            low_a_ = low_b_ = high_a_ = high_b_ = 0.f;
-            break;
-        case LOW:
-            low_a_ = low_b_ = 0.f;
-            break;
-        case HIGH:
-            high_a_ = high_b_ = 0.f;
-            break;
+    if (event->button == 1) {
+        if (event->type == GDK_2BUTTON_PRESS) {
+            switch (litPoint) {
+            case NONE:
+                low_a = low_b = high_a = high_b = 0.f;
+                break;
+            case LOW:
+                low_a = low_b = 0.f;
+                break;
+            case HIGH:
+                high_a = high_b = 0.f;
+                break;
+            }
+            edited = true;
+        } else if (event->type == GDK_BUTTON_PRESS && litPoint != NONE) {
+            isDragged = true;
         }
-        edited_ = true;
-        queue_draw();
-        notify_listener();
+        return false;
     }
     return true;
 }
-    
+
+
+bool LabGrid::on_button_release_event(GdkEventButton *event)
+{
+    if (event->button == 1) {
+        isDragged = false;
+        return false;
+    }
+    return true;
+}
+
 
 bool LabGrid::on_motion_notify_event(GdkEventMotion *event)
 {
-    if (delay_conn_.connected()) {
-        delay_conn_.disconnect();
+    if (isDragged && delayconn.connected()) {
+        delayconn.disconnect();
     }
-        
+
+    State oldLitPoint = litPoint;
+
     int width = get_allocated_width() - 2 * inset, height = get_allocated_height() - 2 * inset;
     const float mouse_x = std::min(std::max(event->x - inset, 0.), double(width));
     const float mouse_y = std::min(std::max(height - 1 - event->y + inset, 0.), double(height));
     const float ma = (2.0 * mouse_x - width) / (float)width;
     const float mb = (2.0 * mouse_y - height) / (float)height;
-    bool refresh = selected_ != OFF;
-    if (event->state & GDK_BUTTON1_MASK) {
-        if (selected_ == LOW) {
-            low_a_ = ma * rtengine::ColorToningParams::LABGRID_CORR_MAX;
-            low_b_ = mb * rtengine::ColorToningParams::LABGRID_CORR_MAX;
-        } else if (selected_ == HIGH) {
-            high_a_ = ma * rtengine::ColorToningParams::LABGRID_CORR_MAX;
-            high_b_ = mb * rtengine::ColorToningParams::LABGRID_CORR_MAX;
+    if (isDragged) {
+        if (litPoint == LOW) {
+            low_a = ma * rtengine::ColorToningParams::LABGRID_CORR_MAX;
+            low_b = mb * rtengine::ColorToningParams::LABGRID_CORR_MAX;
+        } else if (litPoint == HIGH) {
+            high_a = ma * rtengine::ColorToningParams::LABGRID_CORR_MAX;
+            high_b = mb * rtengine::ColorToningParams::LABGRID_CORR_MAX;
         }
+        grab_focus();
+        if (options.adjusterMinDelay == 0) {
+            notifyListener();
+        } else {
+            delayconn = Glib::signal_timeout().connect(sigc::mem_fun(*this, &LabGrid::notifyListener), options.adjusterMinDelay);
+        }
+        queue_draw();
     } else {
-        selected_ = OFF;
-        float la = low_a_ / rtengine::ColorToningParams::LABGRID_CORR_MAX;
-        float lb = low_b_ / rtengine::ColorToningParams::LABGRID_CORR_MAX;
-        float ha = high_a_ / rtengine::ColorToningParams::LABGRID_CORR_MAX;
-        float hb = high_b_ / rtengine::ColorToningParams::LABGRID_CORR_MAX;
+        litPoint = NONE;
+        float la = low_a / rtengine::ColorToningParams::LABGRID_CORR_MAX;
+        float lb = low_b / rtengine::ColorToningParams::LABGRID_CORR_MAX;
+        float ha = high_a / rtengine::ColorToningParams::LABGRID_CORR_MAX;
+        float hb = high_b / rtengine::ColorToningParams::LABGRID_CORR_MAX;
         const float thrs = 0.05f;
         const float distlo = (la - ma) * (la - ma) + (lb - mb) * (lb - mb);
         const float disthi = (ha - ma) * (ha - ma) + (hb - mb) * (hb - mb);
         if (distlo < thrs * thrs && distlo < disthi) {
-            selected_ = LOW;
+            litPoint = LOW;
         } else if (disthi < thrs * thrs && disthi <= distlo) {
-            selected_ = HIGH;
+            litPoint = HIGH;
         }
-    }
-    if (selected_ != OFF) {
-        grab_focus();
-        if (options.adjusterMinDelay == 0) {
-            notify_listener();
-        } else {
-            delay_conn_ = Glib::signal_timeout().connect(sigc::mem_fun(*this, &LabGrid::notify_listener), options.adjusterMinDelay);
+        if ((oldLitPoint == NONE && litPoint != NONE) || (oldLitPoint != NONE && litPoint == NONE)) {
+            queue_draw();
         }
-    }
-    if (refresh) {
-        queue_draw();
     }
     return true;
 }
-    
+
 
 Gtk::SizeRequestMode LabGrid::get_request_mode_vfunc() const
 {
@@ -253,7 +315,7 @@ Gtk::SizeRequestMode LabGrid::get_request_mode_vfunc() const
 void LabGrid::get_preferred_width_vfunc(int &minimum_width, int &natural_width) const
 {
     minimum_width = 50;
-    natural_width = 200;
+    natural_width = 150;  // same as GRAPH_SIZE from mycurve.h
 }
 
 

--- a/rtgui/labgrid.h
+++ b/rtgui/labgrid.h
@@ -43,33 +43,45 @@
 #include "toolpanel.h"
 
 
-class LabGrid: public Gtk::DrawingArea {
+class LabGrid: public Gtk::DrawingArea, public BackBuffer {
 private:
-    rtengine::ProcEvent evt_;
-    enum State { OFF, HIGH, LOW };
-    State selected_;
-    float low_a_;
-    float high_a_;
-    float low_b_;
-    float high_b_;
-    ToolPanelListener *listener_;
-    bool edited_;
-    sigc::connection delay_conn_;
+    rtengine::ProcEvent evt;
+    enum State { NONE, HIGH, LOW };
+    State litPoint;
+    float low_a;
+    float high_a;
+    float low_b;
+    float high_b;
+
+    float defaultLow_a;
+    float defaultHigh_a;
+    float defaultLow_b;
+    float defaultHigh_b;
+
+    ToolPanelListener *listener;
+    bool edited;
+    bool isDragged;
+    sigc::connection delayconn;
     static const int inset = 2;
 
-    bool notify_listener();
-    
+    bool notifyListener();
+    void getLitPoint();
+
 public:
     LabGrid(rtengine::ProcEvent evt);
 
-    void get_params(double &la, double &lb, double &ha, double &hb) const;
-    void set_params(double la, double lb, double ha, double hb, bool notify);
-    void set_edited(bool yes);
-    bool get_edited() const;
-    void set_listener(ToolPanelListener *l);
+    void getParams(double &la, double &lb, double &ha, double &hb) const;
+    void setParams(double la, double lb, double ha, double hb, bool notify);
+    void setDefault (double la, double lb, double ha, double hb);
+    void setEdited(bool yes);
+    bool getEdited() const;
+    void reset(bool toInitial);
+    void setListener(ToolPanelListener *l);
 
     bool on_draw(const ::Cairo::RefPtr<Cairo::Context> &crf);
+    void on_style_updated ();
     bool on_button_press_event(GdkEventButton *event);
+    bool on_button_release_event(GdkEventButton *event);
     bool on_motion_notify_event(GdkEventMotion *event);
     Gtk::SizeRequestMode get_request_mode_vfunc() const;
     void get_preferred_width_vfunc(int &minimum_width, int &natural_width) const;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1543,9 +1543,6 @@ void ParamsEdited::combine (rtengine::procparams::ProcParams& toEdit, const rten
     if (colorToning.labgridALow) {
         toEdit.colorToning.labgridALow = mods.colorToning.labgridALow;
     }
-    if (colorToning.labgridALow) {
-        toEdit.colorToning.labgridALow = mods.colorToning.labgridALow;
-    }
     if (colorToning.labgridBLow) {
         toEdit.colorToning.labgridBLow = mods.colorToning.labgridBLow;
     }


### PR DESCRIPTION
- suppressed trailing `_` char for class' parameters
- renamed function name (those not related to Gtk) to lowerCamelCase
- changed the mecanism of dragging point, to avoid throwing unecessary `panelChange` event
- added a `reset` function, with support of `toInitial` to get back the values at load time (CTRL+click on reset button)
- `on_draw` optimisation: now LabGrid IS A BackBuffer