### PR TITLE
Soft Light: speedup and reduce memory usage

### DIFF
--- a/rtengine/ipsoftlight.cc
+++ b/rtengine/ipsoftlight.cc
@@ -22,8 +22,6 @@
 #include "improcfun.h"
 
 #include "procparams.h"
-#define BENCHMARK
-#include "StopWatch.h"
 
 namespace {
 
@@ -60,7 +58,6 @@ void rtengine::ImProcFunctions::softLight(LabImage *lab)
     if (!params->softlight.enabled || !params->softlight.strength) {
         return;
     }
-    BENCHFUN
 
     const TMatrix wprof = ICCStore::getInstance()->workingSpaceMatrix(params->icm.workingProfile);
     const float wp[3][3] = {

--- a/rtengine/ipsoftlight.cc
+++ b/rtengine/ipsoftlight.cc
@@ -3,6 +3,7 @@
  *  This file is part of RawTherapee.
  *
  *  Copyright 2018 Alberto Griggio <alberto.griggio@gmail.com>
+  * Optimized 2019 Ingo Weyrich <heckflosse67@gmx.de>
  *
  *  RawTherapee is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,14 +19,10 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 #include "improcfun.h"
-
 #include "procparams.h"
-
+#define BENCHMARK
+#include "StopWatch.h"
 namespace rtengine {
 
 namespace {
@@ -33,17 +30,28 @@ namespace {
 inline float sl(float blend, float x)
 {
     if (!OOG(x)) {
-        const float orig = 1.f - blend;
         float v = Color::gamma_srgb(x) / MAXVALF;
-        // Pegtop's formula from
+        // using Pegtop's formula from
         // https://en.wikipedia.org/wiki/Blend_modes#Soft_Light
-        float v2 = v * v;
-        float v22 = v2 * 2.f;
-        v = v2 + v22 - v22 * v;
-        x = blend * Color::igamma_srgb(v * MAXVALF) + orig * x;
+        // const float orig = 1.f - blend;
+        // float v2 = v * v;
+        // float v22 = v2 * 2.f;
+        // v = v2 + v22 - v22 * v;
+        // return blend * Color::igamma_srgb(v * MAXVALF) + orig * x;
+
+        // using optimized formula (heckflosse67@gmx.de)
+        return intp(blend, Color::igamma_srgb(v * v * (3.f - 2.f * v) * MAXVALF), x);
     }
     return x;
 }
+
+#ifdef __SSE2__
+inline vfloat sl(vfloat blend, vfloat x)
+{
+    const vfloat v = Color::gammatab_srgb[x] / F2V(MAXVALF);
+    return vself(vmaskf_gt(x, F2V(MAXVALF)), x, vself(vmaskf_lt(x, ZEROV), x, vintpf(blend, Color::igammatab_srgb[v * v * (F2V(3.f) - (v + v)) * MAXVALF], x)));
+}
+#endif
 
 } // namespace
 
@@ -53,24 +61,81 @@ void ImProcFunctions::softLight(LabImage *lab)
     if (!params->softlight.enabled || !params->softlight.strength) {
         return;
     }
+    BENCHFUN
 
-    Imagefloat working(lab->W, lab->H);
-    lab2rgb(*lab, working, params->icm.workingProfile);
+    TMatrix wprof = ICCStore::getInstance()->workingSpaceMatrix(params->icm.workingProfile);
+    const float wp[3][3] = {
+        {static_cast<float> (wprof[0][0]), static_cast<float> (wprof[0][1]), static_cast<float> (wprof[0][2])},
+        {static_cast<float> (wprof[1][0]), static_cast<float> (wprof[1][1]), static_cast<float> (wprof[1][2])},
+        {static_cast<float> (wprof[2][0]), static_cast<float> (wprof[2][1]), static_cast<float> (wprof[2][2])}
+    };
 
-    const float blend = params->softlight.strength / 100.f;
+    TMatrix wiprof = ICCStore::getInstance()->workingSpaceInverseMatrix(params->icm.workingProfile);
+    const float wip[3][3] = {
+        {static_cast<float> (wiprof[0][0]), static_cast<float> (wiprof[0][1]), static_cast<float> (wiprof[0][2])},
+        {static_cast<float> (wiprof[1][0]), static_cast<float> (wiprof[1][1]), static_cast<float> (wiprof[1][2])},
+        {static_cast<float> (wiprof[2][0]), static_cast<float> (wiprof[2][1]), static_cast<float> (wiprof[2][2])}
+    };
 
-#ifdef _OPENMP
-    #pragma omp parallel for
-#endif
-    for (int y = 0; y < working.getHeight(); ++y) {
-        for (int x = 0; x < working.getWidth(); ++x) {
-            working.r(y, x) = sl(blend, working.r(y, x));
-            working.g(y, x) = sl(blend, working.g(y, x));
-            working.b(y, x) = sl(blend, working.b(y, x));
+#ifdef __SSE2__
+    vfloat wipv[3][3];
+
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            wipv[i][j] = F2V(wiprof[i][j]);
         }
     }
-    
-    rgb2lab(working, *lab, params->icm.workingProfile);
+
+    vfloat wpv[3][3];
+
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            wpv[i][j] = F2V(wprof[i][j]);
+        }
+    }
+#endif
+
+#ifdef _OPENMP
+    #pragma omp parallel
+#endif
+    {
+        const float blend = params->softlight.strength / 100.f;
+#ifdef __SSE2__
+        const vfloat blendv = F2V(blend);
+#endif
+#ifdef _OPENMP
+        #pragma omp for schedule(dynamic,16)
+#endif
+        for (int i = 0; i < lab->H; ++i) {
+            int j = 0;
+#ifdef __SSE2__
+            for (; j < lab->W - 3; j += 4) {
+                vfloat Xv, Yv, Zv;
+                vfloat Rv, Gv, Bv;
+                Color::Lab2XYZ(LVFU(lab->L[i][j]),LVFU (lab->a[i][j]),LVFU (lab->b[i][j]), Xv, Yv, Zv);
+                Color::xyz2rgb(Xv, Yv, Zv, Rv, Gv, Bv, wipv);
+                Rv = sl(blendv, Rv);
+                Gv = sl(blendv, Gv);
+                Bv = sl(blendv, Bv);
+                Color::rgbxyz(Rv, Gv, Bv, Xv, Yv, Zv, wpv);
+                for (int k = 0; k < 4; ++k) {
+                    Color::XYZ2Lab(Xv[k], Yv[k], Zv[k], lab->L[i][j + k], lab->a[i][j + k], lab->b[i][j+ k]);
+                }
+            }
+#endif
+            for (; j < lab->W; j++) {
+                float X, Y, Z;
+                float R, G, B;
+                Color::Lab2XYZ(lab->L[i][j], lab->a[i][j], lab->b[i][j], X, Y, Z);
+                Color::xyz2rgb(X, Y, Z, R, G, B, wip);
+                R = sl(blend, R);
+                G = sl(blend, G);
+                B = sl(blend, B);
+                Color::rgbxyz(R, G, B, X, Y, Z, wp);
+                Color::XYZ2Lab(X, Y, Z, lab->L[i][j], lab->a[i][j], lab->b[i][j]);
+            }
+        }
+    }
 }
 
 } // namespace rtengine


### PR DESCRIPTION
This speeds up and reduces memory usage of soft light tool.

Memory usage is reduced by 12 * width * height byte
Speedup is ~2x

```
12 MP file before: 240 ms, after 120 ms
50 MP file before: 970 ms, after 485 ms
```
