### PR TITLE
GUI improvements for Locallab

### DIFF
--- a/rtgui/controlspotpanel.h
+++ b/rtgui/controlspotpanel.h
@@ -260,6 +260,7 @@ private:
     public:
         ControlSpots();
 
+        Gtk::TreeModelColumn<bool> mouseover; // Used to manage spot enlightening when mouse over
         Gtk::TreeModelColumn<int> id; // Control spot id
         Gtk::TreeModelColumn<Glib::ustring> name;
         Gtk::TreeModelColumn<bool> isvisible;

--- a/rtgui/history.cc
+++ b/rtgui/history.cc
@@ -265,7 +265,8 @@ void History::procParamsChanged(
     }
 
     // if there is no last item or its chev!=ev, create a new one
-    if (size == 0 || !row || row[historyColumns.chev] != ev || ev == EvProfileChanged) {
+    if (size == 0 || !row || row[historyColumns.chev] != ev || ev == EvProfileChanged
+            || ev == EvLocallabSpotCreated || ev == EvLocallabSpotDeleted) { // Special cases: If Locallab spot is created , deleted or duplicated several times in a row, a new history row is used
 //       Gtk::TreeModel::Row newrow = * (historyModel->append());
 //       newrow[historyColumns.realText] = eventDescrArray[ev];
         Gtk::TreeModel::Row newrow = * (historyModel->append());


### PR DESCRIPTION
@Desmis 
Two improvements requested on pixls.us:
- A new history row is added when several spots are created/deleted/duplicated in a row
- Not selected spots are now enlighten in TreeView (row background becomes orange) when mouse is over them

Pierre