### PR TITLE
Double-click resets slider

### DIFF
--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -1247,6 +1247,17 @@ bool MyHScale::on_scroll_event (GdkEventScroll* event)
     return false;
 }
 
+bool MyHScale::on_button_press_event (GdkEventButton* event)
+{
+
+    if (event->type == GDK_2BUTTON_PRESS) {
+        // How do I trigger the reset event ... from here?
+        return false;
+    } else {
+        return Gtk::HScale::on_button_press_event(event);
+    }
+}
+
 bool MyHScale::on_key_press_event (GdkEventKey* event)
 {
 

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -363,8 +363,9 @@ public:
  */
 class MyHScale : public Gtk::HScale
 {
-
+    
     bool on_scroll_event (GdkEventScroll* event);
+    bool on_button_press_event (GdkEventButton* event);
     bool on_key_press_event (GdkEventKey* event);
 };
 


### PR DESCRIPTION
Learning on the job: I'm trying to fix #4612, but I would like some advice on how to proceed. 

I've managed (rather easily) to catch the double-click event by modifying the `MyHScale` class. But now I am unsure how I can trigger the actual reset functionality that is required. Of course this reset function only exists in the class that actually creates a `MyHScale` object, in my case the `Adjuster` class which has a `resetPressed` function. So.. uhm... how to proceed from here? Maybe there is even a C++ or GTK+ guide that can help me understand this from a purely programmatic pov?

https://github.com/Thanatomanic/RawTherapee/blob/doubleclick/rtgui/guiutils.cc#L1254
