### PR TITLE
made histogram matching depend on the input profile

### DIFF
--- a/rtengine/imagesource.h
+++ b/rtengine/imagesource.h
@@ -139,7 +139,7 @@ public:
     }
 
     // for RAW files, compute a tone curve using histogram matching on the embedded thumbnail
-    virtual void getAutoMatchedToneCurve(std::vector<double> &outCurve)
+    virtual void getAutoMatchedToneCurve(const ColorManagementParams &cp, std::vector<double> &outCurve)
     {
         outCurve = { 0.0 };
     }

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -447,7 +447,7 @@ void ImProcCoordinator::updatePreviewImage (int todo, Crop* cropCall)
                                             params.toneCurve.black, params.toneCurve.hlcompr, params.toneCurve.hlcomprthresh, params.toneCurve.hrenabled);
         }
         if (params.toneCurve.histmatching) {
-            imgsrc->getAutoMatchedToneCurve(params.toneCurve.curve);
+            imgsrc->getAutoMatchedToneCurve(params.icm, params.toneCurve.curve);
 
             if (params.toneCurve.autoexp) {
                 params.toneCurve.expcomp = 0.0;

--- a/rtengine/rawimagesource.h
+++ b/rtengine/rawimagesource.h
@@ -96,6 +96,7 @@ protected:
     float psBlueBrightness[4];
 
     std::vector<double> histMatchingCache;
+    ColorManagementParams histMatchingParams;
 
     void hphd_vertical       (float** hpmap, int col_from, int col_to);
     void hphd_horizontal     (float** hpmap, int row_from, int row_to);
@@ -186,7 +187,7 @@ public:
     }
     void        getAutoExpHistogram (LUTu & histogram, int& histcompr);
     void        getRAWHistogram (LUTu & histRedRaw, LUTu & histGreenRaw, LUTu & histBlueRaw);
-    void getAutoMatchedToneCurve(std::vector<double> &outCurve);
+    void getAutoMatchedToneCurve(const ColorManagementParams &cp, std::vector<double> &outCurve);
     DCPProfile *getDCP(const ColorManagementParams &cmp, DCPProfile::ApplyState &as);
 
     void convertColorSpace(Imagefloat* image, const ColorManagementParams &cmp, const ColorTemp &wb);

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -74,7 +74,7 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     0,                // EvLDNEdgeTolerance: obsolete,
     0,                // EvCDNEnabled:obsolete,
     0,                // free entry
-    RGBCURVE,         // EvDCPToneCurve,
+    RGBCURVE|M_AUTOEXP, // EvDCPToneCurve,
     ALLNORAW,         // EvDCPIlluminant,
     RETINEX,          // EvSHEnabled,
     RGBCURVE,         // EvSHHighlights,
@@ -419,8 +419,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     DIRPYREQUALIZER,  // EvWavgreenlow
     DIRPYREQUALIZER,  // EvWavbluelow
     DIRPYREQUALIZER,  // EvWavNeutral
-    RGBCURVE,         // EvDCPApplyLookTable,
-    RGBCURVE,         // EvDCPApplyBaselineExposureOffset,
+    RGBCURVE|M_AUTOEXP, // EvDCPApplyLookTable,
+    RGBCURVE|M_AUTOEXP, // EvDCPApplyBaselineExposureOffset,
     ALLNORAW,         // EvDCPApplyHueSatMap
     DIRPYREQUALIZER,  // EvWavenacont
     DIRPYREQUALIZER,  // EvWavenachrom

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -741,7 +741,7 @@ private:
             ipf.getAutoExp (aehist, aehistcompr, params.toneCurve.clip, expcomp, bright, contr, black, hlcompr, hlcomprthresh);
         }
         if (params.toneCurve.histmatching) {
-            imgsrc->getAutoMatchedToneCurve(params.toneCurve.curve);
+            imgsrc->getAutoMatchedToneCurve(params.icm, params.toneCurve.curve);
 
             if (params.toneCurve.autoexp) {
                 params.toneCurve.expcomp = 0.0;


### PR DESCRIPTION
This improves the accuracy of the matching when using non-default profiles.

IMHO this is the "right thing" to do, though I'm fine with postponing to after 5.4 if it's too late now.
