### PR TITLE
Fallback to RGB histogram if RAW histogram was enabled and a non-RAW is opened

### DIFF
--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -196,7 +196,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
         // raw auto CA is bypassed if no high detail is needed, so we have to compute it when high detail is needed
         if ((todo & M_PREPROC) || (!highDetailPreprocessComputed && highDetailNeeded)) {
-			
+            
             imgsrc->setCurrentFrame(params.raw.bayersensor.imageNum);
 
             imgsrc->preprocess(rp, params.lensProf, params.coarse);

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -196,6 +196,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
         // raw auto CA is bypassed if no high detail is needed, so we have to compute it when high detail is needed
         if ((todo & M_PREPROC) || (!highDetailPreprocessComputed && highDetailNeeded)) {
+			
             imgsrc->setCurrentFrame(params.raw.bayersensor.imageNum);
 
             imgsrc->preprocess(rp, params.lensProf, params.coarse);
@@ -937,7 +938,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
         if (hListener) {
             updateLRGBHistograms();
-            hListener->histogramChanged(histRed, histGreen, histBlue, histLuma, histToneCurve, histLCurve, histCCurve, /*histCLurve, histLLCurve,*/ histLCAM, histCCAM, histRedRaw, histGreenRaw, histBlueRaw, histChroma, histLRETI);
+            hListener->histogramChanged(histRed, histGreen, histBlue, histLuma, histToneCurve, histLCurve, histCCurve, /*histCLurve, histLLCurve,*/ histLCAM, histCCAM, histRedRaw, histGreenRaw, histBlueRaw, histChroma, histLRETI,imgsrc->isRAW());
         }
     }
 

--- a/rtengine/rtengine.h
+++ b/rtengine/rtengine.h
@@ -297,7 +297,7 @@ public:
         const LUTu& histBlueRaw,
         const LUTu& histChroma,
         const LUTu& histLRETI,
-		const bool usableRaw
+        const bool usableRaw
     ) = 0;
 };
 

--- a/rtengine/rtengine.h
+++ b/rtengine/rtengine.h
@@ -296,7 +296,8 @@ public:
         const LUTu& histGreenRaw,
         const LUTu& histBlueRaw,
         const LUTu& histChroma,
