### PR TITLE
remove unnecessary arguments from amaze

### DIFF
--- a/rtengine/demosaic/amaze.cc
+++ b/rtengine/demosaic/amaze.cc
@@ -47,7 +47,7 @@ unsigned fc(std::array<std::array<unsigned, 2>, 2> cfa, unsigned row, unsigned c
 namespace rtengine
 {
 
-void RawImageSource::amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const std::array<std::array<unsigned, 2>, 2> &cfarray, const std::function<bool(double)> setProgCancel, double initGain, int border, int W, int H)
+void RawImageSource::amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const std::array<std::array<unsigned, 2>, 2> &cfarray, const std::function<bool(double)> setProgCancel, double initGain, int border)
 {
     BENCHFUN
 
@@ -1588,7 +1588,7 @@ void RawImageSource::amaze_demosaic(int winx, int winy, int winw, int winh, cons
         free(buffer);
     }
     if(border < 4) {
-        bayerborder_demosaic(W, H, 3, rawData, red, green, blue, cfarray);
+        bayerborder_demosaic(width, height, 3, rawData, red, green, blue, cfarray);
     }
 
     setProgCancel(1.0);

--- a/rtengine/demosaic/dual.cc
+++ b/rtengine/demosaic/dual.cc
@@ -54,7 +54,7 @@ void RawImageSource::dual_demosaic(bool isBayer, const RAWParams &raw, int winw,
                         plistener->setProgress(p);
                     return false;
                 };
-                amaze_demosaic(0, 0, winw, winh, rawData, red, green, blue, cfa, setProgCancel, initialGain, border, W, H);
+                amaze_demosaic(0, 0, winw, winh, rawData, red, green, blue, cfa, setProgCancel, initialGain, border);
             } else if (raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::DCBVNG4) ) {
                 dcb_demosaic(raw.bayersensor.dcb_iterations, raw.bayersensor.dcb_enhance);
             } else if (raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::RCDVNG4) ) {
@@ -90,7 +90,7 @@ void RawImageSource::dual_demosaic(bool isBayer, const RAWParams &raw, int winw,
                     plistener->setProgress(p);
                 return false;
             };
-            amaze_demosaic(0, 0, winw, winh, rawData, red, green, blue, cfa, setProgCancel, initialGain, border, W, H);
+            amaze_demosaic(0, 0, winw, winh, rawData, red, green, blue, cfa, setProgCancel, initialGain, border);
         } else if (raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::DCBVNG4) ) {
             dcb_demosaic(raw.bayersensor.dcb_iterations, raw.bayersensor.dcb_enhance);
         } else if (raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::RCDVNG4) ) {

--- a/rtengine/demosaic/pixelshift.cc
+++ b/rtengine/demosaic/pixelshift.cc
@@ -305,7 +305,7 @@ void RawImageSource::pixelshift(int winx, int winy, int winw, int winh, const RA
             plistener->setProgress(p);
             return false;
         };
-        amaze_demosaic(winx, winy, winw, winh, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border, W, H);
+        amaze_demosaic(winx, winy, winw, winh, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border);
         return;
     }
 
@@ -342,7 +342,7 @@ void RawImageSource::pixelshift(int winx, int winy, int winw, int winh, const RA
                         plistener->setProgress(p);
                         return false;
                     };
-                    amaze_demosaic(winx, winy, winw, winh, *(rawDataFrames[0]), red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border, W, H);
+                    amaze_demosaic(winx, winy, winw, winh, *(rawDataFrames[0]), red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border);
                 }
                 multi_array2D<float, 3> redTmp(winw, winh);
                 multi_array2D<float, 3> greenTmp(winw, winh);
@@ -362,7 +362,7 @@ void RawImageSource::pixelshift(int winx, int winy, int winw, int winh, const RA
                             plistener->setProgress(p);
                             return false;
                         };
-                        amaze_demosaic(winx, winy, winw, winh, *(rawDataFrames[i + 1]), redTmp[i], greenTmp[i], blueTmp[i], {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border, W, H);
+                        amaze_demosaic(winx, winy, winw, winh, *(rawDataFrames[i + 1]), redTmp[i], greenTmp[i], blueTmp[i], {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border);
                     }
                 }
 
@@ -399,7 +399,7 @@ void RawImageSource::pixelshift(int winx, int winy, int winw, int winh, const RA
                         plistener->setProgress(p);
                         return false;
                     };
-                    amaze_demosaic(winx, winy, winw, winh, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border, W, H);
+                    amaze_demosaic(winx, winy, winw, winh, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border);
                 }
             }
         }

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -2076,7 +2076,7 @@ void RawImageSource::demosaic(const RAWParams &raw, bool autoContrast, double &c
                     plistener->setProgress(p);
                 return false;
             };
-            amaze_demosaic (0, 0, W, H, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border, W, H);
+            amaze_demosaic (0, 0, W, H, rawData, red, green, blue, {{{FC(0,0), FC(0,1)},{FC(1,0),FC(1,1)}}}, setProgCancel, initialGain, border);
         } else if (raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::AMAZEVNG4)
                    || raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::DCBVNG4)
                    || raw.bayersensor.method == RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::RCDVNG4)) {

--- a/rtengine/rawimagesource.h
+++ b/rtengine/rawimagesource.h
@@ -256,7 +256,7 @@ protected:
     // demosaicers
     void dcb_demosaic(int iterations, bool dcb_enhance);
     void ahd_demosaic();
-    void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const std::array<std::array<unsigned, 2>, 2> &cfarray, const std::function<bool(double)> setProgCancel, double initGain, int border, int W, int H);//Emil's code for AMaZE
+    void amaze_demosaic(int winx, int winy, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const std::array<std::array<unsigned, 2>, 2> &cfarray, const std::function<bool(double)> setProgCancel, double initGain, int border);//Emil's code for AMaZE
     void bayerborder_demosaic(int winw, int winh, int lborders, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, const std::array<std::array<unsigned, 2>, 2> &cfarray);
     void dual_demosaic(bool isBayer, const RAWParams &raw, int winw, int winh, const array2D<float> &rawData, array2D<float> &red, array2D<float> &green, array2D<float> &blue, double &contrast, bool autoContrast = false, int autoX = -1, int autoY = -1);
     void eahd_demosaic();


### PR DESCRIPTION
W and H at the end were solely used for bayerborder_demosaic and didn't need to be distinct from winw and winh.