### PR TITLE
Preferences: Hide 'Clear All' and 'Clear Processing Profiles' if profiles are saved next to input file

### DIFF
--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1362,11 +1362,13 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
 
     Gtk::HBox* hb5 = Gtk::manage ( new Gtk::HBox () );
     clearThumbnails = Gtk::manage ( new Gtk::Button (M ("PREFERENCES_CACHECLEARTHUMBS")) );
-    clearProfiles = Gtk::manage ( new Gtk::Button (M ("PREFERENCES_CACHECLEARPROFILES")) );
-    clearAll = Gtk::manage ( new Gtk::Button (M ("PREFERENCES_CACHECLEARALL")) );
     hb5->pack_start (*clearThumbnails, Gtk::PACK_SHRINK, 4);
-    hb5->pack_start (*clearProfiles, Gtk::PACK_SHRINK, 4);
-    hb5->pack_start (*clearAll, Gtk::PACK_SHRINK, 4);
+    if (moptions.saveParamsCache) {
+        clearProfiles = Gtk::manage ( new Gtk::Button (M ("PREFERENCES_CACHECLEARPROFILES")) );
+        clearAll = Gtk::manage ( new Gtk::Button (M ("PREFERENCES_CACHECLEARALL")) );
+        hb5->pack_start (*clearProfiles, Gtk::PACK_SHRINK, 4);
+        hb5->pack_start (*clearAll, Gtk::PACK_SHRINK, 4);
+    }
     vbc->pack_start (*hb5, Gtk::PACK_SHRINK, 4);
 
     Gtk::HBox* hb6 = Gtk::manage ( new Gtk::HBox () );
@@ -1387,9 +1389,10 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
     moveExtDown->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::moveExtDownPressed) );
     extension->signal_activate().connect ( sigc::mem_fun (*this, &Preferences::addExtPressed) );
     clearThumbnails->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::clearThumbImagesPressed) );
-    clearProfiles->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::clearProfilesPressed) );
-    clearAll->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::clearAllPressed) );
-
+    if (moptions.saveParamsCache) {
+        clearProfiles->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::clearProfilesPressed) );
+        clearAll->signal_clicked().connect ( sigc::mem_fun (*this, &Preferences::clearAllPressed) );
+    }
     swFileBrowser->add(*vbFileBrowser);
     return swFileBrowser;
 }


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/13733487/47850266-f3546600-ddd4-11e8-9410-137eee3d6f0e.png)

After:
![grafik](https://user-images.githubusercontent.com/13733487/47850357-39a9c500-ddd5-11e8-94b5-b6c1409ba436.png)


