### PR TITLE
Center selected thumb in Filmstrip #5174

### DIFF
--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1057,14 +1057,14 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     } else {
         Gtk::Allocation alloc;
         iareapanel->imageArea->on_resized (alloc);
+
+        // When passing a photo as an argument to the RawTherapee executable, the user wants
+        // this auto-loaded photo's thumbnail to be selected and visible in the Filmstrip.
+        EditorPanel::syncFileBrowser();
     }
 
     history->resetSnapShotNumber();
     navigator->setInvalid(ipc->getFullWidth(),ipc->getFullHeight());
-
-    // When passing a photo as an argument to the RawTherapee executable, the user wants
-    // this auto-loaded photo's thumbnail to be selected and visible in the Filmstrip.
-    EditorPanel::syncFileBrowser();
 }
 
 void EditorPanel::close ()

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -1727,62 +1727,62 @@ void FileBrowser::buttonPressed (LWButton* button, int actionCode, void* actionD
     }
 }
 
-void FileBrowser::openNextImage ()
+void FileBrowser::openNextImage()
 {
     MYWRITERLOCK(l, entryRW);
 
     if (!fd.empty() && selected.size() > 0 && !options.tabbedUI) {
-
         for (size_t i = 0; i < fd.size() - 1; i++) {
             if (selected[0]->thumbnail->getFileName() == fd[i]->filename) { // located 1-st image in current selection
                 if (i < fd.size() && tbl) {
                     // find the first not-filtered-out (next) image
                     for (size_t k = i + 1; k < fd.size(); k++) {
                         if (!fd[k]->filtered/*checkFilter (fd[k])*/) {
+
                             // clear current selection
                             for (size_t j = 0; j < selected.size(); j++) {
                                 selected[j]->selected = false;
                             }
 
-                            selected.clear ();
+                            selected.clear();
 
                             // set new selection
                             fd[k]->selected = true;
-                            selected.push_back (fd[k]);
-                            //queue_draw ();
+                            selected.push_back(fd[k]);
+                            //queue_draw();
 
                             MYWRITERLOCK_RELEASE(l);
 
                             // this will require a read access
-                            notifySelectionListener ();
+                            notifySelectionListener();
 
                             MYWRITERLOCK_ACQUIRE(l);
 
-                            // scroll to the selected position
-                            double h1, v1;
-                            getScrollPosition(h1, v1);
+                            // scroll to the selected position, centered horizontally in the container
+                            double x1, y1;
+                            getScrollPosition(x1, y1);
 
-                            double h2 = selected[0]->getStartX();
-                            double v2 = selected[0]->getStartY();
+                            double x2 = selected[0]->getStartX();
+                            double y2 = selected[0]->getStartY();
 
                             Thumbnail* thumb = (static_cast<FileBrowserEntry*>(fd[k]))->thumbnail;
-                            int minWidth = get_width() - fd[k]->getMinimalWidth();
+                            int tw = fd[k]->getMinimalWidth(); // thumb width
+
+                            int ww = get_width(); // window width
 
                             MYWRITERLOCK_RELEASE(l);
 
                             // scroll only when selected[0] is outside of the displayed bounds
-                            if (h2 + minWidth - h1 > get_width()) {
-                                setScrollPosition(h2 - minWidth, v2);
-                            }
-
-                            if (h1 > h2) {
-                                setScrollPosition(h2, v2);
+                            // or less than a thumbnail's width from either edge.
+                            if ((x2 > x1 + ww - 2 * tw) || (x2 - tw < x1)) {
+                                setScrollPosition(x2 - (ww - tw) / 2, y2);
                             }
 
                             // open the selected image
                             std::vector<Thumbnail*> entries;
-                            entries.push_back (thumb);
-                            tbl->openRequested (entries);
+                            entries.push_back(thumb);
+                            tbl->openRequested(entries);
+
                             return;
                         }
                     }
@@ -1792,62 +1792,62 @@ void FileBrowser::openNextImage ()
     }
 }
 
-void FileBrowser::openPrevImage ()
+void FileBrowser::openPrevImage()
 {
     MYWRITERLOCK(l, entryRW);
 
     if (!fd.empty() && selected.size() > 0 && !options.tabbedUI) {
-
         for (size_t i = 1; i < fd.size(); i++) {
             if (selected[0]->thumbnail->getFileName() == fd[i]->filename) { // located 1-st image in current selection
                 if (i > 0 && tbl) {
                     // find the first not-filtered-out (previous) image
                     for (ssize_t k = (ssize_t)i - 1; k >= 0; k--) {
                         if (!fd[k]->filtered/*checkFilter (fd[k])*/) {
+
                             // clear current selection
                             for (size_t j = 0; j < selected.size(); j++) {
                                 selected[j]->selected = false;
                             }
 
-                            selected.clear ();
+                            selected.clear();
 
                             // set new selection
                             fd[k]->selected = true;
-                            selected.push_back (fd[k]);
-                            //queue_draw ();
+                            selected.push_back(fd[k]);
+                            //queue_draw();
 
                             MYWRITERLOCK_RELEASE(l);
 
                             // this will require a read access
-                            notifySelectionListener ();
+                            notifySelectionListener();
 
                             MYWRITERLOCK_ACQUIRE(l);
 
-                            // scroll to the selected position
-                            double h1, v1;
-                            getScrollPosition(h1, v1);
+                            // scroll to the selected position, centered horizontally in the container
+                            double x1, y1;
+                            getScrollPosition(x1, y1);
 
-                            double h2 = selected[0]->getStartX();
-                            double v2 = selected[0]->getStartY();
+                            double x2 = selected[0]->getStartX();
+                            double y2 = selected[0]->getStartY();
 
                             Thumbnail* thumb = (static_cast<FileBrowserEntry*>(fd[k]))->thumbnail;
-                            int minWidth = get_width() - fd[k]->getMinimalWidth();
+                            int tw = fd[k]->getMinimalWidth(); // thumb width
+
+                            int ww = get_width(); // window width
 
                             MYWRITERLOCK_RELEASE(l);
 
                             // scroll only when selected[0] is outside of the displayed bounds
-                            if (h2 + minWidth - h1 > get_width()) {
-                                setScrollPosition(h2 - minWidth, v2);
-                            }
-
-                            if (h1 > h2) {
-                                setScrollPosition(h2, v2);
+                            // or less than a thumbnail's width from either edge.
+                            if ((x2 > x1 + ww - 2 * tw) || (x2 - tw < x1)) {
+                                setScrollPosition(x2 - (ww - tw) / 2, y2);
                             }
 
                             // open the selected image
                             std::vector<Thumbnail*> entries;
-                            entries.push_back (thumb);
-                            tbl->openRequested (entries);
+                            entries.push_back(thumb);
+                            tbl->openRequested(entries);
+
                             return;
                         }
                     }
@@ -1857,11 +1857,8 @@ void FileBrowser::openPrevImage ()
     }
 }
 
-
-void FileBrowser::selectImage (Glib::ustring fname)
+void FileBrowser::selectImage(Glib::ustring fname)
 {
-
-    // need to clear the filter in filecatalog
     MYWRITERLOCK(l, entryRW);
 
     if (!fd.empty() && !options.tabbedUI) {
@@ -1874,27 +1871,31 @@ void FileBrowser::selectImage (Glib::ustring fname)
                     selected[j]->selected = false;
                 }
 
-                selected.clear ();
+                selected.clear();
 
                 // set new selection
                 fd[i]->selected = true;
-                selected.push_back (fd[i]);
-                queue_draw ();
+                selected.push_back(fd[i]);
+                queue_draw();
 
                 MYWRITERLOCK_RELEASE(l);
 
                 // this will require a read access
-                notifySelectionListener ();
+                notifySelectionListener();
 
                 MYWRITERLOCK_ACQUIRE(l);
 
-                // scroll to the selected position
-                double h = selected[0]->getStartX();
-                double v = selected[0]->getStartY();
+                // scroll to the selected position, centered horizontally in the container
+                double x = selected[0]->getStartX();
+                double y = selected[0]->getStartY();
+
+                int tw = fd[i]->getMinimalWidth(); // thumb width
+
+                int ww = get_width(); // window width
 
                 MYWRITERLOCK_RELEASE(l);
 
-                setScrollPosition(h, v);
+                setScrollPosition(x - (ww - tw) / 2, y);
 
                 return;
             }

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -1779,9 +1779,7 @@ void FileBrowser::openNextImage()
                             }
 
                             // open the selected image
-                            std::vector<Thumbnail*> entries;
-                            entries.push_back(thumb);
-                            tbl->openRequested(entries);
+                            tbl->openRequested({thumb});
 
                             return;
                         }
@@ -1844,9 +1842,7 @@ void FileBrowser::openPrevImage()
                             }
 
                             // open the selected image
-                            std::vector<Thumbnail*> entries;
-                            entries.push_back(thumb);
-                            tbl->openRequested(entries);
+                            tbl->openRequested({thumb});
 
                             return;
                         }
@@ -1857,7 +1853,7 @@ void FileBrowser::openPrevImage()
     }
 }
 
-void FileBrowser::selectImage(Glib::ustring fname)
+void FileBrowser::selectImage(const Glib::ustring& fname)
 {
     MYWRITERLOCK(l, entryRW);
 
@@ -1903,7 +1899,7 @@ void FileBrowser::selectImage(Glib::ustring fname)
     }
 }
 
-void FileBrowser::openNextPreviousEditorImage (Glib::ustring fname, eRTNav nextPrevious)
+void FileBrowser::openNextPreviousEditorImage (const Glib::ustring& fname, eRTNav nextPrevious)
 {
 
     // let FileBrowser acquire Editor's perspective

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -1853,7 +1853,7 @@ void FileBrowser::openPrevImage()
     }
 }
 
