### PR TITLE
Fix wrong suffix in `SaveAsDialog` (#4446)

### DIFF
--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -363,15 +363,12 @@ void BatchQueuePanel::pathFolderButtonPressed ()
 // since these settings are shared with editorpanel :
 void BatchQueuePanel::pathFolderChanged ()
 {
-
     options.savePathFolder = outdirFolder->get_filename();
 }
 
-void BatchQueuePanel::formatChanged (Glib::ustring f)
+void BatchQueuePanel::formatChanged(const Glib::ustring& format)
 {
-
-    options.saveFormatBatch = saveFormatPanel->getFormat ();
-
+    options.saveFormatBatch = saveFormatPanel->getFormat();
 }
 
 bool BatchQueuePanel::handleShortcutKey (GdkEventKey* event)

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -72,7 +72,7 @@ public:
     void saveOptions ();
     void pathFolderChanged ();
     void pathFolderButtonPressed ();
-    void formatChanged (Glib::ustring f);
+    void formatChanged(const Glib::ustring& format) override;
     void updateTab (int qsize, int forceOrientation = 0); // forceOrientation=0: base on options / 1: horizontal / 2: vertical
 
     bool handleShortcutKey (GdkEventKey* event);

--- a/rtgui/saveasdlg.h
+++ b/rtgui/saveasdlg.h
@@ -62,7 +62,7 @@ public:
 
     void okPressed ();
     void cancelPressed ();
-    void formatChanged (Glib::ustring f);
+    void formatChanged(const Glib::ustring& format) override;
     bool keyPressed (GdkEventKey* event);
 };
 

--- a/rtgui/saveformatpanel.h
+++ b/rtgui/saveformatpanel.h
@@ -28,8 +28,8 @@ class FormatChangeListener
 {
 
 public:
-    virtual ~FormatChangeListener () {}
-    virtual void formatChanged (Glib::ustring f) {}
+    virtual ~FormatChangeListener() = default;
+    virtual void formatChanged(const Glib::ustring& format) = 0;
 };
 
 class SaveFormatPanel : public Gtk::Grid, public AdjusterListener


### PR DESCRIPTION
Hi,

this is the patch from #4446 now as a PR:

1. Fix the "double extension" warning I broke in b84e570.
2. Change suffix on format change.

Best,
Flössie