### PR TITLE
Some checkpoints in the startup of RT to measure bottlenecks

### DIFF
--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -40,7 +40,7 @@
 #include "extprog.h"
 #include "../rtengine/dynamicprofile.h"
 
-#include "../rtengine/MyTime.h"
+#include "../rtengine/mytime.h"
 
 #ifndef WIN32
 #include <glibmm/fileutils.h>

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -26,6 +26,8 @@
 #include "rtimage.h"
 #include "whitebalance.h"
 
+#include "../rtengine/MyTime.h"
+
 float fontScale = 1.f;
 Glib::RefPtr<Gtk::CssProvider> cssForced;
 Glib::RefPtr<Gtk::CssProvider> cssRT;
@@ -95,11 +97,19 @@ RTWindow::RTWindow ()
     , fpanel (nullptr)
 {
 
+    MyTime timer_start,timer_stop;
+    timer_start.set();
+
     if (options.is_new_version()) {
         RTImage::cleanup(true);
     }
     cacheMgr->init ();
     ProfilePanel::init (this);
+    
+printf("Done first steps - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
     // ------- loading theme files
 
@@ -223,6 +233,11 @@ RTWindow::RTWindow ()
             }
         }
     }
+    
+printf("Done loading theme - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
 #ifndef NDEBUG
     else if (!screen) {
@@ -322,6 +337,11 @@ RTWindow::RTWindow ()
         mainNB->set_name ("MainNotebook");
         mainNB->set_scrollable (true);
         mainNB->signal_switch_page().connect_notify ( sigc::mem_fun (*this, &RTWindow::on_mainNB_switch_page) );
+        
+printf("Done rest until init mainNB - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         // Editor panel
         fpanel =  new FilePanel () ;
@@ -348,6 +368,10 @@ RTWindow::RTWindow ()
         fpanelLabelGrid->show_all ();
         mainNB->append_page (*fpanel, *fpanelLabelGrid);
 
+printf("Done mainNB->append_page (*fpanel, *fpanelLabelGrid); - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         // Batch Queue panel
         bpanel = Gtk::manage ( new BatchQueuePanel (fpanel->fileCatalog) );
@@ -360,7 +384,11 @@ RTWindow::RTWindow ()
         }
 
         mainNB->append_page (*bpanel, *lbq);
-
+        
+printf("Done mainNB->append_page (*bpanel, *lbq); - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         if (isSingleTabMode()) {
             createSetmEditor();
@@ -370,6 +398,11 @@ RTWindow::RTWindow ()
 
         //Gtk::VBox* mainBox = Gtk::manage (new Gtk::VBox ());
         //mainBox->pack_start (*mainNB);
+        
+printf("Done mainNB->set_current_page (mainNB->page_num (*fpanel)); - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         // filling bottom box
         iFullscreen = new RTImage ("fullscreen-enter.png");
@@ -427,13 +460,39 @@ RTWindow::RTWindow ()
         }
 
         actionGrid->show_all();
+        
+printf("Done even more steps !simpleEditor - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         pldBridge = new PLDBridge (static_cast<rtengine::ProgressListener*> (this));
+        
+printf("Done pldBridge = new PLDBridge - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         add (*mainNB);
+        
+printf("Done add (*mainNB); - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
+        
         show_all ();
+        
+printf("Done show_all (); - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         bpanel->init (this);
+        
+printf("Done bpanel->init - ");
+timer_stop.set();
+printf("%f\n",(float)timer_stop.etime(timer_start) / 1000.0f);
+timer_start.set();
 
         if (!argv1.empty() && !remote) {
             Thumbnail* thm = cacheMgr->getEntry (argv1);
@@ -443,6 +502,7 @@ RTWindow::RTWindow ()
             }
         }
     }
+
 }
 
 RTWindow::~RTWindow()


### PR DESCRIPTION
**Please do not merge with `dev`.**

_(maybe I should have made a branch instead of a PR..? My git magic fails me...)_

This is only to get some input from others on their startup times for RT. Personally I am quite unhappy that I have to wait ~7 seconds before everything I see a screen with pictures (see #5055 as well). So I went and investigate a little bit where the bottlenecks are.

**Could others please show what their command line results are when starting up?**
Mine are as follows (MinGW64, MYS2 on Windows 10):

```
Roel@RPC MINGW64 ~/rtdev/build
$ ./release/rawtherapee
Done everything before loading options - 1.621000
Done loading options - 714.177979
Done gtk_init - 564.547974
Start making RTWindow
Done first steps - 1.848000
Done loading theme - 81.649002
Done rest until init mainNB - 3.842000
Done mainNB->append_page (*fpanel, *fpanelLabelGrid); - 934.763000
Done mainNB->append_page (*bpanel, *lbq); - 6.280000
Done mainNB->set_current_page (mainNB->page_num (*fpanel)); - 703.935974
Done even more steps !simpleEditor - 1.192000
Done pldBridge = new PLDBridge - 0.047000
Done add (*mainNB); - 124.635002
Done show_all (); - 4996.270020
Done bpanel->init - 0.662000
Done making RTWindow
```

Values are all in milliseconds.

First observations:
* Loading time is insensitive to the amount of images in the folder that opens.
* Turning on verbose mode doesn't change much
* Value of "Done loading options" can be reduced to ~130 ms when no flat-field or darkframe images have to be processed
