### PR TITLE
Improve calculation of dual demosaic contrast threshold

### DIFF
--- a/rtengine/rt_algo.cc
+++ b/rtengine/rt_algo.cc
@@ -22,8 +22,6 @@
 #include <cmath>
 #include <cstdint>
 #include <vector>
-#include <iostream>
-#include <vector>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -206,12 +204,14 @@ void buildBlendMask(float** luminance, float **blend, int W, int H, float &contr
         if (autoContrast) {
             for (int pass = 0; pass < 2; ++pass) {
                 const int tilesize = 80 / (pass + 1);
-                const int skip = pass < 1 ? tilesize : tilesize / 4;
+                const int skip = pass == 0 ? tilesize : tilesize / 4;
                 const int numTilesW = W / skip - 3 * pass;
                 const int numTilesH = H / skip - 3 * pass;
                 std::vector<std::vector<float>> variances(numTilesH, std::vector<float>(numTilesW));
 
+#ifdef _OPENMP
                 #pragma omp parallel for schedule(dynamic)
+#endif
                 for (int i = 0; i < numTilesH; ++i) {
                     const int tileY = i * skip;
                     for (int j = 0; j < numTilesW; ++j) {


### PR DESCRIPTION
Calculation of dual demosaic contrast threshold value has up to two passes.
The first pass analyzes the image in tiles of 80x80 pixels. If there is at least one tile with variance <= 1 it uses the tile with the min. variance to calculate the treshold and skips pass two.

Because there are not always flat regions of 80x80 pixels pass two analyzes the image in tiles of 40x40 pixels. If there is at least one tile with variance <= 4 it uses the tile with the min. variance to calculate the threshold, else it returns a threshold of 0.

I improved pass 2 by changing the tile distance from 40 to 10. This increases processing time of pass 2 a bit but gives a better detection rate, means less threshold = 0 values.