### PR TITLE
Avoid unnecessary processing when zooming to >= 100% or opening detai…

### DIFF
--- a/rtgui/crophandler.cc
+++ b/rtgui/crophandler.cc
@@ -198,9 +198,10 @@ void CropHandler::setZoom (int z, int centerx, int centery)
     compDim ();
 
     if (enabled && (oldZoom != zoom || oldcax != cax || oldcay != cay || oldCropX != cropX || oldCropY != cropY || oldCropW != cropW || oldCropH != cropH)) {
-        if (needsFullRefresh) {
+        if (needsFullRefresh && !ipc->getHighQualComputed()) {
             cropPixbuf.clear ();
             ipc->startProcessing(M_HIGHQUAL);
+            ipc->setHighQualComputed();
         } else {
             update ();
         }

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -2005,7 +2005,7 @@ void CropWindow::zoomOut (bool toCursor, int cursorX, int cursorY)
     fitZoom = false;
 }
 
-void CropWindow::zoom11 ()
+void CropWindow::zoom11 (bool notify)
 {
 
     int x = -1;
@@ -2027,7 +2027,7 @@ void CropWindow::zoom11 ()
         screenCoordToImage(xpos + imgX + imgW / 2, ypos + imgY + imgH / 2, x, y);
     }
 
-    changeZoom (zoom11index, true, x, y);
+    changeZoom (zoom11index, notify, x, y, notify);
     fitZoom = false;
 }
 
@@ -2182,7 +2182,7 @@ void CropWindow::updateHoveredPicker (rtengine::Coord *imgPos)
         }
     }
 }
-void CropWindow::changeZoom  (int zoom, bool notify, int centerx, int centery)
+void CropWindow::changeZoom (int zoom, bool notify, int centerx, int centery, bool needsRedraw)
 {
 
     if (zoom < 0) {
@@ -2201,7 +2201,8 @@ void CropWindow::changeZoom  (int zoom, bool notify, int centerx, int centery)
             listener->cropZoomChanged (this);
         }
 
-    iarea->redraw ();
+    if (needsRedraw)
+        iarea->redraw ();
 }
 
 LockableColorPicker::Validity CropWindow::checkValidity (LockableColorPicker*  picker, const rtengine::Coord &pos)

--- a/rtgui/cropwindow.h
+++ b/rtgui/cropwindow.h
@@ -106,7 +106,7 @@ class CropWindow : public LWButtonListener, public CropDisplayHandler, public Ed
     void drawScaledSpotRectangle   (Cairo::RefPtr<Cairo::Context> cr, int rectSize);
     void drawUnscaledSpotRectangle (Cairo::RefPtr<Cairo::Context> cr, int rectSize);
     void drawObservedFrame         (Cairo::RefPtr<Cairo::Context> cr, int rw = 0, int rh = 0);
-    void changeZoom                (int zoom, bool notify = true, int centerx = -1, int centery = -1);
+    void changeZoom                (int zoom, bool notify = true, int centerx = -1, int centery = -1, bool needsRedraw = true);
     void updateHoveredPicker       (rtengine::Coord *imgPos = nullptr);
     void cycleRGB                  ();
     void cycleHSV                  ();
@@ -176,7 +176,7 @@ public:
     // zoomlistener interface
     void zoomIn      (bool toCursor = false, int cursorX = -1, int cursorY = -1);
     void zoomOut     (bool toCursor = false, int cursorX = -1, int cursorY = -1);
-    void zoom11      ();
+    void zoom11      (bool notify = true);
     void zoomFit     ();
     void zoomFitCrop ();
     double getZoom   ();

--- a/rtgui/imagearea.cc
+++ b/rtgui/imagearea.cc
@@ -426,7 +426,7 @@ void ImageArea::addCropWindow ()
     }
 
     CropWindow* cw = new CropWindow (this, true, true);
-    cw->zoom11();
+    cw->zoom11(false);
     cw->setCropGUIListener (cropgl);
     cw->setPointerMotionListener (pmlistener);
     cw->setPointerMotionHListener (pmhlistener);


### PR DESCRIPTION
…l windows

This reduces (but not completely stops) the initial blocky opening of detail windows.