### PR TITLE
Film Negative - Fix History view of values

### DIFF
--- a/rtgui/filmnegative.cc
+++ b/rtgui/filmnegative.cc
@@ -269,7 +269,7 @@ bool FilmNegative::button1Pressed(int modifierKey)
                     listener->panelChanged(
                         evFilmNegativeExponents,
                         Glib::ustring::compose(
-                            "Ref=%1 ; R=%2 ; B=%3",
+                            "Ref=%1\nR=%2\nB=%3",
                             greenExp->getValue(),
                             redRatio->getValue(),
                             blueRatio->getValue()


### PR DESCRIPTION
Setting values with the white - black button, the History shows a different format of the values.
![grafik](https://user-images.githubusercontent.com/13800920/61473681-2fd9e900-a987-11e9-938b-4d190192ed80.png)

This fix make look it equal to the standard view.
![grafik](https://user-images.githubusercontent.com/13800920/61473730-46804000-a987-11e9-877d-7e7e1844625b.png)
