### PR TITLE
Fix GCC 8 warnings

### DIFF
--- a/rtengine/colortemp.cc
+++ b/rtengine/colortemp.cc
@@ -1270,7 +1270,7 @@ void ColorTemp::temp2mul (double temp, double green, double equal, double& rmul,
             }
 
             if (settings->verbose) {
-                double correl_temp;
+                double correl_temp = 0.0;
                 XYZtoCorColorTemp(Xwb, Ywb, Zwb, correl_temp);
                 printf("Correlated temperature (lamp)=%i\n", (int) correl_temp); //use only for lamp...otherwise It give an information!!
             }

--- a/rtengine/demosaic_algos.cc
+++ b/rtengine/demosaic_algos.cc
@@ -1880,7 +1880,7 @@ void RawImageSource::lmmse_interpolate_omp(int winw, int winh, array2D<float> &r
         gamtab->makeIdentity();
     }
 
-    array2D<float> (*rgb[3]);
+    array2D<float>* rgb[3];
     rgb[0] = &red;
     rgb[1] = &green;
     rgb[2] = &blue;
@@ -2619,7 +2619,7 @@ void RawImageSource::ahd_demosaic()
     static const int dir[4] = { -1, 1, -TS, TS };
     float ldiff[2][4], abdiff[2][4], leps, abeps;
     float xyz[3], xyz_cam[3][4];
-    float (*cbrt);
+    float* cbrt;
     float (*rgb)[TS][TS][3];
     float (*lab)[TS][TS][3];
     float (*lix)[3];
@@ -3982,10 +3982,10 @@ void RawImageSource::rcd_demosaic()
     //float V_Stat, H_Stat, P_Stat, Q_Stat;
     float VH_Central_Value, VH_Neighbour_Value, PQ_Central_Value, PQ_Neighbour_Value;
 */    
-    float ( *VH_Dir ), ( *PQ_Dir );
+    float *VH_Dir, *PQ_Dir;
 
     //Low pass filter
