### PR TITLE
Find x87 and x86-32 SSE to adjust compile settings (fixes #4324)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,17 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PROC_FLAGS}")
 # Stop compilation on typos such as std:swap (missing colon will be detected as unused label):
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-label")
 
+# Special treatment for x87 and x86-32 SSE (see GitHub issue #4324)
+include(FindX87Math)
+if(HAVE_X87_MATH)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffloat-store")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffloat-store")
+endif()
+if(HAVE_X86_SSE_MATH)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse")
+endif()
+
 if(WIN32)
     # Add additional paths. Look in the MinGW path first, then in the Gtkmm path.
     # If you wish to build some dependent libraries, you have to install them in MinGW to use them:

--- a/cmake/modules/FindX87Math.cmake
+++ b/cmake/modules/FindX87Math.cmake
@@ -1,0 +1,60 @@
+# This file is part of RawTherapee.
+#
+# Copyright (C) 2018 Flössie <floessie.mail@gmail.com>
+#
+# RawTherapee is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# RawTherapee is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RawTherapee.  If not, see <http://www.gnu.org/licenses/>.
+
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_REQUIRED_QUIET_COPY "${CMAKE_REQUIRED_QUIET}")
+set(CMAKE_REQUIRED_QUIET ON)
+
+set(TEST_SOURCE
+"
+#if !defined(__i386) && !defined(_M_IX86)
+#error
+#endif
+
+#if defined(__SSE2__)
+#error
+#endif
+
+int main()
+{
+}
+")
+
+CHECK_CXX_SOURCE_COMPILES("${TEST_SOURCE}" HAVE_X87_MATH)
+
+set(TEST_SOURCE
+"
+#if !defined(__i386) && !defined(_M_IX86)
+#error
+#endif
+
+#if !defined(__SSE2__)
+#error
+#endif
+
+int main()
+{
+}
+")
+
+CHECK_CXX_SOURCE_COMPILES("${TEST_SOURCE}" HAVE_X86_SSE_MATH)
+
+unset(TEST_SOURCE)
+
+set(CMAKE_REQUIRED_QUIET "${CMAKE_REQUIRED_QUIET_COPY}")
+unset(CMAKE_REQUIRED_QUIET_COPY)

--- a/rtengine/opthelper.h
+++ b/rtengine/opthelper.h
@@ -30,13 +30,8 @@
 
     #ifdef __GNUC__
         #define RESTRICT    __restrict__
-        #if __SIZEOF_POINTER__ == 4 &&  __GNUC__ >= 7 // there seems to be a bug with __builtin_expect on 32bit systems when using gcc >= 7
-            #define LIKELY(x)    (x)
-            #define UNLIKELY(x)  (x)
-        #else
-            #define LIKELY(x)   __builtin_expect (!!(x), 1)
-            #define UNLIKELY(x) __builtin_expect (!!(x), 0)
-        #endif
+        #define LIKELY(x)   __builtin_expect (!!(x), 1)
+        #define UNLIKELY(x) __builtin_expect (!!(x), 0)
         #define ALIGNED64 __attribute__ ((aligned (64)))
         #define ALIGNED16 __attribute__ ((aligned (16)))
     #else


### PR DESCRIPTION
Hi,

this is the ultimate solution to our most `UNLIKELY()` problem, that is legacy 80 bit x87 math. See #4324 for the gory details. 😁 

Kudos to @jakubjelinek for taking the time to look into our i386 problem and for giving hints on how to solve it.

Best,
Flössie