### PR TITLE
Small button fix (TWB & RT theme) for 5.6

### DIFF
--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -2,7 +2,7 @@
   This file is part of RawTherapee.
 
   Copyright (c) 2016-2019 TooWaBoo
-  Version 3.07
+  Version 3.08
 
   RawTherapee is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -1568,6 +1568,10 @@ messagedialog .dialog-action-area button:not(:only-child):nth-child(2) {
     padding: 0 0.13em;
 }
 
+#EditorTopPanel button.narrowbutton image{
+    min-width: 0.833333333333333333em;
+}
+
 /* Image close button */
 #MainNotebook > header tab #CloseButton {
     padding: 0.166666666666666666em;
@@ -1578,21 +1582,23 @@ messagedialog .dialog-action-area button:not(:only-child):nth-child(2) {
 
 /* Filter buttons*/
 #ToolBarPanelFileBrowser .smallbuttonbox {
-    min-height: 0;
+    min-height: 1.166666666666666666em;
     padding: 0;
     margin: 0;
 }
 #ToolBarPanelFileBrowser .smallbuttonbox:nth-child(2) {
-    margin-top: 0.12em;
+    margin-top: 0.166666666666666666em;
+    margin-bottom: -0.166666666666666666em;
 }
 #ToolBarPanelFileBrowser .smallbuttonbox button.smallbutton image {
-    margin: -0.12em;
+    margin: -1em;
+    padding: 0;
     min-width: 0;
     min-height: 0;
 }
 #ToolBarPanelFileBrowser .smallbuttonbox button.smallbutton {
     min-height: 0;
-    min-width: 1.333333333333333333em;
+    min-width: 1.166666666666666666em;
     padding: 0;
     margin: 0 0.25em;
     border: none;

--- a/rtdata/themes/size.css
+++ b/rtdata/themes/size.css
@@ -647,15 +647,17 @@ messagedialog .dialog-action-area button:not(:only-child):nth-child(2) {
 
 /* Filter buttons*/
 #ToolBarPanelFileBrowser .smallbuttonbox {
-    min-height: 0;
+    min-height: 1.166666666666666666em;
     padding: 0;
     margin: 0;
 }
 #ToolBarPanelFileBrowser .smallbuttonbox:nth-child(2) {
-    margin: 0 0 -0.166666666666666666em;
+    margin-top: 0.166666666666666666em;
+    margin-bottom: -0.166666666666666666em;
 }
 #ToolBarPanelFileBrowser .smallbuttonbox button.smallbutton image {
-    margin: -0.166666666666666666em;
+    margin: -1em 0;
+    padding: 0;
     min-width: 0;
     min-height: 0;
 }
@@ -663,7 +665,7 @@ messagedialog .dialog-action-area button:not(:only-child):nth-child(2) {
     min-height: 0;
     min-width: 1.166666666666666666em;
     padding: 0;
-    margin: 0 0.25em;
+    margin: 0 0.166666666666666666em;
     border: none;
     border-radius: 0;
 }


### PR DESCRIPTION
If Pseudo-HiDPI is off and the font size is not the base font size, the small buttons (filter buttons) have a wrong spacing.

old
![grafik](https://user-images.githubusercontent.com/13800920/56454392-16a5aa00-6350-11e9-80e1-09b5f070fbdf.png)

new
![grafik](https://user-images.githubusercontent.com/13800920/56454397-34730f00-6350-11e9-8e8f-6200ccfa0fe7.png)
