### PR TITLE
Fix GUI/batch state synchronization

### DIFF
--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -597,6 +597,8 @@ void BatchQueue::startProcessing ()
             // start batch processing
             rtengine::startBatchProcessing (next->job, this);
             queue_draw ();
+
+            notifyListener();
         }
     }
 }

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -229,7 +229,7 @@ void BatchQueue::addEntries (const std::vector<BatchQueueEntry*>& entries, bool 
         saveBatchQueue ();
 
     redraw ();
-    notifyListener (true);
+    notifyListener ();
 }
 
 bool BatchQueue::saveBatchQueue ()
@@ -387,7 +387,7 @@ bool BatchQueue::loadBatchQueue ()
     }
 
     redraw ();
-    notifyListener (true);
+    notifyListener ();
 
     return !fd.empty ();
 }
@@ -460,7 +460,7 @@ void BatchQueue::cancelItems (const std::vector<ThumbBrowserEntryBase*>& items)
     saveBatchQueue ();
 
     redraw ();
-    notifyListener (true);
+    notifyListener ();
 }
 
 void BatchQueue::headItems (const std::vector<ThumbBrowserEntryBase*>& items)
@@ -775,8 +775,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
     }
 
     redraw ();
-    const bool queueRunning = processing;
-    notifyListener (queueRunning);
+    notifyListener ();
 
     return processing ? processing->job : nullptr;
 }
@@ -971,9 +970,9 @@ void BatchQueue::buttonPressed (LWButton* button, int actionCode, void* actionDa
     }
 }
 
-void BatchQueue::notifyListener (bool queueRunning)
+void BatchQueue::notifyListener ()
 {
-
+    const bool queueRunning = processing;
     if (listener) {
         NLParams* params = new NLParams;
         params->listener = listener;

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -93,7 +93,7 @@ protected:
     Glib::ustring autoCompleteFileName (const Glib::ustring& fileName, const Glib::ustring& format);
     Glib::ustring getTempFilenameForParams( const Glib::ustring &filename );
     bool saveBatchQueue ();
-    void notifyListener (bool queueRunning);
+    void notifyListener ();
 
     BatchQueueEntry* processing;  // holds the currently processed image
     FileCatalog* fileCatalog;

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -247,8 +247,6 @@ void BatchQueuePanel::updateTab (int qsize, int forceOrientation)
 
 void BatchQueuePanel::queueSizeChanged(int qsize, bool queueRunning, bool queueError, const Glib::ustring& queueErrorMessage)
 {
-    updateTab (qsize);
-
     setGuiFromBatchState(queueRunning, qsize);
 
     if (!queueRunning && qsize == 0 && queueShouldRun) {
@@ -284,8 +282,6 @@ void BatchQueuePanel::startBatchProc ()
         saveOptions();
         batchQueue->startProcessing ();
     }
-
-    updateTab (batchQueue->getEntries().size());
 }
 
 void BatchQueuePanel::stopBatchProc ()
@@ -294,8 +290,6 @@ void BatchQueuePanel::stopBatchProc ()
     // background queue thread must check.  It will notify queueSizeChanged()
     // when it stops.
     queueShouldRun = false;
-
-    updateTab (batchQueue->getEntries().size());
 }
 
 void BatchQueuePanel::setGuiFromBatchState(bool queueRunning, int qsize)
@@ -313,6 +307,8 @@ void BatchQueuePanel::setGuiFromBatchState(bool queueRunning, int qsize)
 
     fdir->set_sensitive (!queueRunning);
     fformat->set_sensitive (!queueRunning);
+
+    updateTab(qsize);
 }
 
 void BatchQueuePanel::addBatchQueueJobs(const std::vector<BatchQueueEntry*>& entries, bool head)

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -281,9 +281,6 @@ void BatchQueuePanel::startBatchProc ()
         // callback in response to the *reported* state.
         queueShouldRun = true;
 
