### PR TITLE
Fix source comment and misc. typos

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1429,7 +1429,7 @@ TP_COLORAPP_SURROUND_AVER;Average
 TP_COLORAPP_SURROUND_DARK;Dark
 TP_COLORAPP_SURROUND_DIM;Dim
 TP_COLORAPP_SURROUND_EXDARK;Extremly Dark (Cutsheet)
-TP_COLORAPP_SURROUND_TOOLTIP;Changes tones and colors to take into account the viewing conditions of the output device.\n\n<b>Average</b>: Average light environment (standard). The image will not change.\n\n<b>Dim</b>: Dim environment (TV). The image will become slighty dark.\n\n<b>Dark</b>: Dark environment (projector). The image will become more dark.\n\n<b>Extremly Dark</b>: Extremly dark environment (cutsheet). The image will become very dark.
+TP_COLORAPP_SURROUND_TOOLTIP;Changes tones and colors to take into account the viewing conditions of the output device.\n\n<b>Average</b>: Average light environment (standard). The image will not change.\n\n<b>Dim</b>: Dim environment (TV). The image will become slightly dark.\n\n<b>Dark</b>: Dark environment (projector). The image will become more dark.\n\n<b>Extremly Dark</b>: Extremly dark environment (cutsheet). The image will become very dark.
 TP_COLORAPP_TCMODE_BRIGHTNESS;Brightness
 TP_COLORAPP_TCMODE_CHROMA;Chroma
 TP_COLORAPP_TCMODE_COLORF;Colorfulness

--- a/rtdata/options/options.lin
+++ b/rtdata/options/options.lin
@@ -6,7 +6,7 @@
 
 [General]
 # Setting MultiUser to false will use the application's installation directory as cache directory,
-# which can be useful if you want to keep the application and all the cache datas in a single place,
+# which can be useful if you want to keep the application and all the cache data in a single place,
 # an external HD for example
 MultiUser=true
 

--- a/rtdata/options/options.osx
+++ b/rtdata/options/options.osx
@@ -6,7 +6,7 @@
 
 [General]
 # Setting MultiUser to false will use the application's installation directory as cache directory,
-# which can be useful if you want to keep the application and all the cache datas in a single place,
+# which can be useful if you want to keep the application and all the cache data in a single place,
 # an external HD for example
 MultiUser=true
 

--- a/rtdata/options/options.win
+++ b/rtdata/options/options.win
@@ -6,7 +6,7 @@
 
 [General]
 # Setting MultiUser to false will use the application's installation directory as cache directory,
-# which can be useful if you want to keep the application and all the cache datas in a single place,
+# which can be useful if you want to keep the application and all the cache data in a single place,
 # an external HD for example
 MultiUser=true
 # Windows users should not use the system theme : some composed widget won't be usable

--- a/rtengine/EdgePreservingDecomposition.cc
+++ b/rtengine/EdgePreservingDecomposition.cc
@@ -406,7 +406,7 @@ bool MultiDiagonalSymmetricMatrix::CreateIncompleteCholeskyFactorization(int Max
     fp = 1;
 
     for(int ii = 1; ii < m; ii++) {
-        fp = rtengine::min(StartRows[ii] - StartRows[ii - 1], MaxFillAbove);    //Guarunteed positive since StartRows must be created in increasing order.
+        fp = rtengine::min(StartRows[ii] - StartRows[ii - 1], MaxFillAbove);    //Guaranteed positive since StartRows must be created in increasing order.
         mic = mic + fp;
     }
 

--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -1796,7 +1796,7 @@ public:
     static inline double huelab_to_huehsv2 (float HH)
     {
         //hr=translate Hue Lab value  (-Pi +Pi) in approximative hr (hsv values) (0 1) [red 1/6 yellow 1/6 green 1/6 cyan 1/6 blue 1/6 magenta 1/6 ]
-        // with multi linear correspondances (I expect there is no error !!)
+        // with multi linear correspondences (I expect there is no error !!)
         double hr = 0.0;
         //always put h between 0 and 1
 

--- a/rtengine/demosaic_algos.cc
+++ b/rtengine/demosaic_algos.cc
@@ -1206,10 +1206,10 @@ void RawImageSource::igv_interpolate(int winw, int winh)
             }
 
             for (; col < width; col++, indx += 2) {
-                dest1[indx >> 1] = CLIP(rawData[row][col]); //rawData = RT datas
+                dest1[indx >> 1] = CLIP(rawData[row][col]); //rawData = RT data
                 col++;
                 if(col < width)
-                    dest2[indx >> 1] = CLIP(rawData[row][col]); //rawData = RT datas
+                    dest2[indx >> 1] = CLIP(rawData[row][col]); //rawData = RT data
             }
         }
 
