### PR TITLE
Sort file numbers naturally (#2467)

### DIFF
--- a/rtgui/thumbbrowserentrybase.cc
+++ b/rtgui/thumbbrowserentrybase.cc
@@ -23,6 +23,153 @@
 
 #include "../rtengine/mytime.h"
 
+namespace
+{
+
+Glib::ustring getPaddedName(const Glib::ustring& name)
+{
+    enum class State {
+        OTHER,
+        NUMBER,
+        FRACTION
+    };
+
+    constexpr unsigned int pad_width = 17; // Must be at least 1
+
+    Glib::ustring res;
+
+    State state = State::OTHER;
+    Glib::ustring number;
+
+    for (auto c : name) {
+        switch (state) {
+            case State::OTHER: {
+                switch (c) {
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9': {
+                        number += c;
+                        state = State::NUMBER;
+                        break;
+                    }
+
+                    case '.': {
+                        res += c;
+                        state = State::FRACTION;
+                        break;
+                    }
+
+                    default: {
+                        res += c;
+                        break;
+                    }
+                }
+                break;
+            }
+
+            case State::NUMBER: {
+                switch (c) {
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9': {
+                        number += c;
+                        break;
+                    }
+
+                    default: {
+                        if (number.size() < pad_width) {
+                            res.append(pad_width - number.size(), '0');
+                        }
+                        res += number;
+                        res += c;
+                        number.clear();
+
+                        state =
+                            c == '.'
+                                ? State::FRACTION
+                                : State::OTHER;
+                        break;
+                    }
+                }
+                break;
+            }
+
+            case State::FRACTION: {
+                switch (c) {
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9': {
+                        number += c;
+                        break;
+                    }
+
+                    default: {
+                        res += number;
+                        if (!number.empty() && number.size() < pad_width) {
+                            res.append(pad_width - number.size(), '0');
+                        }
+                        res += c;
+                        number.clear();
+
+                        if (c != '.') {
+                            state = State::OTHER;
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    switch (state) {
+        case State::OTHER: {
+            break;
+        }
+
+        case State::NUMBER: {
+            if (number.size() < pad_width) {
+                res.append(pad_width - number.size(), '0');
+            }
+            res += number;
+            break;
+        }
+
+        case State::FRACTION: {
+            res += number;
+            if (!number.empty() && number.size() < pad_width) {
+                res.append(pad_width - number.size(), '0');
+            }
+            break;
+        }
+    }
+
+    return res;
+}
+
+}
+
 ThumbBrowserEntryBase::ThumbBrowserEntryBase (const Glib::ustring& fname) :
     fnlabw(0),
     fnlabh(0),
@@ -57,7 +204,7 @@ ThumbBrowserEntryBase::ThumbBrowserEntryBase (const Glib::ustring& fname) :
     bbFramed(false),
     bbPreview(nullptr),
     cursor_type(CSUndefined),
-    collate_name(dispname.casefold().collate_key()),
+    collate_name(getPaddedName(dispname).casefold_collate_key()),
     thumbnail(nullptr),
     filename(fname),
     shortname(dispname),

--- a/rtgui/thumbbrowserentrybase.cc
+++ b/rtgui/thumbbrowserentrybase.cc
@@ -34,7 +34,7 @@ Glib::ustring getPaddedName(const Glib::ustring& name)
         FRACTION
     };
 
-    constexpr unsigned int pad_width = 17; // Must be at least 1
+    constexpr unsigned int pad_width = 16;
 
     Glib::ustring res;
 

--- a/rtgui/thumbbrowserentrybase.cc
+++ b/rtgui/thumbbrowserentrybase.cc
@@ -30,8 +30,7 @@ Glib::ustring getPaddedName(const Glib::ustring& name)
 {
     enum class State {
         OTHER,
-        NUMBER,
-        FRACTION
+        NUMBER
     };
 
     constexpr unsigned int pad_width = 16;
@@ -56,13 +55,8 @@ Glib::ustring getPaddedName(const Glib::ustring& name)
                     case '8':
                     case '9': {
                         number += c;
-                        state = State::NUMBER;
-                        break;
-                    }
 
-                    case '.': {
-                        res += c;
-                        state = State::FRACTION;
+                        state = State::NUMBER;
                         break;
                     }
 
@@ -98,43 +92,7 @@ Glib::ustring getPaddedName(const Glib::ustring& name)
                         res += c;
                         number.clear();
 
-                        state =
-                            c == '.'
-                                ? State::FRACTION
-                                : State::OTHER;
-                        break;
-                    }
-                }
-                break;
-            }
-
-            case State::FRACTION: {
-                switch (c) {
-                    case '0':
-                    case '1':
-                    case '2':
-                    case '3':
-                    case '4':
-                    case '5':
-                    case '6':
-                    case '7':
-                    case '8':
-                    case '9': {
-                        number += c;
-                        break;
-                    }
-
-                    default: {
-                        res += number;
-                        if (!number.empty() && number.size() < pad_width) {
-                            res.append(pad_width - number.size(), '0');
-                        }
-                        res += c;
-                        number.clear();
-
-                        if (c != '.') {
-                            state = State::OTHER;
-                        }
+                        state = State::OTHER;
                         break;
                     }
                 }
@@ -153,14 +111,6 @@ Glib::ustring getPaddedName(const Glib::ustring& name)
                 res.append(pad_width - number.size(), '0');
             }
             res += number;
-            break;
-        }
-
-        case State::FRACTION: {
-            res += number;
-            if (!number.empty() && number.size() < pad_width) {
-                res.append(pad_width - number.size(), '0');
-            }
             break;
         }
     }


### PR DESCRIPTION
Hi,

This is an implementation to sort `ThumbBrowserEntryBase`s naturally as proposed in #2467. It does so by padding number strings to a common length without converting them to actual numbers. ~~Fractions are cared for.~~ My first implementation also included negative numbers, but that was rubbish given ISO dates.

The code is sufficiently simple so that I don't mind, if you dislike it.

Best,
Flössie