-void FileBrowser::selectImage(const Glib::ustring& fname)
+void FileBrowser::selectImage(const Glib::ustring& fname, bool doScroll)
 {
     MYWRITERLOCK(l, entryRW);
 
@@ -1891,7 +1891,10 @@ void FileBrowser::selectImage(const Glib::ustring& fname)
 
                 MYWRITERLOCK_RELEASE(l);
 
-                setScrollPosition(x - (ww - tw) / 2, y);
+                if (doScroll) {
+                    // Center thumb
+                    setScrollPosition(x - (ww - tw) / 2, y);
+                }
 
                 return;
             }
@@ -1903,7 +1906,7 @@ void FileBrowser::openNextPreviousEditorImage (const Glib::ustring& fname, eRTNa
 {
 
     // let FileBrowser acquire Editor's perspective
-    selectImage (fname);
+    selectImage (fname, false);
 
     // now switch to the requested image
     if (nextPrevious == NAV_NEXT) {

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -183,7 +183,7 @@ public:
 
     void openNextImage();
     void openPrevImage();
-    void selectImage(const Glib::ustring& fname);
+    void selectImage(const Glib::ustring& fname, bool doScroll);
 
     void copyProfile ();
     void pasteProfile ();

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -181,12 +181,13 @@ public:
         return tbl ? tbl->isInTabMode() : false;
     }
 
-    void openNextImage ();
-    void openPrevImage ();
+    void openNextImage();
+    void openPrevImage();
+    void selectImage(Glib::ustring fname);
+
     void copyProfile ();
     void pasteProfile ();
     void partPasteProfile ();
-    void selectImage (Glib::ustring fname);
     void openNextPreviousEditorImage (Glib::ustring fname, eRTNav eNextPrevious);
 
 #ifdef WIN32

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -183,7 +183,7 @@ public:
 
     void openNextImage();
     void openPrevImage();
-    void selectImage(const Glib::ustring& fname, bool doScroll);
+    void selectImage(const Glib::ustring& fname, bool doScroll = true);
 
     void copyProfile ();
     void pasteProfile ();

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -183,12 +183,12 @@ public:
 
     void openNextImage();
     void openPrevImage();
-    void selectImage(Glib::ustring fname);
+    void selectImage(const Glib::ustring& fname);
 
     void copyProfile ();
     void pasteProfile ();
     void partPasteProfile ();
-    void openNextPreviousEditorImage (Glib::ustring fname, eRTNav eNextPrevious);
+    void openNextPreviousEditorImage(const Glib::ustring& fname, eRTNav eNextPrevious);
 
 #ifdef WIN32
     void openDefaultViewer (int destination);

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -829,7 +829,7 @@ void FileCatalog::previewsFinishedUI ()
     filepanel->loadingThumbs(M("PROGRESSBAR_READY"), 0);
 
     if (!imageToSelect_fname.empty()) {
-        fileBrowser->selectImage(imageToSelect_fname);
+        fileBrowser->selectImage(imageToSelect_fname, true);
         imageToSelect_fname = "";
     }
 
@@ -2144,7 +2144,7 @@ void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
             imageToSelect_fname = fname;
         } else {
             // FileCatalog::filterChanged ();//this will be replaced by queue_draw() in fileBrowser->selectImage
-            fileBrowser->selectImage(fname);
+            fileBrowser->selectImage(fname, true);
             imageToSelect_fname = "";
         }
     }

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -829,7 +829,7 @@ void FileCatalog::previewsFinishedUI ()
     filepanel->loadingThumbs(M("PROGRESSBAR_READY"), 0);
 
     if (!imageToSelect_fname.empty()) {
-        fileBrowser->selectImage(imageToSelect_fname, true);
+        fileBrowser->selectImage(imageToSelect_fname);
         imageToSelect_fname = "";
     }
 
@@ -2144,7 +2144,7 @@ void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
             imageToSelect_fname = fname;
         } else {
             // FileCatalog::filterChanged ();//this will be replaced by queue_draw() in fileBrowser->selectImage
-            fileBrowser->selectImage(fname, true);
+            fileBrowser->selectImage(fname);
             imageToSelect_fname = "";
         }
     }


### PR DESCRIPTION
When opening an image, selecting the next/previous image or syncing the
Filmstrip, the newly selected thumbnail is centered, unless it lies
within the visible area more than 1 thumbnails-width away from either
edge, in which case centering does not occur.