### PR TITLE
Button and progress bar style improvements

### DIFF
--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -368,29 +368,7 @@ separator {
     margin: 5px;
 }
 
-progressbar.vertical trough {
-    min-width: 6px;
-}
-progressbar.vertical trough progress {
-    min-width: 6px;
-}
-
-progressbar.horizontal trough {
-    min-height: 6px;
-}
-progressbar.horizontal trough progress {
-    min-height: 6px;
-}
-
-progressbar trough {
-    background-color: #2A2A2A;
-    border-color: #202020;
-}
-
-notebook header progressbar trough {
-    background-color: #202020;
-    border-color: #181818;
-}
+/* */
 
 .drawingarea {
     border-radius: 0;
@@ -1016,3 +994,36 @@ button.combo, .image-combo .toggle, #MyFileChooserButton {
     padding-right: 4px;
 }
 
+
+/* Progress bars */
+
+progressbar.horizontal {
+    min-width: 100px;
+    margin-bottom: 4px;
+}
+
+progressbar.vertical {
+    min-height: 100px;
+/*    margin: 8px 8px 8px 0;*/
+}
+
+progressbar trough {
+    background-color: #383838;
+    border: none;
+}
+
+progressbar progress {
+    border-color: #363636;
+    background-color: #FFCC00;
+    background-color: #215d9c;
+}
+
+progressbar.horizontal trough, progressbar.horizontal progress {
+    min-height: 8px;
+}
+
+progressbar.vertical trough, progressbar.vertical progress {
+    min-width: 8px;
+}
+
+/* */

--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -994,17 +994,16 @@ button.combo, .image-combo .toggle, #MyFileChooserButton {
     padding-right: 4px;
 }
 
-
 /* Progress bars */
 
 progressbar.horizontal {
     min-width: 100px;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
 }
 
 progressbar.vertical {
     min-height: 100px;
-/*    margin: 8px 8px 8px 0;*/
+    margin: 8px 0;
 }
 
 progressbar trough {
@@ -1014,16 +1013,16 @@ progressbar trough {
 
 progressbar progress {
     border-color: #363636;
-    background-color: #FFCC00;
+    border-radius: 3px;
     background-color: #215d9c;
 }
 
 progressbar.horizontal trough, progressbar.horizontal progress {
-    min-height: 8px;
+    min-height: 10px;
 }
 
 progressbar.vertical trough, progressbar.vertical progress {
-    min-width: 8px;
+    min-width: 10px;
 }
 
 /* */

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -657,18 +657,21 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
 
     Gtk::Image *saveButtonImage =  Gtk::manage (new RTImage ("save.png"));
     saveimgas = Gtk::manage (new Gtk::Button ());
+    saveimgas->set_relief(Gtk::RELIEF_NONE);
     saveimgas->add (*saveButtonImage);
     saveimgas->set_tooltip_markup (M ("MAIN_BUTTON_SAVE_TOOLTIP"));
     setExpandAlignProperties (saveimgas, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_FILL);
 
     Gtk::Image *queueButtonImage = Gtk::manage (new RTImage ("gears.png"));
     queueimg = Gtk::manage (new Gtk::Button ());
+    queueimg->set_relief(Gtk::RELIEF_NONE);
     queueimg->add (*queueButtonImage);
     queueimg->set_tooltip_markup (M ("MAIN_BUTTON_PUTTOQUEUE_TOOLTIP"));
     setExpandAlignProperties (queueimg, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_FILL);
 
     Gtk::Image *sendToEditorButtonImage = Gtk::manage (new RTImage ("palette-brush.png"));
     sendtogimp = Gtk::manage (new Gtk::Button ());
+    sendtogimp->set_relief(Gtk::RELIEF_NONE);
     sendtogimp->add (*sendToEditorButtonImage);
     sendtogimp->set_tooltip_markup (M ("MAIN_BUTTON_SENDTOEDITOR_TOOLTIP"));
     setExpandAlignProperties (sendtogimp, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_FILL);

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -232,6 +232,7 @@ RTWindow::RTWindow ()
 
         Gtk::Button* iccProfileCreator = Gtk::manage (new Gtk::Button ());
         setExpandAlignProperties (iccProfileCreator, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+        iccProfileCreator->set_relief(Gtk::RELIEF_NONE);
         iccProfileCreator->set_image (*Gtk::manage (new RTImage ("gamut-plus.png")));
         iccProfileCreator->set_tooltip_markup (M ("MAIN_BUTTON_ICCPROFCREATOR"));
         iccProfileCreator->signal_clicked().connect ( sigc::mem_fun (*this, &RTWindow::showICCProfileCreator) );
@@ -240,6 +241,7 @@ RTWindow::RTWindow ()
         //Gtk::Button* preferences = Gtk::manage (new Gtk::Button (M("MAIN_BUTTON_PREFERENCES")+"..."));
         Gtk::Button* preferences = Gtk::manage (new Gtk::Button ());
         setExpandAlignProperties (preferences, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+        preferences->set_relief(Gtk::RELIEF_NONE);
         preferences->set_image (*Gtk::manage (new RTImage ("preferences.png")));
         preferences->set_tooltip_markup (M ("MAIN_BUTTON_PREFERENCES"));
         preferences->signal_clicked().connect ( sigc::mem_fun (*this, &RTWindow::showPreferences) );
@@ -247,6 +249,7 @@ RTWindow::RTWindow ()
         //btn_fullscreen = Gtk::manage( new Gtk::Button(M("MAIN_BUTTON_FULLSCREEN")));
         btn_fullscreen = Gtk::manage ( new Gtk::Button());
         setExpandAlignProperties (btn_fullscreen, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+        btn_fullscreen->set_relief(Gtk::RELIEF_NONE);
         btn_fullscreen->set_tooltip_markup (M ("MAIN_BUTTON_FULLSCREEN"));
         btn_fullscreen->set_image (*iFullscreen);
         btn_fullscreen->signal_clicked().connect ( sigc::mem_fun (*this, &RTWindow::toggle_fullscreen) );


### PR DESCRIPTION
- The buttons in the main notebook (ICC Profile Creator, Preferences,
Fullscreen) and the buttons in the bottom-left corner under the preview
(Save, Sent to queue, Send to GIMP) are now consistently flat to match
all other toolbar buttons.
- Progress bar thicker and more centered in their containers.

![screenshot_20180924_132325](https://user-images.githubusercontent.com/5844619/45950371-d1aad680-bfff-11e8-914d-088dc9492fa3.png)

![screenshot_20180924_134259](https://user-images.githubusercontent.com/5844619/45950373-d2436d00-bfff-11e8-93ed-0b1bdb986ac8.png)
