### PR TITLE
Fixes unspecified bit depth in CLI

### DIFF
--- a/rtgui/main-cli.cc
+++ b/rtgui/main-cli.cc
@@ -410,8 +410,6 @@ int processLineParams ( int argc, char **argv )
                         return -3;
                     }
 
-                    std::cout << "Output is " << bits << "-bit " << (isFloat ? "floating-point" : "integer") << "." << std::endl;
-
                     break;
 
                 case 't':
@@ -622,6 +620,18 @@ int processLineParams ( int argc, char **argv )
         }
     }
 
+    if (bits == -1) {
+        if (outputType == "jpg") {
+            bits = 8;
+        } else if (outputType == "png") {
+            bits = 8;
+        } else if (outputType == "tif") {
+            bits = 16;
+        } else {
+            bits = 8;
+        }
+    }
+
     if ( !argv1.empty() ) {
         return 1;
     }
@@ -662,6 +672,7 @@ int processLineParams ( int argc, char **argv )
         rtengine::procparams::ProcParams currentParams;
 
         Glib::ustring inputFile = inputFiles[iFile];
+        std::cout << "Output is " << bits << "-bit " << (isFloat ? "floating-point" : "integer") << "." << std::endl;
         std::cout << "Processing: " << inputFile << std::endl;
 
         rtengine::InitialImage* ii = nullptr;


### PR DESCRIPTION
In rawtherapee-cli, if you did not explcitly specify a bit depth then -1
was used and lead to corrupted saved images.
Fixes #4937