### PR TITLE
Add option to link against libtcmalloc.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ option(TRACE_MYRWMUTEX "Trace custom R/W Mutex (Debug builds only); redirecting 
 option(AUTO_GDK_FLUSH "Use gdk_flush on all gdk_thread_leave other than the GUI thread; set it ON if you experience X Server warning/errors" OFF)
 #option(TARGET32BIT "Build for 32-bit architecture when ON, otherwise 64-bit. Default is OFF" OFF)
 
+option(ENABLE_TCMALLOC "Use the tcmalloc library if available" OFF)
+set(TCMALLOC_LIB_DIR "" CACHE PATH "Custom path for the tcmalloc library")
+
 # Set installation directories:
 if(WIN32 OR APPLE)
     if(BUILD_BUNDLE)
@@ -563,6 +566,23 @@ int main()
     bool b = db->LoadDirectory(0);
     return 0;
 }" LENSFUN_HAS_LOAD_DIRECTORY)
+
+set(TCMALLOC_LIB_DIR)
+if(ENABLE_TCMALLOC)
+    if(TCMALLOC_LIB_DIR)
+        find_library(TCMALLOC_LIBRARIES tcmalloc PATHS ${TCMALLOC_LIB_DIR} NO_DEFAULT_PATH)
+    else()
+        find_library(TCMALLOC_LIBRARIES tcmalloc)
+    endif()
+    if(TCMALLOC_LIBRARIES)
+        message(STATUS "using tcmalloc library in ${TCMALLOC_LIBRARIES}")
+    else()
+        set(TCMALLOC_LIBRARIES "" CACHE INTERNAL "" FORCE)
+        message(STATUS "tcmalloc not found")
+    endif()
+else()
+    set(TCMALLOC_LIBRARIES "" CACHE INTERNAL "" FORCE)
+endif()
 
 
 add_subdirectory(rtexif)

--- a/rtgui/CMakeLists.txt
+++ b/rtgui/CMakeLists.txt
@@ -286,6 +286,7 @@ target_link_libraries(rth rtengine
     ${ZLIB_LIBRARIES}
     ${LENSFUN_LIBRARIES}
     ${RSVG_LIBRARIES}
+    ${TCMALLOC_LIBRARIES}
     )
 
 target_link_libraries(rth-cli rtengine
@@ -307,6 +308,7 @@ target_link_libraries(rth-cli rtengine
     ${ZLIB_LIBRARIES}
     ${LENSFUN_LIBRARIES}
     ${RSVG_LIBRARIES}
+    ${TCMALLOC_LIBRARIES}
     )
 
 # Install executables


### PR DESCRIPTION
Implementation done by Alberto Griggio (agriggio)
for his fork at https://bitbucket.org/agriggio/art

This should fix issues where glibc won't give
memory back to the OS.
Related issue: #4416