### PR TITLE
Properly handle queue start/stop switch

### DIFF
--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -45,7 +45,7 @@ namespace
 struct NLParams {
     BatchQueueListener* listener;
     int qsize;
-    bool queueEmptied;
+    bool queueRunning;
     bool queueError;
     Glib::ustring queueErrorMessage;
 };
@@ -53,7 +53,7 @@ struct NLParams {
 int bqnotifylistenerUI (void* data)
 {
     NLParams* params = static_cast<NLParams*>(data);
-    params->listener->queueSizeChanged (params->qsize, params->queueEmptied, params->queueError, params->queueErrorMessage);
+    params->listener->queueSizeChanged (params->qsize, params->queueRunning, params->queueError, params->queueErrorMessage);
     delete params;
     return 0;
 }
@@ -229,7 +229,7 @@ void BatchQueue::addEntries (const std::vector<BatchQueueEntry*>& entries, bool 
         saveBatchQueue ();
 
     redraw ();
-    notifyListener (false);
+    notifyListener (true);
 }
 
 bool BatchQueue::saveBatchQueue ()
@@ -387,7 +387,7 @@ bool BatchQueue::loadBatchQueue ()
     }
 
     redraw ();
-    notifyListener (false);
+    notifyListener (true);
 
     return !fd.empty ();
 }
@@ -460,7 +460,7 @@ void BatchQueue::cancelItems (const std::vector<ThumbBrowserEntryBase*>& items)
     saveBatchQueue ();
 
     redraw ();
-    notifyListener (false);
+    notifyListener (true);
 }
 
 void BatchQueue::headItems (const std::vector<ThumbBrowserEntryBase*>& items)
@@ -640,7 +640,7 @@ void BatchQueue::error(const Glib::ustring& descr)
     if (listener) {
         NLParams* params = new NLParams;
         params->listener = listener;
-        params->queueEmptied = false;
+        params->queueRunning = false;
         params->queueError = true;
         params->queueErrorMessage = descr;
         idle_register.add(bqnotifylistenerUI, params);
@@ -706,7 +706,6 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
     Glib::ustring processedParams = processing->savedParamsFile;
 
     // delete from the queue
-    bool queueEmptied = false;
     bool remove_button_set = false;
 
     {
@@ -718,9 +717,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
         fd.erase (fd.begin());
 
         // return next job
-        if (fd.empty()) {
-            queueEmptied = true;
-        } else if (listener && listener->canStartNext ()) {
+        if (!fd.empty() && listener && listener->canStartNext ()) {
             BatchQueueEntry* next = static_cast<BatchQueueEntry*>(fd[0]);
             // tag it as selected and set sequence
             next->processing = true;
@@ -778,7 +775,8 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
     }
 
     redraw ();
-    notifyListener (queueEmptied);
+    const bool queueRunning = (processing != nullptr);
+    notifyListener (queueRunning);
 
     return processing ? processing->job : nullptr;
 }
@@ -973,7 +971,7 @@ void BatchQueue::buttonPressed (LWButton* button, int actionCode, void* actionDa
     }
 }
 
-void BatchQueue::notifyListener (bool queueEmptied)
+void BatchQueue::notifyListener (bool queueRunning)
 {
 
     if (listener) {
@@ -983,7 +981,7 @@ void BatchQueue::notifyListener (bool queueEmptied)
             MYREADERLOCK(l, entryRW);
             params->qsize = fd.size();
         }
-        params->queueEmptied = queueEmptied;
+        params->queueRunning = queueRunning;
         params->queueError = false;
         idle_register.add(bqnotifylistenerUI, params);
     }

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -775,7 +775,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
     }
 
     redraw ();
-    const bool queueRunning = (processing != nullptr);
+    const bool queueRunning = processing;
     notifyListener (queueRunning);
 
     return processing ? processing->job : nullptr;

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -31,7 +31,7 @@ class BatchQueueListener
 
 public:
     virtual ~BatchQueueListener() = default;
