### PR TITLE
Add VERSION and SOVERSION to libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ set(PROC_TARGET_NUMBER 0 CACHE STRING "Selected target processor from the list a
 # Some Linux distros build with -O2 instead of -O3. We explicitly enable auto vectorization by using -ftree-vectorize
 set(RTENGINE_CXX_FLAGS "-ftree-vectorize" CACHE STRING "Special compilation flags for RTEngine")
 
+# Set VERSION and SOVERSION for rtengine library
+set(RTENGINE_VERSION "5.7.0")
+set(RTENGINE_SOVERSION "5")
+
+# Set VERSION and SOVERSION for rtexif library
+set(RTEXIF_VERSION "5.7.0")
+set(RTEXIF_SOVERSION "5")
+
 # Loads the ProcessorTargets list:
 include(ProcessorTargets.cmake)
 set(PROC_LABEL "undefined" CACHE STRING "Target processor label, unused if PROC_TARGET_NUMBER = 0 or 2")

--- a/rtengine/CMakeLists.txt
+++ b/rtengine/CMakeLists.txt
@@ -172,7 +172,12 @@ if(BUILD_SHARED_LIBS)
     install(TARGETS rtengine DESTINATION ${LIBDIR})
 endif()
 
-set_target_properties(rtengine PROPERTIES COMPILE_FLAGS "${RTENGINE_CXX_FLAGS}")
+set_target_properties(rtengine
+    PROPERTIES
+        COMPILE_FLAGS "${RTENGINE_CXX_FLAGS}"
+        VERSION "${RTENGINE_VERSION}"
+        SOVERSION "${RTENGINE_SOVERSION}"
+    )
 
 target_link_libraries(rtengine rtexif
     ${EXPAT_LIBRARIES}

--- a/rtexif/CMakeLists.txt
+++ b/rtexif/CMakeLists.txt
@@ -15,3 +15,9 @@ include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}")
 if(BUILD_SHARED_LIBS)
     install(TARGETS rtexif DESTINATION ${LIBDIR})
 endif()
+
+set_target_properties(rtexif
+    PROPERTIES
+        VERSION "${RTEXIF_VERSION}"
+        SOVERSION "${RTEXIF_SOVERSION}"
+    )


### PR DESCRIPTION
This will make `rtengine` and `rtexif` fully versioned.
I've set the starting VERSION to `5.7.0` and the starting SOVERSION to `5`.

Fixes #5402 