### PR TITLE
Added ColorMatrix for HUAWEI DLI-L22

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -2556,6 +2556,11 @@ Camera constants:
         "raw_crop": [ 64, 108, 11608, 8708 ]
     },
 
+    {
+        "make_model": [ "HUAWEI DLI-L22" ],
+        "dcraw_matrix": [ 6984, -812, -975, -4792, 13481, 1381, -1056, 2355, 4873 ] // ColorMatrix1 (D65, wrong order) from Adobe DNG Converter 11.2.1
+    },
+
     // Dummy test entry to test the parser and show the format with all entries active
     {
         "make_model": "DummyMake DummyModel",


### PR DESCRIPTION
From https://discuss.pixls.us/t/canon-powershot-sx-150-regression-in-colors-5-5-vs-5-3/12018/26?u=morgan_hardwood

Illuminants in wrong order, used ColorMatrix1.