### PR TITLE
Misc. typos and whitespace fixes

### DIFF
--- a/rtengine/ahd_demosaic_RT.cc
+++ b/rtengine/ahd_demosaic_RT.cc
@@ -173,7 +173,7 @@ void RawImageSource::ahd_demosaic()
                 }
             }
 
-            //  Combine the most homogenous pixels for the final result:
+            //  Combine the most homogeneous pixels for the final result:
             for (int row = top + 3; row < top + TS - 3 && row < height - 5; row++) {
                 int tr = row - top;
 

--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -4835,7 +4835,7 @@ void CLASS xtrans_interpolate (int passes)
 		  homo[d][row][col]++;
 	}
 
-/* Average the most homogenous pixels for the final result:	*/
+/* Average the most homogeneous pixels for the final result:	*/
       if (height-top < TS+4) mrow = height-top+2;
       if (width-left < TS+4) mcol = width-left+2;
       for (row = MIN(top,8); row < mrow-8; row++)
@@ -4951,7 +4951,7 @@ void CLASS ahd_interpolate()
 		homo[d][tr][tc]++;
 	}
       }
-/*  Combine the most homogenous pixels for the final result:	*/
+/*  Combine the most homogeneous pixels for the final result:	*/
       for (row=top+3; row < top+TS-3 && row < height-5; row++) {
 	tr = row-top;
 	for (col=left+3; col < left+TS-3 && col < width-5; col++) {

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -5376,7 +5376,7 @@ void CLASS pre_interpolate()
 //		  homo[d][row][col]++;
 //	}
 //
-///* Average the most homogenous pixels for the final result:	*/
+///* Average the most homogeneous pixels for the final result:	*/
 //      if (height-top < TS+4) mrow = height-top+2;
 //      if (width-left < TS+4) mcol = width-left+2;
 //      for (row = MIN(top,8); row < mrow-8; row++)

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -181,7 +181,7 @@ void proPhotoBlue(float *rtemp, float *gtemp, float *btemp, int istart, int tH, 
                     float r = rtemp[ti * tileSize + tj + k];
                     float g = gtemp[ti * tileSize + tj + k];
                     float b = btemp[ti * tileSize + tj + k];
-                    
+
                     if ((r == 0.0f || g == 0.0f) && rtengine::min(r, g, b) >= 0.f) {
                         float h, s, v;
                         Color::rgb2hsv (r, g, b, h, s, v);
@@ -314,7 +314,7 @@ void ImProcFunctions::updateColorProfiles (const Glib::ustring& monitorProfile, 
         if (softProof) {
             cmsHPROFILE oprof = nullptr;
             RenderingIntent outIntent;
-            
+
             flags = cmsFLAGS_SOFTPROOFING | cmsFLAGS_NOOPTIMIZE | cmsFLAGS_NOCACHE;
 
             if (!settings->printerProfile.empty()) {
@@ -2521,7 +2521,7 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                     float tmpr[4] ALIGNED16;
                     float tmpg[4] ALIGNED16;
                     float tmpb[4] ALIGNED16;
-                    
+
                     for (int i = istart, ti = 0; i < tH; i++, ti++) {
                         int j = jstart, tj = 0;
 #ifdef __SSE2__
@@ -3223,7 +3223,7 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                 }
 
                 //softLight(rtemp, gtemp, btemp, istart, jstart, tW, tH, TS);
-                
+
                 if (!blackwhite) {
                     if (editImgFloat || editWhatever) {
                         for (int i = istart, ti = 0; i < tH; i++, ti++) {
@@ -3698,7 +3698,7 @@ void ImProcFunctions::retreavergb (float &r, float &g, float &b)
 
 /**
 * @brief Interpolate by decreasing with a parabol k = aa*v*v + bb*v +c  v[0..1]
-* @param reducac val ue of the reduction in the middle of the range
+* @param reducac value of the reduction in the middle of the range
 * @param vinf value [0..1] for beginning decrease
 * @param aa second degree parameter
 * @param bb first degree parameter
@@ -3720,7 +3720,7 @@ void ImProcFunctions::secondeg_end (float reducac, float vinf, float &aa, float 
 
 /**
 * @brief Interpolate by increasing with a parabol k = aa*v*v + bb*v  v[0..1]
-* @param reducac val ue of the reduction in the middle of the range
+* @param reducac value of the reduction in the middle of the range
 * @param vend value [0..1] for beginning increase
 * @param aa second degree parameter
 * @param bb first degree parameter
@@ -4085,7 +4085,7 @@ void ImProcFunctions::labtoning (float r, float g, float b, float &ro, float &go
     ro = CLIP(r);
     go = CLIP(g);
     bo = CLIP(b);
-    
+
     float realL;
     float h, s, l;
     Color::rgb2hsl (ro, go, bo, h, s, l);
@@ -4224,7 +4224,7 @@ void ImProcFunctions::chromiLuminanceCurve (PipetteBuffer *pipetteBuffer, int pW
     }
     //-------------------------------------------------------------------------
 
-    
+
     if (!params->labCurve.enabled) {
         if (editPipette && (editID == EUID_Lab_LCurve || editID == EUID_Lab_aCurve || editID == EUID_Lab_bCurve || editID == EUID_Lab_LHCurve || editID == EUID_Lab_CHCurve || editID == EUID_Lab_HHCurve || editID == EUID_Lab_CLCurve || editID == EUID_Lab_CCurve || editID == EUID_Lab_LCCurve)) {
             // fill pipette buffer with zeros to avoid crashes

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -679,7 +679,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
         }
 
         // The output filename's extension is forced to the current or selected output format,
-        // despite what the user have set in the fielneame's field of the "Save as" dialgo box
+        // despite what the user have set in the filename's field of the "Save as" dialog box
         fname = autoCompleteFileName (removeExtension(processing->outFileName), saveFormat.format);
         //fname = autoCompleteFileName (removeExtension(processing->outFileName), getExtension(processing->outFileName));
     }

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -190,7 +190,7 @@ RTWindow::RTWindow ()
                         resolution /= 2;
                     }
                     // 1pt =  1/72in @ 96 ppi
-                    // HOMBRE: If the font unit is px, is it alredy scaled up to match the resolution ?
+                    // HOMBRE: If the font unit is px, is it already scaled up to match the resolution ?
                     //             px         >inch >pt      >"scaled pt"
                     pt = (int)(double(fontSize) / RTScalable::baseDPI * 72. * (RTScalable::baseHiDPI / resolution) + 0.49);
                 } else {

--- a/tools/color_management.svg
+++ b/tools/color_management.svg
@@ -548,7 +548,7 @@
          sodipodi:role="line"
          id="tspan5376"
          x="100.83148"
-         y="648.47211">Used fo image analysis <tspan
+         y="648.47211">Used for image analysis <tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold'"
    id="tspan7948">only</tspan> with</tspan><tspan
          style="font-size:10px"
@@ -567,7 +567,7 @@
          x="436.97083"
          id="tspan5396"
          sodipodi:role="line"
-         style="font-size:10px">Used fo image analysis with</tspan><tspan
+         style="font-size:10px">Used for image analysis with</tspan><tspan
          id="tspan5398"
          y="660.97211"
          x="436.97083"


### PR DESCRIPTION
Found via `codespell -q 3 -I ../rawtherapy-whitelist.txt -S ./rtdata` 
`rawtherapy-whitelist.txt` consists of:
```
adn
amin
autor
ba
byteorder
cas
childs
developpement
dum
foto
fro
inbetween
interm
ist
iten
ith
lonly
nd
ois
optio
preserv
skipp
som
spred
substracted
tbe
tim
uint
unselect
```