### PR TITLE
Clut scan speedup

### DIFF
--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -270,7 +270,8 @@ void rtengine::HaldCLUT::splitClutFilename(
     const Glib::ustring& filename,
     Glib::ustring& name,
     Glib::ustring& extension,
-    Glib::ustring& profile_name
+    Glib::ustring& profile_name,
+    bool checkProfile
 )
 {
     Glib::ustring basename = Glib::path_get_basename(filename);
@@ -284,17 +285,19 @@ void rtengine::HaldCLUT::splitClutFilename(
         name = basename;
     }
 
-    profile_name = "sRGB";
+    if (checkProfile) {
+        profile_name = "sRGB";
 
-    if (!name.empty()) {
-        for (const auto& working_profile : rtengine::ICCStore::getInstance()->getWorkingProfiles()) {
-            if (
-                !working_profile.empty() // This isn't strictly needed, but an empty wp name should be skipped anyway
-                && std::search(name.rbegin(), name.rend(), working_profile.rbegin(), working_profile.rend()) == name.rbegin()
-            ) {
-                profile_name = working_profile;
-                name.erase(name.size() - working_profile.size());
-                break;
+        if (!name.empty()) {
+            for (const auto& working_profile : rtengine::ICCStore::getInstance()->getWorkingProfiles()) {
+                if (
+                    !working_profile.empty() // This isn't strictly needed, but an empty wp name should be skipped anyway
+                    && std::search(name.rbegin(), name.rend(), working_profile.rbegin(), working_profile.rend()) == name.rbegin()
+                ) {
+                    profile_name = working_profile;
+                    name.erase(name.size() - working_profile.size());
+                    break;
+                }
             }
         }
     }

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -39,7 +39,8 @@ public:
         const Glib::ustring& filename,
         Glib::ustring& name,
         Glib::ustring& extension,
-        Glib::ustring& profile_name
+        Glib::ustring& profile_name,
+        bool checkProfile = true
     );
 
 private:

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -8,6 +8,8 @@
 
 #include "../rtengine/clutstore.h"
 #include "../rtengine/procparams.h"
+#define BENCHMARK
+#include "../rtengine/StopWatch.h"
 
 using namespace rtengine;
 using namespace rtengine::procparams;
@@ -305,6 +307,7 @@ ClutComboBox::ClutModel::ClutModel(const Glib::ustring &path)
 
 int ClutComboBox::ClutModel::parseDir(const Glib::ustring& path)
 {
+    BENCHFUNMICRO
     if (path.empty() || !Glib::file_test(path, Glib::FILE_TEST_IS_DIR)) {
         return 0;
     }
@@ -364,7 +367,7 @@ int ClutComboBox::ClutModel::parseDir(const Glib::ustring& path)
     }
 
     // Fill menu structure with CLUT files
-    std::set<Glib::ustring> entries;
+    std::set<std::string> entries;
 
     unsigned long fileCount = 0;
 

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -393,7 +393,7 @@ int ClutComboBox::ClutModel::parseDir(const Glib::ustring& path)
             Glib::ustring name;
             Glib::ustring extension;
             Glib::ustring profileName;
-            HaldCLUT::splitClutFilename (entry, name, extension, profileName);
+            HaldCLUT::splitClutFilename (entry, name, extension, profileName, false);
 
             extension = extension.casefold();
             if (extension != "png" && extension != "tif") {

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -396,7 +396,7 @@ int ClutComboBox::ClutModel::parseDir(const Glib::ustring& path)
             HaldCLUT::splitClutFilename (entry, name, extension, profileName);
 
             extension = extension.casefold();
-            if (extension.compare("tif") != 0 && extension.compare("png") != 0) {
+            if (extension != "png" && extension != "tif") {
                 continue;
             }
 


### PR DESCRIPTION
Processing time of the function which scans the clut folder structure when starting rt (as usual all measures are median of 7):

dev: 52.5 ms
1st commit: 24.0 ms
2nd commit: 23.0 ms
3rd commit: 22.6 ms