### PR TITLE
dcraw.cc: replace memcpy with memmove

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -4216,8 +4216,8 @@ void CLASS foveon_interpolate()
 	  foveon_avg (image[row*width]+c, dscr[1], cfilt) * 3
 	  - ddft[0][c][0] ) / 4 - ddft[0][c][1];
   }
-  memcpy (black, black+8, sizeof *black*8);
-  memcpy (black+height-11, black+height-22, 11*sizeof *black);
+  memmove (black, black+8, sizeof *black*8);
+  memmove (black+height-11, black+height-22, 11*sizeof *black);
   memcpy (last, black, sizeof last);
 
   for (row=1; row < height-1; row++) {


### PR DESCRIPTION
Memcpy does not support overlapping. It can cause problems in specific situations.
You can find some details here: https://stackoverflow.com/questions/25629736/memcpy-of-overlapping-buffers