### PR TITLE
Clip label takes to much space

### DIFF
--- a/rtgui/tonecurve.cc
+++ b/rtgui/tonecurve.cc
@@ -48,7 +48,7 @@ ToneCurve::ToneCurve () : FoldableToolPanel(this, "tonecurve", M("TP_EXPOSURE_LA
     
 //----------- Auto Levels ----------------------------------
     abox = Gtk::manage (new Gtk::HBox ());
-    abox->set_spacing (10);
+    abox->set_spacing (4);
 
     autolevels = Gtk::manage (new Gtk::ToggleButton (M("TP_EXPOSURE_AUTOLEVELS")));
     autolevels->set_tooltip_markup (M("TP_EXPOSURE_AUTOLEVELS_TIP"));


### PR DESCRIPTION
The clip label "Clip %" takes to much space.
This changes the spacing from 10px to 4px.
![ezgif com-gif-maker](https://user-images.githubusercontent.com/13800920/47965133-53504400-e043-11e8-99a0-4fff40937444.gif)
