### PR TITLE
Mac Executable Loader: Set LC_ALL

### DIFF
--- a/tools/osx/executable_loader.in
+++ b/tools/osx/executable_loader.in
@@ -51,5 +51,6 @@ esac
 # Prevent crash when directory name contains special characters
 AppleLocale=`defaults read -g AppleLocale`
 export LANG=${AppleLocale%@*}.UTF-8
+export LC_ALL=${AppleLocale%@*}.UTF-8
 
 exec "${cwd}/rawtherapee-bin" "$@"


### PR DESCRIPTION
This prevents a crash when switching to queue with ö/ü in image path using en_US introduced in dev.
https://github.com/Beep6581/RawTherapee/issues/4319#issuecomment-364468235