### PR TITLE
Fix linking against system klt

### DIFF
--- a/rtengine/CMakeLists.txt
+++ b/rtengine/CMakeLists.txt
@@ -12,6 +12,11 @@ include_directories(${EXTRA_INCDIR}
     ${LENSFUN_INCLUDE_DIRS}
     ${RSVG_INCLUDE_DIRS}
 )
+if(NOT WITH_SYSTEM_KLT)
+    include_directories("${CMAKE_SOURCE_DIR}/rtengine/klt")
+else()
+    include_directories(${KLT_INCLUDE_DIRS})
+endif()
 
 link_directories("${PROJECT_SOURCE_DIR}/rtexif"
     ${EXPAT_LIBRARY_DIRS}
@@ -184,6 +189,7 @@ target_link_libraries(rtengine rtexif
     ${ZLIB_LIBRARIES}
     ${LENSFUN_LIBRARIES}
     ${RSVG_LIBRARIES}
+    ${KLT_LIBRARIES}
 )
 
 install(FILES ${CAMCONSTSFILE} DESTINATION "${DATADIR}" PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)

--- a/rtengine/calc_distort.cc
+++ b/rtengine/calc_distort.cc
@@ -5,8 +5,8 @@ locations (before and after tracking) to text files and to PPM files,
 and prints the features to the screen.
 **********************************************************************/
 
-#include "klt/pnmio.h"
-#include "klt/klt.h"
+#include <pnmio.h>
+#include <klt.h>
 #include <cmath>
 #include <cstring>
 


### PR DESCRIPTION
This should fix #5525 and also assures that system KLT sources are used when the relevant option is specified.

I'm very unfamiliar with c++/cmake library linking, so please review this PR carefully... I did test locally building with and without system KLT and everything works, but...