### PR TITLE
Scrolling speed changed to height of thumbnail.

### DIFF
--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -490,6 +490,7 @@ void FileCatalog::exifInfoButtonToggled()
     }
 
     fileBrowser->refreshThumbImages ();
+    refreshHeight();
 }
 
 void FileCatalog::on_realize()

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -501,8 +501,8 @@ void ThumbBrowserBase::configScrollBars ()
         vscroll.get_adjustment()->set_upper (inH);
         hscroll.get_adjustment()->set_lower (0);
         vscroll.get_adjustment()->set_lower (0);
-        hscroll.get_adjustment()->set_step_increment (fd[0]->getEffectiveHeight()); // Is it safe enough to assume fd[0] is accessible? There seems to be no other way to get the _actual_ height of the thumbnail.
-        vscroll.get_adjustment()->set_step_increment (fd[0]->getEffectiveHeight());
+        hscroll.get_adjustment()->set_step_increment (!fd.empty() ? fd[0]->getEffectiveHeight() : 0);
+        vscroll.get_adjustment()->set_step_increment (!fd.empty() ? fd[0]->getEffectiveHeight() : 0);
         hscroll.get_adjustment()->set_page_increment (iw);
         vscroll.get_adjustment()->set_page_increment (ih);
         hscroll.get_adjustment()->set_page_size (iw);
@@ -567,7 +567,7 @@ void ThumbBrowserBase::arrangeFiles()
 
         MYREADERLOCK_RELEASE(l);
         // This will require a Writer access
-        resizeThumbnailArea(currx, rowHeight);
+        resizeThumbnailArea(currx, !fd.empty() ? fd[0]->getEffectiveHeight() : rowHeight);
     } else {
         const int availWidth = internal.get_width();
 

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -501,8 +501,8 @@ void ThumbBrowserBase::configScrollBars ()
         vscroll.get_adjustment()->set_upper (inH);
         hscroll.get_adjustment()->set_lower (0);
         vscroll.get_adjustment()->set_lower (0);
-        hscroll.get_adjustment()->set_step_increment (getThumbnailHeight());
-        vscroll.get_adjustment()->set_step_increment (getThumbnailHeight());
+        hscroll.get_adjustment()->set_step_increment (fd[0]->getEffectiveHeight()); // Is it safe enough to assume fd[0] is accessible? There seems to be no other way to get the _actual_ height of the thumbnail.
+        vscroll.get_adjustment()->set_step_increment (fd[0]->getEffectiveHeight());
         hscroll.get_adjustment()->set_page_increment (iw);
         vscroll.get_adjustment()->set_page_increment (ih);
         hscroll.get_adjustment()->set_page_size (iw);

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -501,8 +501,8 @@ void ThumbBrowserBase::configScrollBars ()
         vscroll.get_adjustment()->set_upper (inH);
         hscroll.get_adjustment()->set_lower (0);
         vscroll.get_adjustment()->set_lower (0);
-        hscroll.get_adjustment()->set_step_increment (32);
-        vscroll.get_adjustment()->set_step_increment (32);
+        hscroll.get_adjustment()->set_step_increment (getThumbnailHeight());
+        vscroll.get_adjustment()->set_step_increment (getThumbnailHeight());
         hscroll.get_adjustment()->set_page_increment (iw);
         vscroll.get_adjustment()->set_page_increment (ih);
         hscroll.get_adjustment()->set_page_size (iw);

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -519,6 +519,9 @@ void ThumbBrowserBase::configScrollBars ()
         } else {
             vscroll.show();
         }
+    } else { // hide scrollbars when a filter is applied which returns no files
+        hscroll.hide();
+        vscroll.hide();
     }
 }
 


### PR DESCRIPTION
Fixes #1901
This works really well in the browser. I don't see any reason why someone actually wants to scroll slower than one image-height per scroll event.
Horizontal scrolling has the same speed, which works reasonably well too (unless you have images with abnormal aspect ratio's).
