### PR TITLE
added support for user-specific DCP and input ICC profiles dirs

### DIFF
--- a/rtengine/dcp.h
+++ b/rtengine/dcp.h
@@ -166,7 +166,7 @@ private:
     DCPStore() = default;
 
     mutable MyMutex mutex;
-    Glib::ustring profileDir;
+    std::vector<Glib::ustring> profileDir;
 
     // these contain standard profiles from RT. keys are all in uppercase, file path is value
     std::map<Glib::ustring, Glib::ustring> file_std_profiles;

--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -334,6 +334,8 @@ public:
         fileStdProfilesFileNames.clear();
         if (loadAll) {
             loadProfiles(stdProfilesDir, nullptr, nullptr, &fileStdProfilesFileNames, true);
+            Glib::ustring user_input_icc_dir = Glib::build_filename(options.rtdir, "iccprofiles", "input");
+            loadProfiles(user_input_icc_dir, nullptr, nullptr, &fileStdProfilesFileNames, true);
         }
 
         defaultMonitorProfile = settings->monitorProfile;


### PR DESCRIPTION
Look for direcories `dcpprofiles/` and `iccprofiles/input/` under `Options::rtdir`
(typically something like `$HOME/.config/RawTherapee`)