### PR TITLE
GUI update fixes

### DIFF
--- a/rtgui/crophandler.cc
+++ b/rtgui/crophandler.cc
@@ -313,8 +313,6 @@ void CropHandler::setDetailedCrop (IImage8* im, IImage8* imtrue, rtengine::procp
     cropParams = cp;
     colorParams = cmp;
 
-    cropPixbuf.clear ();
-
     if (!cropimg.empty()) {
         cropimg.clear();
     }

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1053,13 +1053,6 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     // since there was no resize event
     if (iareapanel->imageArea->mainCropWindow) {
         iareapanel->imageArea->mainCropWindow->cropHandler.newImage (ipc, false);
-
-        // In single tab mode, the image is not always updated between switches
-        // normal redraw don't work, so this is the hard way
-        // Disabled this with Issue 2435 because it seems to work fine now
-//        if (!options.tabbedUI && iareapanel->imageArea->mainCropWindow->getZoomFitVal() == 1.0) {
-        iareapanel->imageArea->mainCropWindow->cropHandler.update();
-//        }
     } else {
         Gtk::Allocation alloc;
         iareapanel->imageArea->on_resized (alloc);
@@ -2205,7 +2198,7 @@ void EditorPanel::beforeAfterToggled ()
         rtengine::RenderingIntent intent;
         ipc->getMonitorProfile(monitorProfile, intent);
         beforeIpc->setMonitorProfile(monitorProfile, intent);
-        
+
         beforeIarea->imageArea->setPreviewHandler (beforePreviewHandler);
         beforeIarea->imageArea->setImProcCoordinator (beforeIpc);
 


### PR DESCRIPTION
Hi there,

here are two little fixes for you to test for regressions:

1. Loading a RAW with the default profile and moving e.g. "Lightness" (or basically any other slider updating the preview) sometimes results in a transitional coarse image, which is annoying for judging the change. The first commit heals that for me.
2. When switching between images (F3/F4) there is a moment when no preview is shown. @Beep6581 complained about that in #4476. I removed some ancient code in the second commit, and it seems to work well without it.

Have a nice weekend,
Flössie