-    virtual void queueSizeChanged(int qsize, bool queueEmptied, bool queueError, const Glib::ustring& queueErrorMessage) = 0;
+    virtual void queueSizeChanged(int qsize, bool queueRunning, bool queueError, const Glib::ustring& queueErrorMessage) = 0;
     virtual bool canStartNext() = 0;
 };
 
@@ -93,7 +93,7 @@ protected:
     Glib::ustring autoCompleteFileName (const Glib::ustring& fileName, const Glib::ustring& format);
     Glib::ustring getTempFilenameForParams( const Glib::ustring &filename );
     bool saveBatchQueue ();
-    void notifyListener (bool queueEmptied);
+    void notifyListener (bool queueRunning);
 
     BatchQueueEntry* processing;  // holds the currently processed image
     FileCatalog* fileCatalog;

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -245,7 +245,7 @@ void BatchQueuePanel::updateTab (int qsize, int forceOrientation)
     }
 }
 
-void BatchQueuePanel::queueSizeChanged(int qsize, bool queueEmptied, bool queueError, const Glib::ustring& queueErrorMessage)
+void BatchQueuePanel::queueSizeChanged(int qsize, bool queueRunning, bool queueError, const Glib::ustring& queueErrorMessage)
 {
     updateTab (qsize);
 
@@ -255,12 +255,14 @@ void BatchQueuePanel::queueSizeChanged(int qsize, bool queueEmptied, bool queueE
         qStartStop->set_sensitive(true);
     }
 
-    if (queueEmptied || queueError) {
+    if (!queueRunning) {
         stopBatchProc ();
         fdir->set_sensitive (true);
         fformat->set_sensitive (true);
 
-        SoundManager::playSoundAsync(options.sndBatchQueueDone);
+        if (qsize == 0) {
+            SoundManager::playSoundAsync(options.sndBatchQueueDone);
+        }
     }
 
     if (queueError) {

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -249,7 +249,7 @@ void BatchQueuePanel::queueSizeChanged(int qsize, bool queueRunning, bool queueE
 {
     updateTab (qsize);
 
-    if (qsize == 0 || (qsize == 1 && !fdir->get_sensitive())) {
+    if (qsize == 0 || (qsize == 1 && queueRunning)) {
         qStartStop->set_sensitive(false);
     } else {
         qStartStop->set_sensitive(true);

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -324,19 +324,39 @@ void BatchQueuePanel::addBatchQueueJobs(const std::vector<BatchQueueEntry*>& ent
     }
 }
 
-bool BatchQueuePanel::canStartNext ()
-{
-    // This function is called from the background BatchQueue thread.
-    // It cannot call UI functions, so grab the stored state of qStartStop.
-    return qStartStopState;
-}
-
 void BatchQueuePanel::saveOptions ()
 {
 
     options.savePathTemplate    = outdirTemplate->get_text();
     options.saveUsePathTemplate = useTemplate->get_active();
     options.procQueueEnabled    = qAutoStart->get_active();
+}
+
+bool BatchQueuePanel::handleShortcutKey (GdkEventKey* event)
+{
+    bool ctrl = event->state & GDK_CONTROL_MASK;
+
+    if (ctrl) {
+        switch(event->keyval) {
+        case GDK_KEY_s:
+            if (qStartStop->get_active()) {
+                stopBatchProc();
+            } else {
+                startBatchProc();
+            }
+
+            return true;
+        }
+    }
+
+    return batchQueue->keyPressed (event);
+}
+
+bool BatchQueuePanel::canStartNext ()
+{
+    // This function is called from the background BatchQueue thread.
+    // It cannot call UI functions, so grab the stored state of qStartStop.
+    return qStartStopState;
 }
 
 void BatchQueuePanel::pathFolderButtonPressed ()
@@ -367,24 +387,4 @@ void BatchQueuePanel::pathFolderChanged ()
 void BatchQueuePanel::formatChanged(const Glib::ustring& format)
 {
     options.saveFormatBatch = saveFormatPanel->getFormat();
-}
-
-bool BatchQueuePanel::handleShortcutKey (GdkEventKey* event)
-{
-    bool ctrl = event->state & GDK_CONTROL_MASK;
-
-    if (ctrl) {
-        switch(event->keyval) {
-        case GDK_KEY_s:
-            if (qStartStop->get_active()) {
-                stopBatchProc();
-            } else {
-                startBatchProc();
-            }
-
-            return true;
-        }
-    }
-
-    return batchQueue->keyPressed (event);
 }

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -286,6 +286,7 @@ void BatchQueuePanel::startBatchProc ()
     // Update switch when queue started programmatically
     qStartStopConn.block (true);
     qStartStop->set_active(true);
+    qStartStopState = true;
     qStartStopConn.block (false);
 
     if (batchQueue->hasJobs()) {
@@ -308,6 +309,7 @@ void BatchQueuePanel::stopBatchProc ()
     // Update switch when queue started programmatically
     qStartStopConn.block (true);
     qStartStop->set_active(false);
+    qStartStopState = false;
     qStartStopConn.block (false);
 
     updateTab (batchQueue->getEntries().size());
@@ -324,14 +326,9 @@ void BatchQueuePanel::addBatchQueueJobs(const std::vector<BatchQueueEntry*>& ent
 
 bool BatchQueuePanel::canStartNext ()
 {
-//    GThreadLock lock;
-    if (qStartStop->get_active()) {
-        return true;
-    } else {
-        fdir->set_sensitive (true);
-        fformat->set_sensitive (true);
-        return false;
-    }
+    // This function is called from the background BatchQueue thread.
+    // It cannot call UI functions, so grab the stored state of qStartStop.
+    return qStartStopState;
 }
 
 void BatchQueuePanel::saveOptions ()

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -19,6 +19,8 @@
 #ifndef _BATCHQUEUEPANEL_
 #define _BATCHQUEUEPANEL_
 
+#include <atomic>
+
 #include <gtkmm.h>
 #include "batchqueue.h"
 #include "saveformatpanel.h"
@@ -52,6 +54,8 @@ class BatchQueuePanel : public Gtk::VBox,
     Gtk::HBox* topBox;
 
     IdleRegister idle_register;
+
+    std::atomic<bool> qStartStopState;
 
 public:
     explicit BatchQueuePanel (FileCatalog* aFileCatalog);

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -60,22 +60,23 @@ public:
     void init (RTWindow* parent);
 
     void addBatchQueueJobs(const std::vector<BatchQueueEntry*>& entries , bool head = false);
+    void saveOptions ();
+
+    bool handleShortcutKey (GdkEventKey* event);
 
     // batchqueuelistener interface
     void queueSizeChanged(int qsize, bool queueEmptied, bool queueError, const Glib::ustring& queueErrorMessage);
     bool canStartNext();
 
+private:
     void startBatchProc ();
     void stopBatchProc ();
     void startOrStopBatchProc();
 
-    void saveOptions ();
     void pathFolderChanged ();
     void pathFolderButtonPressed ();
     void formatChanged(const Glib::ustring& format) override;
     void updateTab (int qsize, int forceOrientation = 0); // forceOrientation=0: base on options / 1: horizontal / 2: vertical
-
-    bool handleShortcutKey (GdkEventKey* event);
 };
 #endif
 

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -53,9 +53,9 @@ class BatchQueuePanel : public Gtk::VBox,
     Gtk::HBox* bottomBox;
     Gtk::HBox* topBox;
 
-    IdleRegister idle_register;
-
     std::atomic<bool> qStartStopState;
+
+    IdleRegister idle_register;
 
 public:
     explicit BatchQueuePanel (FileCatalog* aFileCatalog);

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -69,7 +69,7 @@ public:
     bool handleShortcutKey (GdkEventKey* event);
 
     // batchqueuelistener interface
-    void queueSizeChanged(int qsize, bool queueEmptied, bool queueError, const Glib::ustring& queueErrorMessage);
+    void queueSizeChanged(int qsize, bool queueRunning, bool queueError, const Glib::ustring& queueErrorMessage);
     bool canStartNext();
 
 private:


### PR DESCRIPTION
This is a small series of patches to clean up the GUI callback for the queue worker.  It no longer deadlocks or crashes when cancelling the batch.  See #4882 for more details.