### PR TITLE
Mac: cmake/bash codesign implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,12 @@ if(DEFINED LENSFUNDBDIR AND NOT IS_ABSOLUTE "${LENSFUNDBDIR}")
     set(LENSFUNDBDIR "${DATADIR}/${LENSFUNDBDIR}")
 endif()
 
+if(APPLE)
+    if("${CODESIGNID}")
+        set(CODESIGNID "${CODESIGNID}" CAHCE STRING "Codesigning Identity")
+    endif()
+endif()
+
 # Enforce absolute paths for non-bundle builds:
 if(NOT BUILD_BUNDLE)
     foreach(path BINDIR DATADIR LIBDIR DOCDIR CREDITSDIR LICENCEDIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ endif()
 
 if(APPLE)
     if("${CODESIGNID}")
-        set(CODESIGNID "${CODESIGNID}" CAHCE STRING "Codesigning Identity")
+        set(CODESIGNID "${CODESIGNID}" CACHE STRING "Codesigning Identity")
     endif()
 endif()
 

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -199,8 +199,11 @@ s|@arch@|${arch}|" \
     "${CONTENTS}/Info.plist"
 plutil -convert binary1 "${CONTENTS}/Info.plist"
 
-
-
+# Sign the app
+CODESIGNID="$(cmake .. -LA -N | grep "CODESIGNID" | cut -d "=" -f2)"
+codesign --deep --force -v -s "${CODESIGNID}"  "${APP}"
+spctl -a -vvvv "${APP}"
+ 
 function CreateDmg {
     local srcDir="$(mktemp -dt $$)"
 
@@ -226,6 +229,9 @@ function CreateDmg {
 
     msg "Creating disk image:"
     hdiutil create -format UDBZ -srcdir "${srcDir}" -volname "${PROJECT_NAME}_${PROJECT_FULL_VERSION}" "${dmg_name}.dmg"
+
+    # Sign disk image
+    codesign --deep --force -v -s "${CODESIGNID}" "${dmg_name}.dmg"
 
     # Zip disk image for redistribution
     zip "${dmg_name}.zip" "${dmg_name}.dmg" AboutThisBuild.txt


### PR DESCRIPTION
* User sets `cmake` parameter `-DCODESIGNID:STRING="`\<ident\>`"`
* App and DMG get signed during `make macosx_bundle`