### PR TITLE
reduce the range of the lab grid colour toning method

### DIFF
--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -5740,10 +5740,11 @@ void ImProcFunctions::lab2rgb (const LabImage &src, Imagefloat &dst, const Glib:
 void ImProcFunctions::colorToningLabGrid(LabImage *lab, int xstart, int xend, int ystart, int yend, bool MultiThread)
 {
     const float factor = ColorToningParams::LABGRID_CORR_MAX * 3.f;
-    float a_scale = (params->colorToning.labgridAHigh - params->colorToning.labgridALow) / factor;
-    float a_base = params->colorToning.labgridALow;
-    float b_scale = (params->colorToning.labgridBHigh - params->colorToning.labgridBLow) / factor;
-    float b_base = params->colorToning.labgridBLow;
+    const float scaling = ColorToningParams::LABGRID_CORR_SCALE;
+    float a_scale = (params->colorToning.labgridAHigh - params->colorToning.labgridALow) / factor / scaling;
+    float a_base = params->colorToning.labgridALow / scaling;
+    float b_scale = (params->colorToning.labgridBHigh - params->colorToning.labgridBLow) / factor / scaling;
+    float b_base = params->colorToning.labgridBLow / scaling;
 
 #ifdef _OPENMP
     #pragma omp parallel for if (multiThread)

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -606,6 +606,7 @@ bool LocalContrastParams::operator!=(const LocalContrastParams &other) const
 
 
 const double ColorToningParams::LABGRID_CORR_MAX = 12000.f;
+const double ColorToningParams::LABGRID_CORR_SCALE = 3.f;
 
 ColorToningParams::ColorToningParams() :
     enabled(false),
@@ -4591,6 +4592,13 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
             assignFromKeyfile(keyFile, "ColorToning", "LabGridBLow", pedited, colorToning.labgridBLow, pedited->colorToning.labgridBLow);
             assignFromKeyfile(keyFile, "ColorToning", "LabGridAHigh", pedited, colorToning.labgridAHigh, pedited->colorToning.labgridAHigh);
             assignFromKeyfile(keyFile, "ColorToning", "LabGridBHigh", pedited, colorToning.labgridBHigh, pedited->colorToning.labgridBHigh);
+            if (ppVersion < 337) {
+                const double scale = ColorToningParams::LABGRID_CORR_SCALE;
+                colorToning.labgridALow *= scale;
+                colorToning.labgridAHigh *= scale;
+                colorToning.labgridBLow *= scale;
+                colorToning.labgridBHigh *= scale;
+            }            
         }
 
         if (keyFile.has_group ("RAW")) {

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -454,6 +454,7 @@ struct ColorToningParams {
     double labgridAHigh;
     double labgridBHigh;
     static const double LABGRID_CORR_MAX;
+    static const double LABGRID_CORR_SCALE;
 
     ColorToningParams();
 

--- a/rtgui/labgrid.cc
+++ b/rtgui/labgrid.cc
@@ -74,10 +74,12 @@ void LabGrid::getParams(double &la, double &lb, double &ha, double &hb) const
 
 void LabGrid::setParams(double la, double lb, double ha, double hb, bool notify)
 {
-    low_a = la;
-    low_b = lb;
-    high_a = ha;
-    high_b = hb;
+    const double lo = -rtengine::ColorToningParams::LABGRID_CORR_MAX;
+    const double hi = rtengine::ColorToningParams::LABGRID_CORR_MAX;
+    low_a = rtengine::LIM(la, lo, hi);
+    low_b = rtengine::LIM(lb, lo, hi);
+    high_a = rtengine::LIM(ha, lo, hi);
+    high_b = rtengine::LIM(hb, lo, hi);
     queue_draw();
     if (notify) {
         notifyListener();

--- a/rtgui/ppversion.h
+++ b/rtgui/ppversion.h
@@ -1,11 +1,13 @@
 #pragma once
 
 // This number has to be incremented whenever the PP3 file format is modified or the behaviour of a tool changes
-#define PPVERSION 336
+#define PPVERSION 337
 #define PPVERSION_AEXP 301 //value of PPVERSION when auto exposure algorithm was modified
 
 /*
   Log of version changes
+   337  2018-06-13
+        new scales for the LabGrid color toning parameters
    336  2018-06-01
         new demosaic method combobox for pixelshift
    335  2018-05-30


### PR DESCRIPTION
This allows for more fine-tuning where it matters most. 
I have never needed to use the extreme settings of the tool: moving the markers close to the edges of the grid gives a very strong colour cast to the images; this might have a use for artistic purposes, but for "colour corrections" it is not so useful IMHO. For the latter use case, the markers usually stay very close to the center. With this PR, I reduced the intensity of the correction, so that the full grid (well, almost) can be used effectively for subtle colour corrections.

If you want stronger effects, there are still the other colour toning methods available.

I had to bump the ppversion because the parameters need to be rescaled for this to work.