@@ -1561,7 +1561,7 @@ void RawImageSource::igv_interpolate(int winw, int winh)
         for (int row = 0; row < height - 0; row++)
             for (int col = 0, indx = row * width + col; col < width - 0; col++, indx++) {
                 int c = FC(row, col);
-                rgb[c][indx] = CLIP(rawData[row][col]); //rawData = RT datas
+                rgb[c][indx] = CLIP(rawData[row][col]); //rawData = RT data
             }
 
 //  border_interpolate2(7, rgb);

--- a/rtengine/eahd_demosaic.cc
+++ b/rtengine/eahd_demosaic.cc
@@ -415,7 +415,7 @@ void RawImageSource::eahd_demosaic ()
         }
     }
 
-    // finish H-2th and H-1th row, homogenity value is still valailable
+    // finish H-2th and H-1th row, homogeneity value is still available
     for (int i = H - 1; i < H + 1; i++)
         for (int j = 0; j < W; j++) {
             int hc = homh[(i - 1) % 3][j];

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -729,7 +729,7 @@ void ImProcFunctions::ciecam_02float (CieImage* ncie, float adap, int pW, int pw
         const float hue = params->colorappearance.colorh;
         const float rstprotection = 100. - params->colorappearance.rstprotection;
 
-        // extracting datas from 'params' to avoid cache flush (to be confirmed)
+        // extracting data from 'params' to avoid cache flush (to be confirmed)
         const ColorAppearanceParams::TcMode curveMode = params->colorappearance.curveMode;
         const bool hasColCurve1 = bool (customColCurve1);
         const bool t1L = hasColCurve1 && curveMode == ColorAppearanceParams::TcMode::LIGHT;
@@ -1668,7 +1668,7 @@ void ImProcFunctions::ciecam_02float (CieImage* ncie, float adap, int pW, int pw
 
 
 
-//all this treatments reduce artifacts, but can lead to slighty different results
+//all this treatments reduce artifacts, but can lead to slightly different results
 
                 if (params->defringe.enabled)
                     if (execsharp) {
@@ -2231,7 +2231,7 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
     const float shoulder = ((65536.0 / max (1.0f, exp_scale)) * (hlcomprthresh / 200.0)) + 0.1;
     const float hlrange = 65536.0 - shoulder;
     const bool isProPhoto = (params->icm.workingProfile == "ProPhoto");
-    // extracting datas from 'params' to avoid cache flush (to be confirmed)
+    // extracting data from 'params' to avoid cache flush (to be confirmed)
     ToneCurveMode curveMode = params->toneCurve.curveMode;
     ToneCurveMode curveMode2 = params->toneCurve.curveMode2;
     bool highlight = params->toneCurve.hrenabled;//Get the value if "highlight reconstruction" is activated

--- a/rtengine/ipretinex.cc
+++ b/rtengine/ipretinex.cc
@@ -656,7 +656,7 @@ void RawImageSource::MSR(float** luminance, float** originalLuminance, float **e
             float cdfactor = 32768.f / delta;
             maxCD = -9999999.f;
             minCD = 9999999.f;
-            // coeff for auto    "transmission" with 2 sigma #95% datas
+            // coeff for auto    "transmission" with 2 sigma #95% data
             float aza = 16300.f / (2.f * stddv);
             float azb = -aza * (mean - 2.f * stddv);
             float bza = 16300.f / (2.f * stddv);

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -3004,7 +3004,7 @@ void ImProcFunctions::ContAllL (float *koeLi[12], float *maxkoeLi, bool lipschit
             if(useChromAndHue) {
                 float modhue = varhue[ii][jj];
                 modchro = varchrom[ii * 2][jj * 2];
-                // hue chroma skin with initial lab datas
+                // hue chroma skin with initial lab data
                 scale = 1.f;
 
                 if(skinprot > 0.f) {
@@ -3216,7 +3216,7 @@ void ImProcFunctions::ContAllAB (LabImage * labco, int maxlvl, float ** varhue, 
                 float LL100 = labco->L[ii * 2][jj * 2] / 327.68f;
                 float modhue = varhue[ii][jj];
                 float modchro = varchrom[ii * 2][jj * 2];
-                // hue chroma skin with initial lab datas
+                // hue chroma skin with initial lab data
                 float scale = 1.f;
 
                 if(skinprot > 0.f) {
@@ -3252,7 +3252,7 @@ void ImProcFunctions::ContAllAB (LabImage * labco, int maxlvl, float ** varhue, 
             float modchro = varchrom[ii * 2][jj * 2];
 
             if(useSkinControl) {
-                // hue chroma skin with initial lab datas
+                // hue chroma skin with initial lab data
                 float LL100 = labco->L[ii * 2][jj * 2] / 327.68f;
                 float modhue = varhue[ii][jj];
 

--- a/rtgui/myflatcurve.cc
+++ b/rtgui/myflatcurve.cc
@@ -1621,7 +1621,7 @@ void MyFlatCurve::movePoint(bool moveX, bool moveY, bool pipetteDrag)
     }
 }
 
-// Set datas relative to cursor position
+// Set data relative to cursor position
 void MyFlatCurve::getCursorPosition(Gdk::EventType evType, bool isHint, int evX, int evY, Gdk::ModifierType modifierKey)
 {
     int tx, ty;

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -44,7 +44,7 @@
 
 // User's settings directory, including images' profiles if used
 Glib::ustring Options::rtdir;
-// User's cached datas' directory
+// User's cached data directory
 Glib::ustring Options::cacheBaseDir;
 
 Options options;

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -768,8 +768,8 @@ rtengine::RawImage* ToolPanelCoordinator::getFF()
     const rtengine::FramesMetaData *imd = ipc->getInitialImage()->getMetaData();
 
     if (imd) {
-        // int iso = imd->getISOSpeed();              temporarilly removed because unused
-        // double shutter = imd->getShutterSpeed();   temporarilly removed because unused
+        // int iso = imd->getISOSpeed();              temporarily removed because unused
+        // double shutter = imd->getShutterSpeed();   temporarily removed because unused
         double aperture = imd->getFNumber();
         double focallength = imd->getFocalLen();
         std::string maker ( imd->getMake()  );

--- a/win.cmake
+++ b/win.cmake
@@ -5,7 +5,7 @@
 #set(CMAKE_BUILD_TYPE Release CACHE STRING "Between: None Debug Release RelWithDebInfo MinSizeRel.")
 
 set(CMAKE_INSTALL_PREFIX ./${CMAKE_BUILD_TYPE} CACHE PATH "Libraries installation path")
-set(DATADIR . CACHE PATH "Datas installation path")
+set(DATADIR . CACHE PATH "Data installation path")
 set(BINDIR . CACHE PATH "Binaries installation path")
 set(LIBDIR . CACHE PATH "Libraries installation path")
 set(DOCDIR ./doc CACHE PATH "Documentation installation path")


### PR DESCRIPTION
Found via `codespell -q 3 -I ../rawtherapy-whitelist.txt -S ./rtdata/languages -L hist,fo,reall,bloc,alph`