### PR TITLE
Modifications to store histogram settings across sessions

### DIFF
--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -2241,7 +2241,7 @@ void EditorPanel::histogramChanged (LUTu & histRed, LUTu & histGreen, LUTu & his
 {
 
     if (histogramPanel) {
-        histogramPanel->histogramChanged (histRed, histGreen, histBlue, histLuma, histRedRaw, histGreenRaw, histBlueRaw, histChroma);
+        histogramPanel->histogramChanged (histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw);
     }
 
     tpc->updateCurveBackgroundHistogram (histToneCurve, histLCurve, histCCurve,/*histCLurve,  histLLCurve,*/ histLCAM, histCCAM, histRed, histGreen, histBlue, histLuma, histLRETI);

--- a/rtgui/histogrampanel.h
+++ b/rtgui/histogrampanel.h
@@ -70,10 +70,10 @@ protected:
     bool needGreen;
     bool needBlue;
     bool needLuma;
+    bool needChroma;
     bool rawMode;
     bool showMode;
     bool barDisplayed;
-    bool needChroma;
 
     Gtk::Grid* parent;
 
@@ -91,7 +91,7 @@ public:
     };
 
     void update (int val, int rh, int gh, int bh);
-    void updateOptions (bool r, bool g, bool b, bool l, bool raw, bool show, bool c);
+    void updateOptions (bool r, bool g, bool b, bool l, bool c, bool raw, bool show);
 
     void on_realize();
     bool on_draw(const ::Cairo::RefPtr< Cairo::Context> &cr);
@@ -104,7 +104,7 @@ private:
     void get_preferred_width_vfunc (int &minimum_width, int &natural_width) const;
     void get_preferred_height_for_width_vfunc (int width, int &minimum_height, int &natural_height) const;
     void get_preferred_width_for_height_vfunc (int h, int &minimum_width, int &natural_width) const;
-    // Some ...
+
 };
 
 class DrawModeListener
@@ -124,15 +124,16 @@ private:
     type_signal_factor_changed sigFactorChanged;
 
 protected:
-    LUTu lhist, rhist, ghist, bhist, chist;
-    LUTu lhistRaw, rhistRaw, ghistRaw, bhistRaw;
+    LUTu rhist, ghist, bhist, lhist, chist;
+    LUTu rhistRaw, ghistRaw, bhistRaw, lhistRaw; //lhistRaw is unused?
 
     bool valid;
     int drawMode;
     DrawModeListener *myDrawModeListener;
     int oldwidth, oldheight;
 
-    bool needLuma, needRed, needGreen, needBlue, rawMode, needChroma;
+    bool needRed, needGreen, needBlue, needLuma, needChroma;
+    bool rawMode;
     bool isPressed;
     double movingPosition;
 
@@ -143,8 +144,8 @@ public:
     ~HistogramArea();
 
     void updateBackBuffer ();
-    void update (LUTu &histRed, LUTu &histGreen, LUTu &histBlue, LUTu &histLuma, LUTu &histRedRaw, LUTu &histGreenRaw, LUTu &histBlueRaw, LUTu &histChroma);
-    void updateOptions (bool r, bool g, bool b, bool l, bool raw, bool c, int mode);
+    void update (LUTu &histRed, LUTu &histGreen, LUTu &histBlue, LUTu &histLuma, LUTu &histChroma, LUTu &histRedRaw, LUTu &histGreenRaw, LUTu &histBlueRaw);
+    void updateOptions (bool r, bool g, bool b, bool l, bool c, bool raw, int mode);
     void on_realize();
     bool on_draw(const ::Cairo::RefPtr< Cairo::Context> &cr);
     bool on_button_press_event (GdkEventButton* event);
@@ -208,9 +209,9 @@ public:
     HistogramPanel ();
     ~HistogramPanel ();
 