-        const LUTu& histLRETI
+        const LUTu& histLRETI,
+		const bool usableRaw
     ) = 0;
 };
 

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -2276,11 +2276,12 @@ void EditorPanel::histogramChanged(
     const LUTu& histGreenRaw,
     const LUTu& histBlueRaw,
     const LUTu& histChroma,
-    const LUTu& histLRETI
+    const LUTu& histLRETI,
+	const bool usableRaw
 )
 {
     if (histogramPanel) {
-        histogramPanel->histogramChanged(histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw);
+        histogramPanel->histogramChanged(histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw, usableRaw);
     }
 
     tpc->updateCurveBackgroundHistogram(histToneCurve, histLCurve, histCCurve, histLCAM, histCCAM, histRed, histGreen, histBlue, histLuma, histLRETI);

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -2277,7 +2277,7 @@ void EditorPanel::histogramChanged(
     const LUTu& histBlueRaw,
     const LUTu& histChroma,
     const LUTu& histLRETI,
-	const bool usableRaw
+    const bool usableRaw
 )
 {
     if (histogramPanel) {

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -122,7 +122,8 @@ public:
         const LUTu& histGreenRaw,
         const LUTu& histBlueRaw,
         const LUTu& histChroma,
-        const LUTu& histLRETI
+        const LUTu& histLRETI,
+		const bool usableRaw
     );
 
     // event handlers

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -123,7 +123,7 @@ public:
         const LUTu& histBlueRaw,
         const LUTu& histChroma,
         const LUTu& histLRETI,
-		const bool usableRaw
+        const bool usableRaw
     );
 
     // event handlers

--- a/rtgui/histogrampanel.cc
+++ b/rtgui/histogrampanel.cc
@@ -742,7 +742,8 @@ void HistogramArea::update(
     const LUTu& histChroma,
     const LUTu& histRedRaw,
     const LUTu& histGreenRaw,
-    const LUTu& histBlueRaw
+    const LUTu& histBlueRaw,
+	const bool usableRaw
 )
 {
     if (histRed) {
@@ -758,6 +759,15 @@ void HistogramArea::update(
     } else {
         valid = false;
     }
+	
+	if (!usableRaw && rawMode) {
+		rawMode = false;
+		
+		// What I would actually like to do here is to call members from HistogramPanel
+		//
+		// showRAW->set_active(false);
+		// raw_toggled ()
+	}
 
     haih->pending++;
     // Can be done outside of the GUI thread

--- a/rtgui/histogrampanel.cc
+++ b/rtgui/histogrampanel.cc
@@ -78,7 +78,7 @@ HistogramPanel::HistogramPanel ()
     chroImage_g  = new RTImage ("histogram-gold-off-small.png");
     rawImage_g   = new RTImage ("histogram-bayer-off-small.png");
     barImage_g   = new RTImage ("histogram-bar-off-small.png");
-	
+    
     mode0Image  = new RTImage ("histogram-mode-linear-small.png");
     mode1Image  = new RTImage ("histogram-mode-logx-small.png");
     mode2Image  = new RTImage ("histogram-mode-logxy-small.png");
@@ -648,7 +648,7 @@ bool HistogramRGBArea::on_button_press_event (GdkEventButton* event)
 
 void HistogramRGBArea::factorChanged (double newFactor)
 {
-	factor = newFactor;
+    factor = newFactor;
 }
 
 //
@@ -743,7 +743,7 @@ void HistogramArea::update(
     const LUTu& histRedRaw,
     const LUTu& histGreenRaw,
     const LUTu& histBlueRaw,
-	const bool usableRaw
+    const bool usableRaw
 )
 {
     if (histRed) {
@@ -759,15 +759,15 @@ void HistogramArea::update(
     } else {
         valid = false;
     }
-	
-	if (!usableRaw && rawMode) {
-		rawMode = false;
-		
-		// What I would actually like to do here is to call members from HistogramPanel
-		//
-		// showRAW->set_active(false);
-		// raw_toggled ()
-	}
+    
+    if (!usableRaw && rawMode) {
+        rawMode = false;
+        
+        // What I would actually like to do here is to call members from HistogramPanel
+        //
+        // showRAW->set_active(false);
+        // raw_toggled ()
+    }
 
     haih->pending++;
     // Can be done outside of the GUI thread

--- a/rtgui/histogrampanel.h
+++ b/rtgui/histogrampanel.h
@@ -153,7 +153,7 @@ public:
         const LUTu& histRedRaw,
         const LUTu& histGreenRaw,
         const LUTu& histBlueRaw,
-		const bool usableRaw
+        const bool usableRaw
     );
     void updateOptions (bool r, bool g, bool b, bool l, bool c, bool raw, int mode);
     void on_realize();
@@ -228,7 +228,7 @@ public:
         const LUTu& histRedRaw,
         const LUTu& histGreenRaw,
         const LUTu& histBlueRaw,
-		const bool usableRaw)
+        const bool usableRaw)
     {
         histogramArea->update(histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw, usableRaw);
     }

--- a/rtgui/histogrampanel.h
+++ b/rtgui/histogrampanel.h
@@ -152,7 +152,8 @@ public:
         const LUTu& histChroma,
         const LUTu& histRedRaw,
         const LUTu& histGreenRaw,
-        const LUTu& histBlueRaw
+        const LUTu& histBlueRaw,
+		const bool usableRaw
     );
     void updateOptions (bool r, bool g, bool b, bool l, bool c, bool raw, int mode);
     void on_realize();
@@ -226,9 +227,10 @@ public:
         const LUTu& histChroma,
         const LUTu& histRedRaw,
         const LUTu& histGreenRaw,
-        const LUTu& histBlueRaw)
+        const LUTu& histBlueRaw,
+		const bool usableRaw)
     {
-        histogramArea->update(histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw);
+        histogramArea->update(histRed, histGreen, histBlue, histLuma, histChroma, histRedRaw, histGreenRaw, histBlueRaw, usableRaw);
     }
     // pointermotionlistener interface
     void pointerMoved (bool validPos, const Glib::ustring &profile, const Glib::ustring &profileW, int x, int y, int r, int g, int b, bool isRaw = false);


### PR DESCRIPTION
I am trying to fix #4813 but I hope somebody can enlighten me on how to elegantly solve a programmatic issue. 

Please see line 766 in `rtgui/histogrampanel.cc` (can I link there directly?)