### PR TITLE
Save space in Preferences -> File Browser Tab

### DIFF
--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -473,7 +473,7 @@ separator,
     background-color: transparent;
 }
 grid separator.horizontal, box separator.horizontal {
-    margin: 0.166666666666666666em;
+    margin: 0.333333333333333333em 0.166666666666666666em;
     padding: 0;
 }
 grid separator.vertical, box separator.vertical {
@@ -550,7 +550,7 @@ menu separator {
     margin: 0.166666666666666666em;
 }
 
-#MyExpander separator {
+#MyExpander separator.horizontal {
     background-color: @view-grid-border;
     margin: 0.333333333333333333em 0.166666666666666666em;
 }

--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -473,7 +473,7 @@ separator,
     background-color: transparent;
 }
 grid separator.horizontal, box separator.horizontal {
-    margin: 0.166666666666666666em 0;
+    margin: 0.166666666666666666em;
     padding: 0;
 }
 grid separator.vertical, box separator.vertical {
@@ -549,10 +549,7 @@ menu separator {
     background-color: shade(@bg-light-grey,.75);
     margin: 0.166666666666666666em;
 }
-separator#PrefCacheSeparator.horizontal {
-    margin: 0.25em 0.166666666666666666em;
-    padding: 0;
-}
+
 #MyExpander separator {
     background-color: @view-grid-border;
     margin: 0.333333333333333333em 0.166666666666666666em;