-        // Don't need an update callback from the queue to know it is started:
-        setGuiFromBatchState(true, batchQueue->getEntries().size());
-
         saveOptions();
         batchQueue->startProcessing ();
     }

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -249,20 +249,13 @@ void BatchQueuePanel::queueSizeChanged(int qsize, bool queueRunning, bool queueE
 {
     updateTab (qsize);
 
-    if (qsize == 0 || (qsize == 1 && queueRunning)) {
-        qStartStop->set_sensitive(false);
-    } else {
-        qStartStop->set_sensitive(true);
-    }
+    setGuiFromBatchState(queueRunning, qsize);
 
-    if (!queueRunning) {
-        stopBatchProc ();
-        fdir->set_sensitive (true);
-        fformat->set_sensitive (true);
+    if (!queueRunning && qsize == 0 && queueShouldRun) {
+        // There was work, but it is all done now.
+        queueShouldRun = false;
 
-        if (qsize == 0) {
-            SoundManager::playSoundAsync(options.sndBatchQueueDone);
-        }
+        SoundManager::playSoundAsync(options.sndBatchQueueDone);
     }
 
     if (queueError) {
@@ -273,8 +266,7 @@ void BatchQueuePanel::queueSizeChanged(int qsize, bool queueRunning, bool queueE
 
 void BatchQueuePanel::startOrStopBatchProc()
 {
-    bool state = qStartStop->get_state();
-    if (state) {
+    if (qStartStop->get_state()) {
         startBatchProc();
     } else {
         stopBatchProc();
@@ -283,22 +275,17 @@ void BatchQueuePanel::startOrStopBatchProc()
 
 void BatchQueuePanel::startBatchProc ()
 {
-    // Update switch when queue started programmatically
-    qStartStopConn.block (true);
-    qStartStop->set_active(true);
-    qStartStopState = true;
-    qStartStopConn.block (false);
-
     if (batchQueue->hasJobs()) {
-        fdir->set_sensitive (false);
-        fformat->set_sensitive (false);
-        if (batchQueue->getEntries().size() == 1) {
-            qStartStop->set_sensitive(false);
-        }
+        // Update the *desired* state of the queue, then launch it.  The switch
+        // state is not updated here; it is changed by the queueSizeChanged()
+        // callback in response to the *reported* state.
+        queueShouldRun = true;
+
+        // Don't need an update callback from the queue to know it is started:
+        setGuiFromBatchState(true, batchQueue->getEntries().size());
+
         saveOptions();
         batchQueue->startProcessing ();
-    } else {
-        stopBatchProc ();
     }
 
     updateTab (batchQueue->getEntries().size());
@@ -306,13 +293,29 @@ void BatchQueuePanel::startBatchProc ()
 
 void BatchQueuePanel::stopBatchProc ()
 {
-    // Update switch when queue started programmatically
-    qStartStopConn.block (true);
-    qStartStop->set_active(false);
-    qStartStopState = false;
-    qStartStopConn.block (false);
+    // There is nothing much to do here except set the desired state, which the
+    // background queue thread must check.  It will notify queueSizeChanged()
+    // when it stops.
+    queueShouldRun = false;
 
     updateTab (batchQueue->getEntries().size());
+}
+
+void BatchQueuePanel::setGuiFromBatchState(bool queueRunning, int qsize)
+{
+    // Change the GUI state in response to the reported queue state
+    if (qsize == 0 || (qsize == 1 && queueRunning)) {
+        qStartStop->set_sensitive(false);
+    } else {
+        qStartStop->set_sensitive(true);
+    }
+
+    qStartStopConn.block(true);
+    qStartStop->set_active(queueRunning);
+    qStartStopConn.block(false);
+
+    fdir->set_sensitive (!queueRunning);
+    fformat->set_sensitive (!queueRunning);
 }
 
 void BatchQueuePanel::addBatchQueueJobs(const std::vector<BatchQueueEntry*>& entries, bool head)
@@ -320,6 +323,7 @@ void BatchQueuePanel::addBatchQueueJobs(const std::vector<BatchQueueEntry*>& ent
     batchQueue->addEntries(entries, head);
 
     if (!qStartStop->get_active() && qAutoStart->get_active()) {
+        // Auto-start as if the user had pressed the qStartStop switch
         startBatchProc ();
     }
 }
@@ -354,9 +358,9 @@ bool BatchQueuePanel::handleShortcutKey (GdkEventKey* event)
 
 bool BatchQueuePanel::canStartNext ()
 {
-    // This function is called from the background BatchQueue thread.
-    // It cannot call UI functions, so grab the stored state of qStartStop.
-    return qStartStopState;
+    // This function is called from the background BatchQueue thread.  It
+    // cannot call UI functions; we keep the desired state in an atomic.
+    return queueShouldRun;
 }
 
 void BatchQueuePanel::pathFolderButtonPressed ()

--- a/rtgui/batchqueuepanel.h
+++ b/rtgui/batchqueuepanel.h
@@ -53,7 +53,7 @@ class BatchQueuePanel : public Gtk::VBox,
     Gtk::HBox* bottomBox;
     Gtk::HBox* topBox;
 
-    std::atomic<bool> qStartStopState;
+    std::atomic<bool> queueShouldRun;
 
     IdleRegister idle_register;
 
@@ -76,6 +76,7 @@ private:
     void startBatchProc ();
     void stopBatchProc ();
     void startOrStopBatchProc();
+    void setGuiFromBatchState(bool queueRunning, int qsize);
 
     void pathFolderChanged ();
     void pathFolderButtonPressed ();


### PR DESCRIPTION
Previously, this function required a `queueEmptied` bool, which I changed to `queueRunning`.  But I goofed the logic on this bool; it should always be "is `processing` nullptr."

See original report #4882, and initial fix PR #4895.