### PR TITLE
Make `LFDatabase::findModifier()` non-static

### DIFF
--- a/rtengine/iptransform.cc
+++ b/rtengine/iptransform.cc
@@ -415,7 +415,7 @@ void ImProcFunctions::transform (Imagefloat* original, Imagefloat* transformed, 
     std::unique_ptr<const LensCorrection> pLCPMap;
 
     if (needsLensfun()) {
-        pLCPMap = LFDatabase::findModifier(params->lensProf, metadata, oW, oH, params->coarse, rawRotationDeg);
+        pLCPMap = LFDatabase::getInstance()->findModifier(params->lensProf, metadata, oW, oH, params->coarse, rawRotationDeg);
     } else if (needsLCP()) { // don't check focal length to allow distortion correction for lenses without chip
         const std::shared_ptr<LCPProfile> pLCPProf = LCPStore::getInstance()->getProfile (params->lensProf.lcpFile);
 

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -1385,7 +1385,7 @@ void RawImageSource::preprocess  (const RAWParams &raw, const LensProfParams &le
     if (!hasFlatField && lensProf.useVign && lensProf.lcMode != LensProfParams::LcMode::NONE) {
         std::unique_ptr<LensCorrection> pmap;
         if (lensProf.useLensfun()) {
-            pmap = LFDatabase::findModifier(lensProf, idata, W, H, coarse, -1);
+            pmap = LFDatabase::getInstance()->findModifier(lensProf, idata, W, H, coarse, -1);
         } else {
             const std::shared_ptr<LCPProfile> pLCPProf = LCPStore::getInstance()->getProfile(lensProf.lcpFile);
 

--- a/rtengine/rtlensfun.h
+++ b/rtengine/rtlensfun.h
@@ -124,7 +124,13 @@ public:
     LFCamera findCamera(const Glib::ustring &make, const Glib::ustring &model) const;
     LFLens findLens(const LFCamera &camera, const Glib::ustring &name) const;
 
-    static std::unique_ptr<LFModifier> findModifier(const procparams::LensProfParams &lensProf, const FramesMetaData *idata, int width, int height, const procparams::CoarseTransformParams &coarse, int rawRotationDeg);
+    std::unique_ptr<LFModifier> findModifier(
+        const procparams::LensProfParams &lensProf,
+        const FramesMetaData *idata,
+        int width, int height,
+        const procparams::CoarseTransformParams &coarse,
+        int rawRotationDeg
+    ) const;
 
 private:
     std::unique_ptr<LFModifier> getModifier(const LFCamera &camera, const LFLens &lens,
@@ -136,7 +142,7 @@ private:
     mutable MyMutex lfDBMutex;
     static LFDatabase instance_;
     lfDatabase *data_;
-    static std::set<std::string> notFound;
+    mutable std::set<std::string> notFound;
 };
 
 } // namespace rtengine

--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -761,7 +761,7 @@ bool LensProfilePanel::checkLensfunCanCorrect(bool automatch)
 
     rtengine::procparams::ProcParams lpp;
     write(&lpp);
-    const std::unique_ptr<LFModifier> mod(LFDatabase::findModifier(lpp.lensProf, metadata, 100, 100, lpp.coarse, -1));
+    const std::unique_ptr<LFModifier> mod(LFDatabase::getInstance()->findModifier(lpp.lensProf, metadata, 100, 100, lpp.coarse, -1));
     return static_cast<bool>(mod);
 }
 


### PR DESCRIPTION
Hi,

This is a follow-up to @heckflosse's lensfun optimizations.

Basic concept: a singleton should have a single static function (often called `getInstance()`), other functionality should be provided by the instance. This is especially true for a static member function that uses the instance under the hood.

Best,
Flössie