--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -113,6 +113,10 @@ window > box {
 dialog {
     background-color: @bg-grey;
     border-radius: 0;
+    -GtkDialog-button-spacing: 0;
+    -GtkDialog-content-area-spacing: 0;
+    -GtkDialog-content-area-border: 0;
+    -GtkDialog-action-area-border: 0;
 }
 dialog > box {
     padding: 0.666666666666666666em;
@@ -336,9 +340,13 @@ fontchooser scrolledwindow,
 /*** end ***************************************************************************************/
 
 /*** Load - Save dialog ************************************************************************/
+filechooser {
+margin-bottom: 0.25em;
+}
 
-filechooser  box > box   box > button  {
+filechooser box > box box > button {
 margin-top: 0.5em;
+margin-right: 0;
 }
 
 filechooser image  {
@@ -537,11 +545,14 @@ menu separator {
     padding: 0;
 }
 
-.scrollableToolbar separator:not(.dummy) {
+.scrollableToolbar separator.vertical {
     background-color: shade(@bg-light-grey,.75);
     margin: 0.166666666666666666em;
 }
-
+separator#PrefCacheSeparator.horizontal {
+    margin: 0.25em 0.166666666666666666em;
+    padding: 0;
+}
 #MyExpander separator {
     background-color: @view-grid-border;
     margin: 0.333333333333333333em 0.166666666666666666em;
@@ -944,7 +955,8 @@ window.csd:not(.fullscreen) #MainNotebook > header.top {
 #PrefNotebook > header {
     margin: -0.666666666666666666em -0.666666666666666666em 0.333333333333333333em;
 }
-#PrefNotebook > header tab label {
+#PrefNotebook > header tab label,
+#AboutNotebook > header tab label {
     padding-top: 0.25em;
     padding-bottom: 0.25em;
 }
@@ -1435,14 +1447,15 @@ colorchooser colorswatch#add-color-button:first-child {
 }
 
 /* Save, Cancel, OK ... buttons */
-.dialog-action-area button {
+dialog .dialog-action-area button {
     min-height: 2.166666666666666666em;
-    margin-top: 1em;
+    margin: 0.5em 0 0 0.333333333333333333em;
     padding: 0;
 }
 messagedialog .dialog-action-area button {
     min-height: 1.833333333333333333em;
-    margin: -12px 0.5em 0.5em 0.5em;
+    margin: -12px 0.5em 0.5em;
+    padding: 0;
 }
 messagedialog .dialog-action-area button:not(:only-child):nth-child(1) {
     margin-right: 0.25em;
@@ -1789,7 +1802,7 @@ radio:disabled {
 
 radiobutton label,
 checkbutton label {
-    margin: 0 0 0 0.416666666666666666em;
+    margin: 0 0.416666666666666666em;
     padding: 0;
 }
 

--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -1421,8 +1421,12 @@ combobox entry + button:not(.dummy) {
     border-bottom-left-radius: 0;
     border-left: none;
 }
+
 #PlacesPaned button.combo {
-    margin: 0 0 calc(0.416666666666666666em - 8px) 0;
+    margin: 0;
+}
+#PlacesPaned combobox {
+    margin-bottom: calc(0.416666666666666666em - 8px);
 }
 
 /* Reset button */

--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -2,7 +2,7 @@
   This file is part of RawTherapee.
 
   Copyright (c) 2016-2018 TooWaBoo
-  Version 2.85
+  Version 2.86
 
   RawTherapee is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1206,7 +1206,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
     startupdir = Gtk::manage ( new Gtk::Entry () );
 
     Gtk::Button* sdselect = Gtk::manage ( new Gtk::Button () );
-    sdselect->set_image (*Gtk::manage (new RTImage ("folder-open.png")));
+    sdselect->set_image (*Gtk::manage (new RTImage ("folder-open-small.png")));
 
     Gtk::RadioButton::Group opts = sdcurrent->get_group();
     sdlast->set_group (opts);
@@ -1275,20 +1275,26 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
 
 
     Gtk::Frame* frmnu = Gtk::manage ( new Gtk::Frame (M ("PREFERENCES_MENUOPTIONS")) );
+    
+    Gtk::Grid* menuGrid = Gtk::manage(new Gtk::Grid());
+    menuGrid->get_style_context()->add_class("grid-spacing");
+    setExpandAlignProperties(menuGrid, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
+    
     ckbmenuGroupRank = Gtk::manage ( new Gtk::CheckButton (M ("PREFERENCES_MENUGROUPRANK")) );
+    setExpandAlignProperties(ckbmenuGroupRank, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     ckbmenuGroupLabel = Gtk::manage ( new Gtk::CheckButton (M ("PREFERENCES_MENUGROUPLABEL")) );
     ckbmenuGroupFileOperations = Gtk::manage ( new Gtk::CheckButton (M ("PREFERENCES_MENUGROUPFILEOPERATIONS")) );
+    setExpandAlignProperties(ckbmenuGroupFileOperations, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     ckbmenuGroupProfileOperations = Gtk::manage ( new Gtk::CheckButton (M ("PREFERENCES_MENUGROUPPROFILEOPERATIONS")) );
     ckbmenuGroupExtProg = Gtk::manage ( new Gtk::CheckButton (M ("PREFERENCES_MENUGROUPEXTPROGS")) );
-    Gtk::VBox* vbmnu = Gtk::manage ( new Gtk::VBox () );
+    
+    menuGrid->attach (*ckbmenuGroupRank, 0, 0, 1, 1);
+    menuGrid->attach (*ckbmenuGroupLabel, 1, 0, 1, 1);
+    menuGrid->attach (*ckbmenuGroupFileOperations, 0, 1, 1, 1);
+    menuGrid->attach (*ckbmenuGroupProfileOperations, 1, 1, 1, 1);
+    menuGrid->attach (*ckbmenuGroupExtProg, 0, 2, 2, 1);
 
-    vbmnu->pack_start (*ckbmenuGroupRank, Gtk::PACK_SHRINK, 0);
-    vbmnu->pack_start (*ckbmenuGroupLabel, Gtk::PACK_SHRINK, 0);
-    vbmnu->pack_start (*ckbmenuGroupFileOperations, Gtk::PACK_SHRINK, 0);
-    vbmnu->pack_start (*ckbmenuGroupProfileOperations, Gtk::PACK_SHRINK, 0);
-    vbmnu->pack_start (*ckbmenuGroupExtProg, Gtk::PACK_SHRINK, 0);
-
-    frmnu->add (*vbmnu);
+    frmnu->add (*menuGrid);
 
 
     Gtk::Frame* fre = Gtk::manage ( new Gtk::Frame (M ("PREFERENCES_PARSEDEXT")) );
@@ -1360,7 +1366,8 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
 
     // Separation is needed so that a button is not accidentally clicked when one wanted
     // to click a spinbox. Ideally, the separation wouldn't require attaching a widget, but how?
-    Gtk::Label *separator = Gtk::manage (new Gtk::Label());
+    Gtk::HSeparator *cacheSeparator = Gtk::manage (new  Gtk::HSeparator());
+    cacheSeparator->set_name("PrefCacheSeparator");
 
     Gtk::Label* clearThumbsLbl = Gtk::manage (new Gtk::Label(M("PREFERENCES_CACHECLEAR_ALLBUTPROFILES")));
     setExpandAlignProperties(clearThumbsLbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -1378,7 +1385,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
     cacheGrid->attach (*maxThumbHeightSB, 1, 0, 1, 1);
     cacheGrid->attach (*maxCacheEntriesLbl, 0, 1, 1, 1);
     cacheGrid->attach (*maxCacheEntriesSB, 1, 1, 1, 1);
-    cacheGrid->attach (*separator, 0, 2, 2, 1);
+    cacheGrid->attach (*cacheSeparator, 0, 2, 2, 1);
     cacheGrid->attach (*clearThumbsLbl, 0, 3, 1, 1);
     cacheGrid->attach (*clearThumbsBtn, 1, 3, 1, 1);
     if (moptions.saveParamsCache) {

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1367,7 +1367,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel ()
     // Separation is needed so that a button is not accidentally clicked when one wanted
     // to click a spinbox. Ideally, the separation wouldn't require attaching a widget, but how?
     Gtk::HSeparator *cacheSeparator = Gtk::manage (new  Gtk::HSeparator());
-    cacheSeparator->set_name("PrefCacheSeparator");
+    cacheSeparator->get_style_context()->add_class("grid-row-separator");
 
     Gtk::Label* clearThumbsLbl = Gtk::manage (new Gtk::Label(M("PREFERENCES_CACHECLEAR_ALLBUTPROFILES")));
     setExpandAlignProperties(clearThumbsLbl, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);


### PR DESCRIPTION
Changed `Folder-open.png` to `Folder-open-small.png`. The TWB-theme is using the same height for buttons and entry fields. The big icon is increasing the size. I hope this is OK

Changed "Context Menu Options" to two columns

Changed the `cache button separator` to a real separater with ID `#PrefCacheSeparator` for styling in css.
```
separator#PrefCacheSeparator.horizontal {
    <any style>
}
```
Adapted the TWB

ping @Beep6581 

old
![oldrt](https://user-images.githubusercontent.com/13800920/47979074-6c97d580-e0c1-11e8-85d0-a3716324397d.PNG)
new
![newrt](https://user-images.githubusercontent.com/13800920/47979082-73264d00-e0c1-11e8-822e-3a8b86757562.PNG)
old
![oldtwb](https://user-images.githubusercontent.com/13800920/47979089-791c2e00-e0c1-11e8-8dcf-a0cfd7cbde55.PNG)
new
![newtwb](https://user-images.githubusercontent.com/13800920/47979093-7de0e200-e0c1-11e8-8026-640afd807327.PNG)
