### PR TITLE
Smooth scrolling improvements

### DIFF
--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -51,7 +51,7 @@ CropWindow::CropWindow (ImageArea* parent, bool isLowUpdatePriority_, bool isDet
       backColor(options.bgcolor), decorated(true), isFlawnOver(false), titleHeight(30), sideBorderWidth(3), lowerBorderWidth(3),
       upperBorderWidth(1), sepWidth(2), xpos(30), ypos(30), width(0), height(0), imgAreaX(0), imgAreaY(0), imgAreaW(0), imgAreaH(0),
       imgX(-1), imgY(-1), imgW(1), imgH(1), iarea(parent), cropZoom(0), zoomVersion(0), exposeVersion(0), cropgl(nullptr),
-      pmlistener(nullptr), pmhlistener(nullptr), observedCropWin(nullptr),
+      pmlistener(nullptr), pmhlistener(nullptr), scrollAccum(0.0), observedCropWin(nullptr),
       crop_custom_ratio(0.f)
 {
     initZoomSteps();
@@ -295,11 +295,16 @@ void CropWindow::scroll (int state, GdkScrollDirection direction, int x, int y, 
     } else {
         delta = deltaY;
     }
-    if (delta == 0.0 && direction == GDK_SCROLL_SMOOTH) {
-        // sometimes this case happens. To avoid zooming into the wrong direction in this case, we just do nothing
-        return;
+
+    if (direction == GDK_SCROLL_SMOOTH) {
+        scrollAccum += delta;
+        //Only change zoom level if we've accumulated +/- 1.0 of deltas.  This conditional handles the previous delta=0.0 case
+        if (abs(scrollAccum) < 1.0) {
+            return;
+        }
     }
-    bool isUp = direction == GDK_SCROLL_UP || (direction == GDK_SCROLL_SMOOTH && delta < 0.0);
+    bool isUp = direction == GDK_SCROLL_UP || (direction == GDK_SCROLL_SMOOTH && scrollAccum < 0.0);
+    scrollAccum = 0.0;
     if ((state & GDK_CONTROL_MASK) && onArea(ColorPicker, x, y)) {
         // resizing a color picker
         if (isUp) {

--- a/rtgui/cropwindow.h
+++ b/rtgui/cropwindow.h
@@ -102,6 +102,7 @@ class CropWindow : public LWButtonListener, public CropDisplayHandler, public Ed
     PointerMotionListener* pmlistener;
     PointerMotionListener* pmhlistener;
     std::list<CropWindowListener*> listeners;
+    double scrollAccum;
 
     CropWindow* observedCropWin;  // Pointer to the currently active detail CropWindow
 

--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -971,9 +971,8 @@ bool MyScrolledWindow::on_scroll_event (GdkEventScroll* event)
                 scroll->set_value(value2);
             }
         } else if (event->direction == GDK_SCROLL_SMOOTH) {
-            if (abs(event->delta_y) > 0.1) {
-                value2 = rtengine::LIM<double>(value + (event->delta_y > 0 ? step : -step), lowerBound, upperBound);
-            }
+            value2 = rtengine::LIM<double>(value + event->delta_y * step, lowerBound, upperBound);
+
             if (value2 != value) {
                 scroll->set_value(value2);
             }

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -79,10 +79,19 @@ void ThumbBrowserBase::scroll (int direction, double deltaX, double deltaY)
         delta = deltaY;
     }
     if (direction == GDK_SCROLL_SMOOTH && delta == 0.0) {
-        // sometimes this case happens. To avoid scrolling the wrong direction in this case, we just do nothing    
+        // sometimes this case happens. To avoid scrolling the wrong direction in this case, we just do nothing
+        // This is probably no longer necessary now that coef is no longer quantized to +/-1.0 but why waste CPU cycles?
         return;
     }
-    double coef = direction == GDK_SCROLL_DOWN || (direction == GDK_SCROLL_SMOOTH && delta > 0.0) ? +1.0 : -1.0;
+    //GDK_SCROLL_SMOOTH can come in as many events with small deltas, don't quantize these to +/-1.0 so trackpads work well
+    double coef;
+    if(direction == GDK_SCROLL_SMOOTH) {
+        coef = delta;
+    } else if (direction == GDK_SCROLL_DOWN) {
+        coef = +1.0;
+    } else {
+        coef = -1.0;
+    }
 
     // GUI already acquired when here
     if (direction == GDK_SCROLL_UP || direction == GDK_SCROLL_DOWN || direction == GDK_SCROLL_SMOOTH) {


### PR DESCRIPTION
The thumbnail browser (thumbbrowser.cc), right-side panels (guiutils.cc), and editor zooming (cropwindow.cc) all had discretized scroll behaviors that quantized GDK_SMOOTH_SCROLL events up to +/- 1.0, greatly amplifying the response to some smooth scrolling events (most notably touchpad scroll gestures)

This patchset:
Allows the thumb browser and right-side panels to scroll more smoothly, proportionally to the scroll event delta
Accumulates smooth scroll deltas when zooming the editor to prevent high-frequency small-delta events from rapidly traversing between minimum and maximum zoom

Smooth scrolling without delta accumulation in the zoom window would be an ideal goal but would also require a major rewrite of most of the cropwindow.cc zooming mechanisms in order to not use discretized zoom steps.

This fixes the most egregious issues raised in issue #5426 - implementing the requested swipe right/left in editor to move to prev/next photo will require additional work, and there are GUI design considerations to be made since this might break behavior for some existing users who rely on left/right smooth scrolling being treated identically to up/down by the zoom scrolling code.