-    void histogramChanged (LUTu &histRed, LUTu &histGreen, LUTu &histBlue, LUTu &histLuma, LUTu &histRedRaw, LUTu &histGreenRaw, LUTu &histBlueRaw, LUTu &histChroma)
+    void histogramChanged (LUTu &histRed, LUTu &histGreen, LUTu &histBlue, LUTu &histLuma, LUTu &histChroma, LUTu &histRedRaw, LUTu &histGreenRaw, LUTu &histBlueRaw)
     {
-        histogramArea->update (histRed, histGreen, histBlue, histLuma, histRedRaw, histGreenRaw, histBlueRaw, histChroma);
+        histogramArea->update (histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw);
     }
     // pointermotionlistener interface
     void pointerMoved (bool validPos, const Glib::ustring &profile, const Glib::ustring &profileW, int x, int y, int r, int g, int b, bool isRaw = false);

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -417,6 +417,9 @@ void Options::setDefaults()
     mainNBVertical = true;
     multiDisplayMode = 0;
     histogramPosition = 1;
+    histogramRed = true;
+    histogramGreen = true;
+    histogramBlue = true;
     histogramBar = true;
     histogramHeight = 200;
     histogramDrawMode = 0;
@@ -1305,6 +1308,30 @@ void Options::readFromFile(Glib::ustring fname)
                 if (keyFile.has_key("GUI", "HistogramPosition")) {
                     histogramPosition = keyFile.get_integer("GUI", "HistogramPosition");
                 }
+                
+                if (keyFile.has_key("GUI", "HistogramRed")) {
+                    histogramRed = keyFile.get_boolean("GUI", "HistogramRed");
+                }
+                
+                if (keyFile.has_key("GUI", "HistogramGreen")) {
+                    histogramGreen = keyFile.get_boolean("GUI", "HistogramGreen");
+                }
+                
+                if (keyFile.has_key("GUI", "HistogramBlue")) {
+                    histogramBlue = keyFile.get_boolean("GUI", "HistogramBlue");
+                }
+                
+                if (keyFile.has_key("GUI", "HistogramLuma")) {
+                    histogramLuma = keyFile.get_boolean("GUI", "HistogramLuma");
+                }
+                
+                if (keyFile.has_key("GUI", "HistogramChroma")) {
+                    histogramChroma = keyFile.get_boolean("GUI", "HistogramChroma");
+                }
+                
+                if (keyFile.has_key("GUI", "HistogramRAW")) {
+                    histogramRAW = keyFile.get_boolean("GUI", "HistogramRAW");
+                }
 
                 if (keyFile.has_key("GUI", "HistogramBar")) {
                     histogramBar = keyFile.get_boolean("GUI", "HistogramBar");
@@ -2035,6 +2062,12 @@ void Options::saveToFile(Glib::ustring fname)
         keyFile.set_double_list ("GUI", "CutOverlayBrush", cutOverlayBrush);
         keyFile.set_double_list ("GUI", "NavGuideBrush", navGuideBrush);
         keyFile.set_integer ("GUI", "HistogramPosition", histogramPosition);
+        keyFile.set_boolean ("GUI", "HistogramRed", histogramRed);
+        keyFile.set_boolean ("GUI", "HistogramGreen", histogramGreen);
+        keyFile.set_boolean ("GUI", "HistogramBlue", histogramBlue);
+        keyFile.set_boolean ("GUI", "HistogramLuma", histogramLuma);
+        keyFile.set_boolean ("GUI", "HistogramChroma", histogramChroma);
+        keyFile.set_boolean ("GUI", "HistogramRAW", histogramRAW);
         keyFile.set_boolean ("GUI", "HistogramBar", histogramBar);
         keyFile.set_integer ("GUI", "HistogramHeight", histogramHeight);
         keyFile.set_integer ("GUI", "HistogramDrawMode", histogramDrawMode);

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -254,7 +254,8 @@ public:
     bool sndEnable;
 
     int histogramPosition;  // 0=disabled, 1=left pane, 2=right pane
-    //int histogramWorking;  // 0=disabled, 1=left pane, 2=right pane
+    bool histogramRed, histogramGreen, histogramBlue;
+    bool histogramLuma, histogramChroma, histogramRAW;
     bool histogramBar;
     int histogramHeight;
     int histogramDrawMode;


### PR DESCRIPTION
This should fix #4749 and store all histogram related sessions in `options`.
Please check for silly stuff.