### PR TITLE
Update desktop file

### DIFF
--- a/rtdata/rawtherapee.desktop.in
+++ b/rtdata/rawtherapee.desktop.in
@@ -17,4 +17,5 @@ Terminal=false
 MimeType=image/jpeg;image/png;image/tiff;image/x-adobe-dng;image/x-canon-cr2;image/x-canon-crf;image/x-canon-crw;image/x-fuji-raf;image/x-hasselblad-3fr;image/x-hasselblad-fff;image/x-jpg;image/x-kodak-dcr;image/x-kodak-k25;image/x-kodak-kdc;image/x-leaf-mos;image/x-leica-rwl;image/x-mamiya-mef;image/x-minolta-mrw;image/x-nikon-nef;image/x-nikon-nrw;image/x-olympus-orf;image/x-panasonic-raw;image/x-panasonic-rw2;image/x-pentax-pef;image/x-pentax-raw;image/x-phaseone-iiq;image/x-raw;image/x-rwz;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arq;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-tif;
 Categories=Graphics;Photography;2DGraphics;RasterGraphics;GTK;
 Keywords=raw;photo;photography;develop;pp3;graphics;
+StartupNotify=true
 StartupWMClass=rawtherapee


### PR DESCRIPTION
 - Add `StartupNotify` entry

https://developer.gnome.org/gtkmm-tutorial/3.24/gtkmm-tutorial.html#sec-buildapp-trivial-app
https://hammered999.wordpress.com/2010/03/11/startup-notification-system-and-gtkmm/
> Have you noticed that when you launch an application from the application’s menu that the cursor becomes busy and a new entry in the windows list appears saying “starting <application name>”? (I am refering to Gnome but probably KDE/xfce/etc have equivalent visual indications). No? Maybe a picture will refresh your memory!
> So now that you noticed you’re probably asking yourself as a programmer: “How do I make my gtkmm application display that notification?”.
> The answer is that it merely depends on the desktop environment your application is launced in. If the DE supports startup notification then all you have to do is insert StartupNotify=true in your .desktop file. The other part depends on you(or the toolkit you’re using). **Luckily Gtk/Gtkmm handles this somewhat automatically. You don’t have to add extra code for the notification to appear.**

See also:
https://forum.unity.com/threads/add-startupnotify-true-to-desktop-file-for-unity.350573/