### PR TITLE
Misc. typos

### DIFF
--- a/rtengine/alignedbuffer.h
+++ b/rtengine/alignedbuffer.h
@@ -66,7 +66,7 @@ public:
         return allocatedSize == 0;
     }
 
-    /** @brief Allocate the the "size" amount of elements of "structSize" length each
+    /** @brief Allocate the "size" amount of elements of "structSize" length each
     * @param size number of elements to allocate
     * @param structSize if non null, will let you override the default struct's size (unit: byte)
     * @return True is everything went fine, including freeing memory when size==0, false if the allocation failed

--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -3826,7 +3826,7 @@ void CLASS remove_zeroes()
 }
 
 /*
-   Seach from the current directory up to the root looking for
+   Search from the current directory up to the root looking for
    a ".badpixels" file, and fix those pixels now.
  */
 void CLASS bad_pixels (const char *cfname)

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1528,7 +1528,7 @@ Gtk::Widget* Preferences::getSoundPanel ()
     txtSndLngEditProcDone = Gtk::manage (new Gtk::Entry());
     pSndLngEditProcDone->pack_start (*txtSndLngEditProcDone, Gtk::PACK_EXPAND_WIDGET, 4);
 
-    Gtk::Label* lSndLngEditProcDoneSecs = Gtk::manage (new Gtk::Label (M ("PREFERENCES_SND_TRESHOLDSECS") + Glib::ustring (":")));
+    Gtk::Label* lSndLngEditProcDoneSecs = Gtk::manage (new Gtk::Label (M ("PREFERENCES_SND_THRESHOLDSECS") + Glib::ustring (":")));
     pSndLngEditProcDone->pack_start (*lSndLngEditProcDoneSecs, Gtk::PACK_SHRINK, 12);
 
     spbSndLngEditProcDoneSecs = Gtk::manage ( new Gtk::SpinButton () );

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -2215,7 +2215,7 @@ void Preferences::selectStartupDir ()
     Gtk::FileChooserDialog dialog (getToplevelWindow (this), M ("PREFERENCES_DIRSELECTDLG"), Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER);
 //    dialog.set_transient_for(*this);
 
-    //Add response buttons the the dialog:
+    //Add response buttons to the dialog:
     dialog.add_button (M ("GENERAL_CANCEL"), Gtk::RESPONSE_CANCEL);
     dialog.add_button (M ("GENERAL_OPEN"), Gtk::RESPONSE_OK);
 

--- a/rtgui/profilepanel.cc
+++ b/rtgui/profilepanel.cc
@@ -284,7 +284,7 @@ void ProfilePanel::save_clicked (GdkEventButton* event)
         dialog.add_shortcut_folder(imagePath);
     } catch (Glib::Error&) {}
 
-    //Add response buttons the the dialog:
+    //Add response buttons to the dialog:
     dialog.add_button(M("GENERAL_CANCEL"), Gtk::RESPONSE_CANCEL);
     dialog.add_button(M("GENERAL_SAVE"), Gtk::RESPONSE_OK);
 
@@ -457,7 +457,7 @@ void ProfilePanel::load_clicked (GdkEventButton* event)
         dialog.add_shortcut_folder(imagePath);
     } catch (Glib::Error&) {}
 
-    //Add response buttons the the dialog:
+    //Add response buttons to the dialog:
     dialog.add_button(M("GENERAL_CANCEL"), Gtk::RESPONSE_CANCEL);
     dialog.add_button(M("GENERAL_OPEN"), Gtk::RESPONSE_OK);
 


### PR DESCRIPTION
Found via `codespell -q 3 -I ../rawtherapy-whitelist.txt --skip="./rtdata/languages"`