-    float ( *lpf );
+    float *lpf;
 
 
     /**

--- a/rtengine/gauss.cc
+++ b/rtengine/gauss.cc
@@ -758,7 +758,7 @@ template<class T> void gaussVerticalSsemult (T** RESTRICT src, T** RESTRICT dst,
     }
 }
 
-template<class T> void gaussVerticalSsediv (T** RESTRICT src, T** RESTRICT dst, T** divBuffer, const int W, const int H, const float sigma)
+template<class T> void gaussVerticalSsediv (T** src, T** dst, T** divBuffer, const int W, const int H, const float sigma)
 {
     double b1, b2, b3, B, M[3][3];
     calculateYvVFactors<double>(sigma, b1, b2, b3, B, M);

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -2453,7 +2453,7 @@ void ImProcFunctions::finalContAllL (float ** WavCoeffs_L, float * WavCoeffs_L0,
         }
     }
 
-    int choicelevel = atoi(params->wavelet.Lmethod.data()) - 1;
+    int choicelevel = params->wavelet.Lmethod - 1;
     choicelevel = choicelevel == -1 ? 4 : choicelevel;
 
     int choiceClevel = 0;
@@ -3266,7 +3266,7 @@ void ImProcFunctions::ContAllL (float *koeLi[12], float *maxkoeLi, bool lipschit
     }
 
     // to see each level of wavelet ...level from 0 to 8
-    int choicelevel = atoi(params->wavelet.Lmethod.data()) - 1;
+    int choicelevel = params->wavelet.Lmethod - 1;
     choicelevel = choicelevel == -1 ? 4 : choicelevel;
 }
 
@@ -3524,7 +3524,7 @@ void ImProcFunctions::ContAllAB (LabImage * labco, int maxlvl, float ** varhue, 
     }
 
     // to see each level of wavelet ...level from 0 to 8
-    int choicelevel = atoi(params->wavelet.Lmethod.data()) - 1;
+    int choicelevel = params->wavelet.Lmethod - 1;
     choicelevel = choicelevel == -1 ? 4 : choicelevel;
     int choiceClevel = 0;
 

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -2081,7 +2081,7 @@ WaveletParams::WaveletParams() :
     expfinal(false),
     exptoning(false),
     expnoise(false),
-    Lmethod("4_"),
+    Lmethod(4),
     CLmethod("all"),
     Backmethod("grey"),
     Tilesmethod("full"),
@@ -2809,7 +2809,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
         saveToKeyfile(!pedited || pedited->localContrast.amount, "Local Contrast", "Amount", localContrast.amount, keyFile);
         saveToKeyfile(!pedited || pedited->localContrast.darkness, "Local Contrast", "Darkness", localContrast.darkness, keyFile);
         saveToKeyfile(!pedited || pedited->localContrast.lightness, "Local Contrast", "Lightness", localContrast.lightness, keyFile);
-        
+
 
 // Channel mixer
         saveToKeyfile(!pedited || pedited->chmixer.enabled, "Channel Mixer", "Enabled", chmixer.enabled, keyFile);
@@ -3672,7 +3672,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                     pedited->labCurve.enabled = true;
                 }
             }
-            
+
             assignFromKeyfile(keyFile, "Luminance Curve", "Brightness", pedited, labCurve.brightness, pedited->labCurve.brightness);
             assignFromKeyfile(keyFile, "Luminance Curve", "Contrast", pedited, labCurve.contrast, pedited->labCurve.contrast);
 
@@ -4220,7 +4220,15 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
             assignFromKeyfile(keyFile, "Wavelet", "Lipst", pedited, wavelet.lipst, pedited->wavelet.lipst);
             assignFromKeyfile(keyFile, "Wavelet", "AvoidColorShift", pedited, wavelet.avoid, pedited->wavelet.avoid);
             assignFromKeyfile(keyFile, "Wavelet", "TMr", pedited, wavelet.tmr, pedited->wavelet.tmr);
-            assignFromKeyfile(keyFile, "Wavelet", "LevMethod", pedited, wavelet.Lmethod, pedited->wavelet.Lmethod);
+            if (ppVersion < 331) { // wavelet.Lmethod was a string before version 331
+                Glib::ustring temp;
+                assignFromKeyfile(keyFile, "Wavelet", "LevMethod", pedited, temp, pedited->wavelet.Lmethod);
+                if (!temp.empty()) {
+                    wavelet.Lmethod = std::stoi(temp);
+                }
+            } else {
+                assignFromKeyfile(keyFile, "Wavelet", "LevMethod", pedited, wavelet.Lmethod, pedited->wavelet.Lmethod);
+            }
             assignFromKeyfile(keyFile, "Wavelet", "ChoiceLevMethod", pedited, wavelet.CLmethod, pedited->wavelet.CLmethod);
             assignFromKeyfile(keyFile, "Wavelet", "BackMethod", pedited, wavelet.Backmethod, pedited->wavelet.Backmethod);
             assignFromKeyfile(keyFile, "Wavelet", "TilesMethod", pedited, wavelet.Tilesmethod, pedited->wavelet.Tilesmethod);
@@ -4595,7 +4603,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
             assignFromKeyfile(keyFile, "ColorToning", "LabGridALow", pedited, colorToning.labgridALow, pedited->colorToning.labgridALow);
             assignFromKeyfile(keyFile, "ColorToning", "LabGridBLow", pedited, colorToning.labgridBLow, pedited->colorToning.labgridBLow);
             assignFromKeyfile(keyFile, "ColorToning", "LabGridAHigh", pedited, colorToning.labgridAHigh, pedited->colorToning.labgridAHigh);
-            assignFromKeyfile(keyFile, "ColorToning", "LabGridBHigh", pedited, colorToning.labgridBHigh, pedited->colorToning.labgridBHigh);            
+            assignFromKeyfile(keyFile, "ColorToning", "LabGridBHigh", pedited, colorToning.labgridBHigh, pedited->colorToning.labgridBHigh);
         }
 
         if (keyFile.has_group ("RAW")) {

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1098,7 +1098,7 @@ struct WaveletParams {
     bool exptoning;
     bool expnoise;
 
-    Glib::ustring Lmethod;
+    int Lmethod;
     Glib::ustring CLmethod;
     Glib::ustring Backmethod;
     Glib::ustring Tilesmethod;

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -1346,7 +1346,7 @@ int RawImageSource::findHotDeadPixels( PixelsMap &bpMap, float thresh, bool find
     float varthresh = (20.0 * (thresh / 100.0) + 1.0 ) / 24.f;
 
     // allocate temporary buffer
-    float (*cfablur);
+    float* cfablur;
     cfablur = (float (*)) malloc (H * W * sizeof * cfablur);
 
     // counter for dead or hot pixels

--- a/rtgui/ppversion.h
+++ b/rtgui/ppversion.h
@@ -1,11 +1,13 @@
 #pragma once
 
 // This number has to be incremented whenever the PP3 file format is modified or the behaviour of a tool changes
-#define PPVERSION 330
+#define PPVERSION 331
 #define PPVERSION_AEXP 301 //value of PPVERSION when auto exposure algorithm was modified
 
 /*
   Log of version changes
+   331  2018-14-02
+        changed wavelet.Lmethod to int
    330  2018-20-01
         Added 'Auto-matched Tone Curve' button, performing histogram matching
    329  2017-12-09

--- a/rtgui/wavelet.cc
+++ b/rtgui/wavelet.cc
@@ -1096,7 +1096,7 @@ void Wavelet::read (const ProcParams* pp, const ParamsEdited* pedited)
         Dirmethod->set_active (3);
     }
 
-    int selectedLevel = atoi(pp->wavelet.Lmethod.data()) - 1;
+    int selectedLevel = pp->wavelet.Lmethod - 1;
     Lmethod->set_active (selectedLevel == -1 ? 4 : selectedLevel);
 
     ccshape->setCurve (pp->wavelet.ccwcurve);
@@ -1735,9 +1735,7 @@ void Wavelet::write (ProcParams* pp, ParamsEdited* pedited)
         pp->wavelet.Dirmethod = "all";
     }
 
-    char lMethod[3]; // one additional char to avoid buffer overrun if someone increases number of levels > 9
-    sprintf(lMethod, "%d", Lmethod->get_active_row_number() + 1);
-    pp->wavelet.Lmethod = lMethod;
+    pp->wavelet.Lmethod = Lmethod->get_active_row_number() + 1;
 }
 
 void Wavelet::curveChanged (CurveEditor* ce)


### PR DESCRIPTION
Hi,

This fixes most of the new warnings when using GCC 8. I deliberately left out `dcraw.cc`, I guess you know why. 😁 Includes a patch by @heckflosse.

Best,
Flössie