### PR TITLE
Ci macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run a one-line script
+      run: echo Hello, world!
+    - name: Run a multi-line script
+      run: |
+        echo Add other actions to build,
+        echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: test getting the git branch of the triggering ref 
       run: echo ${GITHUB_REF##*/}
     - name: Install dependencies
-      run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun wget llvm cmake expat pkgconfig libomp
+      run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,11 @@ jobs:
         make --jobs 8
         make install
         sudo make macosx_bundle
-        ARTIFACT=$(ls | grep .dmg)
-        echo "===== Writing ${ARTIFACT} to the ARTIFACT environment variable for use in upload-artifact step ====="
-        echo "::set-env name=ARTIFACT::${ARTIFACT}"
+        ARTIFACT=$(ls | grep RawTherapee*.zip)
+        echo "=== artifact: ${ARTIFACT}"
+        echo "::set-env name=ARTIFACT_PATH::${GITHUB_WORKSPACE}/build/${ARTIFACT}"
+        echo "::set-env name=ARTIFACT_FILE::${ARTIFACT}"
     - uses: actions/upload-artifact@v1
       with:
-        name: ${{env.ARTIFACT}}
-        path: build/${{env.ARTIFACT}}
+        name: ${{env.ARTIFACT_FILE}}
+        path: ${{env.ARTIFACT_PATH}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         sudo make macosx_bundle
         ARTIFACT=(RawTherapee*.zip)
         echo "=== artifact: ${ARTIFACT}"
+        # defining environment variables for next step as per https://github.com/actions/starter-workflows/issues/68
         echo "::set-env name=ARTIFACT_PATH::${GITHUB_WORKSPACE}/build/${ARTIFACT}"
         echo "::set-env name=ARTIFACT_FILE::${ARTIFACT}"
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         CMAKE_CXX_STANDARD: 11
       run: |
         cmake \
-          -DCMAKE_BUILD_TYPE="release"  \
+          -DCMAKE_BUILD_TYPE="release" \
           -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
           -DWITH_LTO="OFF" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: test getting the git branch of the triggering ref 
-      run: echo ${GITHUB_REF##*/}
     - name: Install dependencies
       run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
     - name: cmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Mac OS build
 
 on:
   - push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
+          -DPROC_LABEL="generic processor" \
           -DWITH_LTO="OFF" \
           -DLENSFUNDBDIR="./share/lensfun" \
           -DLDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
-    - name: create and move to build directory
-      run: mkdir build && cd build
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11
@@ -21,6 +19,7 @@ jobs:
         RAW_THERAPEE_MAJOR: '5'
         RAW_THERAPEE_MINOR: '7'
       run: |
+        mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
-on: [push]
+on:
+  - push
 
 jobs:
   build:
@@ -9,9 +10,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Run a one-line script
-      run: echo Hello, world!
-    - name: Run a multi-line script
-      run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+    - name: Install dependencies
+      run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun wget llvm cmake expat pkgconfig libomp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib -L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib" \
           -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${REF}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
+      run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp shared-mime-info
     - name: patch libiconv
       run: |
         mkdir libiconv && cd libiconv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
+          -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
           -DWITH_LTO="OFF" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,5 @@ jobs:
           -DCMAKE_BUILD_TYPE="release"  \
           -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
-          -DBUILD_BUNDLE="ON" \
           -DWITH_LTO="OFF" \
           -DLENSFUNDBDIR="./share/lensfun"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,4 +40,5 @@ jobs:
           ..
         make --jobs 8
         make install
-        make macosx_bundle
+        sudo make macosx_bundle
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,14 +33,14 @@ jobs:
         PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
         RAW_THERAPEE_MAJOR: '5'
         RAW_THERAPEE_MINOR: '7'
-        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
+        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/gdk-pixbuf/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
         REF=${GITHUB_REF##*/}
         mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib" \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib -L/usr/local/opt/gdk-pixbuf/lib -L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib" \
           -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${REF}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,5 @@ jobs:
           -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
           -DWITH_LTO="OFF" \
-          -DLENSFUNDBDIR="./share/lensfun"
+          -DLENSFUNDBDIR="./share/lensfun" \
+          .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
         make --jobs 2
         make DESTDIR="${destDir}" install
         sudo mv opt/local /usr/local/opt/libiconv
-        cd -
     - name: print /usr/local/lib contents
       run: ls -al /usr/local/lib
     - name: cmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
+    - name: create and move to build directory
+      run: mkdir build && cd build
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11
@@ -25,4 +27,4 @@ jobs:
           -DLENSFUNDBDIR="./share/lensfun" \
           -DLDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
           -DCXXFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include" \
-          .
+          ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11
+        PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
       run: |
         cmake \
           -DCMAKE_BUILD_TYPE="release" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,20 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun llvm expat pkgconfig libomp
+    - name: patch libiconv
+      run: |
+        mkdir libiconv && cd libiconv
+        wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
+        tar xf libiconv-1.16.tar.gz
+        cd libiconv-1.16
+        patch -p1 < "${GITHUB_WORKSPACE}/tools/osx/libiconv_1.16_rt.patch"
+        mkdir build && cd build
+        destDir="$(pwd)"
+        ../configure --prefix=/opt/local --disable-static 'CFLAGS=-arch x86_64 -mmacosx-version-min=10.9' 'LDFLAGS=-arch x86_64 -mmacosx-version-min=10.9' CXXFLAGS="-arch x86_64 -mmacosx-version-min=10.9"
+        make --jobs 2
+        make DESTDIR="${destDir}" install
+        sudo cp opt/local/lib/libiconv.2.dylib /usr/lib/libiconv.2.dylib
+        cd -
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11
@@ -39,7 +53,7 @@ jobs:
           -DOpenMP_C_FLAGS="${C_FLAGS}" \
           -DOpenMP_CXX_FLAGS="${C_FLAGS}" \
           ..
-        make --jobs 8
+        make --jobs 2
         make install
         sudo make macosx_bundle
         ARTIFACT=$(ls | grep RawTherapee*.zip)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,12 @@ jobs:
           -DPROC_LABEL="generic processor" \
           -DWITH_LTO="OFF" \
           -DLENSFUNDBDIR="./share/lensfun" \
-          -DLDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
-          -DCXXFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include" \
+          -DOpenMP_C_FLAGS=-fopenmp=libomp \
+          -DOpenMP_CXX_FLAGS=-fopenmp=libomp \
+          -DOpenMP_C_LIB_NAMES="libomp" \
+          -DOpenMP_CXX_LIB_NAMES="libomp" \
+          -DOpenMP_libomp_LIBRARY="/usr/local/lib/libomp.dylib" \
+          -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" \
+          -DOpenMP_CXX_LIB_NAMES="libomp" \
+          -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" \
           ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,6 @@ jobs:
         make --jobs
         make DESTDIR="${destDir}" install
         sudo mv opt/local /usr/local/opt/libiconv
-    - name: print /usr/local/lib contents
-      run: ls -al /usr/local/lib
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: test getting the git branch of the triggering ref 
+      run: echo ${GITHUB_REF##*/}
     - name: Install dependencies
       run: brew install gtk+3 gtkmm3 gtk-mac-integration adwaita-icon-theme libsigc++ little-cms2 libiptcdata fftw lensfun wget llvm cmake expat pkgconfig libomp
+    - name: cmake
+      env:
+        CMAKE_CXX_STANDARD: 11
+      run: |
+        cmake \
+          -DCMAKE_BUILD_TYPE="release"  \
+          -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
+          -DPROC_TARGET_NUMBER="2" \
+          -DBUILD_BUNDLE="ON" \
+          -DWITH_LTO="OFF" \
+          -DLENSFUNDBDIR="./share/lensfun"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
           -DOpenMP_libomp_LIBRARY="/usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib" \
           -DOpenMP_C_FLAGS="${C_FLAGS}" \
           -DOpenMP_CXX_FLAGS="${C_FLAGS}" \
+          -DCMAKE_AR="/usr/local/opt/llvm/bin/llvm-ar" \
+          -DCMAKE_RANLIB="/usr/local/opt/llvm/bin/llvm-ranlib" \
           ..
         make --jobs 2
         make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         mkdir build && cd build
         destDir="$(pwd)"
         ../configure --prefix=/opt/local --disable-static 'CFLAGS=-arch x86_64 -mmacosx-version-min=10.9' 'LDFLAGS=-arch x86_64 -mmacosx-version-min=10.9' CXXFLAGS="-arch x86_64 -mmacosx-version-min=10.9"
-        make --jobs 2
+        make --jobs
         make DESTDIR="${destDir}" install
         sudo mv opt/local /usr/local/opt/libiconv
     - name: print /usr/local/lib contents
@@ -57,7 +57,7 @@ jobs:
           -DCMAKE_AR="/usr/local/opt/llvm/bin/llvm-ar" \
           -DCMAKE_RANLIB="/usr/local/opt/llvm/bin/llvm-ranlib" \
           ..
-        make --jobs 2
+        make --jobs
         make install
         sudo make macosx_bundle
         ARTIFACT=(RawTherapee*.zip)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,13 @@ jobs:
       env:
         CMAKE_CXX_STANDARD: 11
         PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
+        RAW_THERAPEE_MAJOR: '5'
+        RAW_THERAPEE_MINOR: '7'
       run: |
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-          -DCACHE_NAME_SUFFIX="5-${GITHUB_REF##*/}" \
+          -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \
           -DWITH_LTO="OFF" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         make --jobs 2
         make install
         sudo make macosx_bundle
-        ARTIFACT=$(ls | grep RawTherapee*.zip)
+        ARTIFACT=(RawTherapee*.zip)
         echo "=== artifact: ${ARTIFACT}"
         echo "::set-env name=ARTIFACT_PATH::${GITHUB_WORKSPACE}/build/${ARTIFACT}"
         echo "::set-env name=ARTIFACT_FILE::${ARTIFACT}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,13 @@ jobs:
         PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
         RAW_THERAPEE_MAJOR: '5'
         RAW_THERAPEE_MINOR: '7'
+        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
         mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
           -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${GITHUB_REF##*/}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \
@@ -32,10 +34,9 @@ jobs:
           -DOpenMP_CXX_FLAGS=-fopenmp=libomp \
           -DOpenMP_C_LIB_NAMES="libomp" \
           -DOpenMP_CXX_LIB_NAMES="libomp" \
-          -DOpenMP_libomp_LIBRARY="/usr/local/lib/libomp.dylib" \
-          -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" \
-          -DOpenMP_CXX_LIB_NAMES="libomp" \
-          -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" \
+          -DOpenMP_libomp_LIBRARY="/usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib" \
+          -DOpenMP_C_FLAGS="${C_FLAGS}" \
+          -DOpenMP_CXX_FLAGS="${C_FLAGS}" \
           ..
         make --jobs 8
         make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         ../configure --prefix=/opt/local --disable-static 'CFLAGS=-arch x86_64 -mmacosx-version-min=10.9' 'LDFLAGS=-arch x86_64 -mmacosx-version-min=10.9' CXXFLAGS="-arch x86_64 -mmacosx-version-min=10.9"
         make --jobs 2
         make DESTDIR="${destDir}" install
-        sudo cp opt/local/lib/libiconv.2.dylib /usr/lib/libiconv.2.dylib
+        sudo mv opt/local /usr/local/opt/libiconv
         cd -
     - name: cmake
       env:
@@ -32,14 +32,14 @@ jobs:
         PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
         RAW_THERAPEE_MAJOR: '5'
         RAW_THERAPEE_MINOR: '7'
-        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
+        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
         REF=${GITHUB_REF##*/}
         mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
           -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${REF}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Mac OS build
 
 on:
-  - push
+  push
 
 jobs:
   build:
@@ -42,4 +42,11 @@ jobs:
         make --jobs 8
         make install
         sudo make macosx_bundle
-
+        
+        ARTIFACT=$(ls | grep .dmg)
+        echo "Writing -${ARTIFACT} to the ARTIFACT environment variable for use in upload-artifact step"
+        echo "::set-env name=ARTIFACT::${ARTIFACT}"
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ${{env.ARTIFACT}}
+        path: build/${{env.ARTIFACT}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         PKG_CONFIG_PATH: /usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig
         RAW_THERAPEE_MAJOR: '5'
         RAW_THERAPEE_MINOR: '7'
-        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
+        C_FLAGS: -Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
         REF=${GITHUB_REF##*/}
         mkdir build && cd build
@@ -50,7 +50,7 @@ jobs:
           -DOpenMP_CXX_FLAGS=-fopenmp=libomp \
           -DOpenMP_C_LIB_NAMES="libomp" \
           -DOpenMP_CXX_LIB_NAMES="libomp" \
-          -DOpenMP_libomp_LIBRARY="/usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib" \
+          -DOpenMP_libomp_LIBRARY="/usr/local/lib/libomp.dylib" \
           -DOpenMP_C_FLAGS="${C_FLAGS}" \
           -DOpenMP_CXX_FLAGS="${C_FLAGS}" \
           -DCMAKE_AR="/usr/local/opt/llvm/bin/llvm-ar" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,6 @@ jobs:
           -DOpenMP_CXX_LIB_NAMES="libomp" \
           -DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include" \
           ..
+        make --jobs 8
+        make install
+        make macosx_bundle

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,8 @@ jobs:
         make --jobs 8
         make install
         sudo make macosx_bundle
-        
         ARTIFACT=$(ls | grep .dmg)
-        echo "Writing -${ARTIFACT} to the ARTIFACT environment variable for use in upload-artifact step"
+        echo "===== Writing ${ARTIFACT} to the ARTIFACT environment variable for use in upload-artifact step ====="
         echo "::set-env name=ARTIFACT::${ARTIFACT}"
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         RAW_THERAPEE_MINOR: '7'
         C_FLAGS: -Xpreprocessor -fopenmp /usr/local/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/gdk-pixbuf/include -I/usr/local/opt/libiconv/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
+        # GITHUB_REF is the ref that triggered the build, like refs/heads/new-feature - the next line parses that to REF: the branch name only (new-feature)
         REF=${GITHUB_REF##*/}
         mkdir build && cd build
         cmake \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
         make DESTDIR="${destDir}" install
         sudo mv opt/local /usr/local/opt/libiconv
         cd -
+    - name: print /usr/local/lib contents
+      run: ls -al /usr/local/lib
     - name: cmake
       env:
         CMAKE_CXX_STANDARD: 11
@@ -39,7 +41,7 @@ jobs:
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
+          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/lib -L/usr/local/opt/libiconv/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
           -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${REF}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,6 @@ jobs:
           -DPROC_TARGET_NUMBER="2" \
           -DWITH_LTO="OFF" \
           -DLENSFUNDBDIR="./share/lensfun" \
+          -DLDFLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
+          -DCXXFLAGS="-I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include" \
           .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,13 @@ jobs:
         RAW_THERAPEE_MINOR: '7'
         C_FLAGS: -Xpreprocessor -fopenmp /usr/local/Cellar/libomp/9.0.0/lib/libomp.dylib -I/usr/local/include -I/usr/local/opt/libxml2/include -I/usr/local/opt/expat/include -I/usr/local/opt/llvm/include
       run: |
+        REF=${GITHUB_REF##*/}
         mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE="release" \
           -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
           -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/libffi/lib -L/usr/local/lib -L/usr/local/opt/libffi/lib -L/usr/local/opt/libxml2/lib -L/usr/local/opt/expat/lib -L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib" \
-          -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${GITHUB_REF##*/}" \
+          -DCACHE_NAME_SUFFIX="${RAW_THERAPEE_MAJOR}.${RAW_THERAPEE_MINOR}-${REF}" \
           -DPROC_TARGET_NUMBER="2" \
           -DPROC_LABEL="generic processor" \
           -DWITH_LTO="OFF" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Mac OS build
+name: macOS build
 
 on:
   push

--- a/tools/osx/libiconv_1.16_rt.patch
+++ b/tools/osx/libiconv_1.16_rt.patch
@@ -1,0 +1,31 @@
+diff --git a/lib/iconv.c b/lib/iconv.c
+index b7a04f8..41c5896 100644
+--- a/lib/iconv.c
++++ b/lib/iconv.c
+@@ -610,5 +610,26 @@ strong_alias (libiconv_open, iconv_open)
+ strong_alias (libiconv, iconv)
+ strong_alias (libiconv_close, iconv_close)
+ #endif
++
++#undef iconv_open
++#undef iconv
++#undef iconv_close
++
++LIBICONV_DLL_EXPORTED iconv_t iconv_open (const char* tocode, const char* fromcode)
++{
++  return libiconv_open(tocode, fromcode);
++}
++
++LIBICONV_DLL_EXPORTED size_t iconv (iconv_t icd,
++                                    ICONV_CONST char * * inbuf, size_t *inbytesleft,
++                                    char * * outbuf, size_t *outbytesleft)
++{
++  return libiconv(icd, inbuf, inbytesleft, outbuf, outbytesleft);
++}
++
++LIBICONV_DLL_EXPORTED int iconv_close (iconv_t icd)
++{
++  return libiconv_close(icd);
++}
+
+ #endif

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -137,43 +137,43 @@ rm -r "${LIB}"/gdk-pixbuf-2.0
 "${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so,libprint*.so} > "${ETC}/gtk-3.0/gtk.immodules"
 sed -i "" -e "s|${PWD}/RawTherapee.app/Contents/|/Applications/RawTherapee.app/Contents/|" "${ETC}/gtk-3.0/gdk-pixbuf.loaders" "${ETC}/gtk-3.0/gtk.immodules"
 
-ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/glib-2.0/schemas
-"${GTK_PREFIX}/bin/glib-compile-schemas" "${RESOURCES}/share/glib-2.0/schemas"
+ditto {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
+"/usr/local/bin/glib-compile-schemas" "${RESOURCES}/share/glib-2.0/schemas"
 
 msg "Copying shared files from ${GTK_PREFIX}:"
-ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/mime
+ditto {"/usr/local","${RESOURCES}"}/share/mime
 # GTK3 themes
-ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/themes/Mac/gtk-3.0/gtk-keys.css
-ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css
+ditto {"/usr/local","${RESOURCES}"}/share/themes/Mac/gtk-3.0/gtk-keys.css
+ditto {"/usr/local","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css
 # Adwaita icons
 iconfolders=("16x16/actions" "16x16/devices" "16x16/mimetypes" "16x16/places" "16x16/status" "48x48/devices")
 for f in "${iconfolders[@]}"; do
-    ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/icons/Adwaita/"$f"
+    ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/"$f"
 done
-ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/icons/Adwaita/index.theme
-"${GTK_PREFIX}/bin/gtk-update-icon-cache-3.0" "${RESOURCES}/share/icons/Adwaita"
+ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/index.theme
+"/usr/local/bin/gtk-update-icon-cache" "${RESOURCES}/share/icons/Adwaita"
 
 # Copy libjpeg-turbo into the app bundle
-cp /opt/local/lib/libjpeg.62.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libjpeg.*.dylib "${RESOURCES}/../Frameworks"
 
-# Copy libexpat into the app bundle
-cp /opt/local/lib/libexpat.1.dylib "${RESOURCES}/../Frameworks"
+# Copy libexpat into the app bundle (which is keg-only)
+cp /usr/local/Cellar/expat/*/lib/libexpat.1.dylib "${RESOURCES}/../Frameworks"
 
 # Copy libz into the app bundle
-cp /opt/local/lib/libz.1.dylib "${RESOURCES}/../Frameworks"
+cp /usr/lib/libz.1.dylib "${RESOURCES}/../Frameworks"
 
 # Copy libtiff into the app bundle
-cp /opt/local/lib/libtiff.5.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libtiff.5.dylib "${RESOURCES}/../Frameworks"
 
 # Copy the Lensfun database into the app bundle
 mkdir -p "${RESOURCES}/share/lensfun"
-cp /opt/local/share/lensfun/version_2/* "${RESOURCES}/share/lensfun"
+cp /usr/local/share/lensfun/version_2/* "${RESOURCES}/share/lensfun"
 
 # Copy liblensfun to Frameworks
-cp /opt/local/lib/liblensfun.2.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/liblensfun.2.dylib "${RESOURCES}/../Frameworks"
 
 # Copy libomp to Frameworks
-cp /opt/local/lib/libomp.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libomp.dylib "${RESOURCES}/../Frameworks"
 
 # Install names
 find -E "${CONTENTS}" -type f -regex '.*/(rawtherapee-cli|rawtherapee|.*\.(dylib|so))' | while read -r x; do

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -117,7 +117,7 @@ msg "Copying dependencies from ${GTK_PREFIX}:"
 CheckLink "${EXECUTABLE}"
 
 msg "Copying library modules from ${GTK_PREFIX}:"
-ditto --arch "${arch}" {"/usr/local/Cellar/gdk-pixbuf/2*/lib","${LIB}"}/gdk-pixbuf-2.0
+ditto --arch "${arch}" {"/usr/local/opt/gdk-pixbuf/lib","${LIB}"}/gdk-pixbuf-2.0
 ditto --arch "${arch}" {"${GTK_PREFIX}/lib","${LIB}"}/gtk-3.0
 
 msg "Removing static libraries and cache files:"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -138,7 +138,8 @@ rm -r "${LIB}"/gdk-pixbuf-2.0
 "${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so,libprint*.so} > "${ETC}/gtk-3.0/gtk.immodules"
 sed -i "" -e "s|${PWD}/RawTherapee.app/Contents/|/Applications/RawTherapee.app/Contents/|" "${ETC}/gtk-3.0/gdk-pixbuf.loaders" "${ETC}/gtk-3.0/gtk.immodules"
 
-ditto {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
+mkdir -p ${RESOURCES}/share/glib-2.0
+cp -pRL {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
 "/usr/local/bin/glib-compile-schemas" "${RESOURCES}/share/glib-2.0/schemas"
 
 msg "Copying shared files from ${GTK_PREFIX}:"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -145,16 +145,15 @@ cp -pRL {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
 "/usr/local/bin/glib-compile-schemas" "${RESOURCES}/share/glib-2.0/schemas"
 
 msg "Copying shared files from ${GTK_PREFIX}:"
-set -x
-find /usr -name mime
 cp -pRL {"/usr/local","${RESOURCES}"}/share/mime
-set +x
+
 # GTK3 themes
 ditto {"/usr/local","${RESOURCES}"}/share/themes/Mac/gtk-3.0/gtk-keys.css
 ditto {"/usr/local","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css
 # Adwaita icons
 iconfolders=("16x16/actions" "16x16/devices" "16x16/mimetypes" "16x16/places" "16x16/status" "48x48/devices")
 for f in "${iconfolders[@]}"; do
+    mkdir -p ${RESOURCES}/share/icons/Adwaita/${f}
     cp -pRL {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/"$f"
 done
 ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/index.theme

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -112,7 +112,7 @@ install -d  "${RESOURCES}" \
 
 msg "Copying release files:"
 ditto "${CMAKE_BUILD_TYPE}/MacOS" "${MACOS}"
-ditto "${CMAKE_BUILD_TYPE}/Resources" "${RESOURCES}"
+ditto "Resources" "${RESOURCES}"
 
 msg "Copying dependencies from ${GTK_PREFIX}:"
 CheckLink "${EXECUTABLE}"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -117,7 +117,7 @@ msg "Copying dependencies from ${GTK_PREFIX}:"
 CheckLink "${EXECUTABLE}"
 
 msg "Copying library modules from ${GTK_PREFIX}:"
-ditto --arch "${arch}" {"${GTK_PREFIX}/lib","${LIB}"}/gdk-pixbuf-2.0
+ditto --arch "${arch}" {"/usr/local/Cellar/gdk-pixbuf/2*/lib","${LIB}"}/gdk-pixbuf-2.0
 ditto --arch "${arch}" {"${GTK_PREFIX}/lib","${LIB}"}/gtk-3.0
 
 msg "Removing static libraries and cache files:"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -99,6 +99,7 @@ MACOS="${CONTENTS}/MacOS"
 LIB="${CONTENTS}/Frameworks"
 ETC="${RESOURCES}/etc"
 EXECUTABLE="${MACOS}/rawtherapee"
+GDK_PREFIX="/usr/local/opt/gdk-pixbuf"
 
 msg "Removing old files:"
 rm -rf "${APP}" "${PROJECT_NAME}_*.dmg" "*zip"
@@ -117,7 +118,7 @@ msg "Copying dependencies from ${GTK_PREFIX}:"
 CheckLink "${EXECUTABLE}"
 
 msg "Copying library modules from ${GTK_PREFIX}:"
-ditto --arch "${arch}" {"/usr/local/opt/gdk-pixbuf/lib","${LIB}"}/gdk-pixbuf-2.0
+ditto --arch "${arch}" {"${GDK_PREFIX}/lib","${LIB}"}/gdk-pixbuf-2.0
 ditto --arch "${arch}" {"${GTK_PREFIX}/lib","${LIB}"}/gtk-3.0
 
 msg "Removing static libraries and cache files:"
@@ -132,8 +133,8 @@ mv "${LIB}"/gtk-3.0/3*/immodules/*.so "${LIB}"
 rm -r "${LIB}"/gtk-3.0
 rm -r "${LIB}"/gdk-pixbuf-2.0
 
-"${GTK_PREFIX}/bin/gdk-pixbuf-query-loaders" "${LIB}"/libpix*.so > "${ETC}/gtk-3.0/gdk-pixbuf.loaders"
-"${GTK_PREFIX}/bin/gtk-query-immodules-3.0"  "${LIB}"/{im*.so,libprint*.so}      > "${ETC}/gtk-3.0/gtk.immodules"
+"${GDK_PREFIX}/bin/gdk-pixbuf-query-loaders" "${LIB}"/libpix*.so > "${ETC}/gtk-3.0/gdk-pixbuf.loaders"
+"${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so,libprint*.so} > "${ETC}/gtk-3.0/gtk.immodules"
 sed -i "" -e "s|${PWD}/RawTherapee.app/Contents/|/Applications/RawTherapee.app/Contents/|" "${ETC}/gtk-3.0/gdk-pixbuf.loaders" "${ETC}/gtk-3.0/gtk.immodules"
 
 ditto {"${GTK_PREFIX}","${RESOURCES}"}/share/glib-2.0/schemas

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -130,12 +130,14 @@ install -d "${ETC}/gtk-3.0"
 # Make Frameworks folder flat
 mv "${LIB}"/gdk-pixbuf-2.0/2*/loaders/*.so "${LIB}"
 mv "${LIB}"/gtk-3.0/3*/immodules/*.so "${LIB}"
-mv "${LIB}"/gtk-3.0/3*/printbackends/*.so "${LIB}"
+# the print*.so lead to errors when running gtk-query-immodules-3.0, just seeing what the app does without, since they are not in immodules
+# and including them leads to errors and a completely empty gtk.immodules file
+# mv "${LIB}"/gtk-3.0/3*/printbackends/*.so "${LIB}"
 rm -r "${LIB}"/gtk-3.0
 rm -r "${LIB}"/gdk-pixbuf-2.0
 
 "${GDK_PREFIX}/bin/gdk-pixbuf-query-loaders" "${LIB}"/libpix*.so > "${ETC}/gtk-3.0/gdk-pixbuf.loaders"
-"${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so,libprint*.so} > "${ETC}/gtk-3.0/gtk.immodules"
+"${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so} > "${ETC}/gtk-3.0/gtk.immodules"
 sed -i "" -e "s|${PWD}/RawTherapee.app/Contents/|/Applications/RawTherapee.app/Contents/|" "${ETC}/gtk-3.0/gdk-pixbuf.loaders" "${ETC}/gtk-3.0/gtk.immodules"
 
 mkdir -p ${RESOURCES}/share/glib-2.0

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -154,7 +154,7 @@ ditto {"/usr/local","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css
 iconfolders=("16x16/actions" "16x16/devices" "16x16/mimetypes" "16x16/places" "16x16/status" "48x48/devices")
 for f in "${iconfolders[@]}"; do
     mkdir -p ${RESOURCES}/share/icons/Adwaita/${f}
-    cp -pRL {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/"$f"
+    cp /usr/local/share/icons/Adwaita/${f}/* "${RESOURCES}"/share/icons/Adwaita/${f}
 done
 ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/index.theme
 "/usr/local/bin/gtk-update-icon-cache" "${RESOURCES}/share/icons/Adwaita"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -146,8 +146,8 @@ cp -pRL {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
 
 msg "Copying shared files from ${GTK_PREFIX}:"
 set -x
-find /usr/local -name mime
-ditto {"/usr/local","${RESOURCES}"}/share/mime
+sudo find / -name mime
+cp -pRL {"/usr/local","${RESOURCES}"}/share/mime
 set +x
 # GTK3 themes
 ditto {"/usr/local","${RESOURCES}"}/share/themes/Mac/gtk-3.0/gtk-keys.css
@@ -155,7 +155,7 @@ ditto {"/usr/local","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css
 # Adwaita icons
 iconfolders=("16x16/actions" "16x16/devices" "16x16/mimetypes" "16x16/places" "16x16/status" "48x48/devices")
 for f in "${iconfolders[@]}"; do
-    ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/"$f"
+    cp -pRL {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/"$f"
 done
 ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/index.theme
 "/usr/local/bin/gtk-update-icon-cache" "${RESOURCES}/share/icons/Adwaita"

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -130,6 +130,7 @@ install -d "${ETC}/gtk-3.0"
 # Make Frameworks folder flat
 mv "${LIB}"/gdk-pixbuf-2.0/2*/loaders/*.so "${LIB}"
 mv "${LIB}"/gtk-3.0/3*/immodules/*.so "${LIB}"
+mv "${LIB}"/gtk-3.0/3*/printbackends/*.so "${LIB}"
 rm -r "${LIB}"/gtk-3.0
 rm -r "${LIB}"/gdk-pixbuf-2.0
 

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -136,8 +136,8 @@ mv "${LIB}"/gtk-3.0/3*/immodules/*.so "${LIB}"
 rm -r "${LIB}"/gtk-3.0
 rm -r "${LIB}"/gdk-pixbuf-2.0
 
-"${GDK_PREFIX}/bin/gdk-pixbuf-query-loaders" "${LIB}"/libpix*.so > "${ETC}/gtk-3.0/gdk-pixbuf.loaders"
-"${GTK_PREFIX}/bin/gtk-query-immodules-3.0" "${LIB}"/{im*.so} > "${ETC}/gtk-3.0/gtk.immodules"
+"${GDK_PREFIX}"/bin/gdk-pixbuf-query-loaders "${LIB}"/libpix*.so > "${ETC}"/gtk-3.0/gdk-pixbuf.loaders
+"${GTK_PREFIX}"/bin/gtk-query-immodules-3.0 "${LIB}"/im*.so > "${ETC}"/gtk-3.0/gtk.immodules
 sed -i "" -e "s|${PWD}/RawTherapee.app/Contents/|/Applications/RawTherapee.app/Contents/|" "${ETC}/gtk-3.0/gdk-pixbuf.loaders" "${ETC}/gtk-3.0/gtk.immodules"
 
 mkdir -p ${RESOURCES}/share/glib-2.0

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -143,7 +143,10 @@ cp -pRL {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
 "/usr/local/bin/glib-compile-schemas" "${RESOURCES}/share/glib-2.0/schemas"
 
 msg "Copying shared files from ${GTK_PREFIX}:"
+set -x
+find /usr/local -name mime
 ditto {"/usr/local","${RESOURCES}"}/share/mime
+set +x
 # GTK3 themes
 ditto {"/usr/local","${RESOURCES}"}/share/themes/Mac/gtk-3.0/gtk-keys.css
 ditto {"/usr/local","${RESOURCES}"}/share/themes/Default/gtk-3.0/gtk-keys.css

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -155,26 +155,26 @@ ditto {"/usr/local","${RESOURCES}"}/share/icons/Adwaita/index.theme
 "/usr/local/bin/gtk-update-icon-cache" "${RESOURCES}/share/icons/Adwaita"
 
 # Copy libjpeg-turbo into the app bundle
-cp /usr/local/lib/libjpeg.*.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libjpeg.*.dylib "${CONTENTS}/Frameworks"
 
 # Copy libexpat into the app bundle (which is keg-only)
-cp /usr/local/Cellar/expat/*/lib/libexpat.1.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/Cellar/expat/*/lib/libexpat.1.dylib "${CONTENTS}/Frameworks"
 
 # Copy libz into the app bundle
-cp /usr/lib/libz.1.dylib "${RESOURCES}/../Frameworks"
+cp /usr/lib/libz.1.dylib "${CONTENTS}/Frameworks"
 
 # Copy libtiff into the app bundle
-cp /usr/local/lib/libtiff.5.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libtiff.5.dylib "${CONTENTS}/Frameworks"
 
 # Copy the Lensfun database into the app bundle
 mkdir -p "${RESOURCES}/share/lensfun"
 cp /usr/local/share/lensfun/version_2/* "${RESOURCES}/share/lensfun"
 
 # Copy liblensfun to Frameworks
-cp /usr/local/lib/liblensfun.2.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/liblensfun.2.dylib "${CONTENTS}/Frameworks"
 
 # Copy libomp to Frameworks
-cp /usr/local/lib/libomp.dylib "${RESOURCES}/../Frameworks"
+cp /usr/local/lib/libomp.dylib "${CONTENTS}/Frameworks"
 
 # Install names
 find -E "${CONTENTS}" -type f -regex '.*/(rawtherapee-cli|rawtherapee|.*\.(dylib|so))' | while read -r x; do

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -146,7 +146,7 @@ cp -pRL {"/usr/local","${RESOURCES}"}/share/glib-2.0/schemas
 
 msg "Copying shared files from ${GTK_PREFIX}:"
 set -x
-sudo find / -name mime
+find /usr -name mime
 cp -pRL {"/usr/local","${RESOURCES}"}/share/mime
 set +x
 # GTK3 themes


### PR DESCRIPTION
For issue #5550 .
This is a first step to create CI for Mac OS. I strongly believe having CI in place and allowing all supporting operating systems feel like first citizens is important for the user base of an open source project. Now all beta mac users have to build themselves which we can also channel into improving this build for all to use.

Included for now is the build on Github Actions (free for open source). The result is that by navigating to Github Actions you are now able to download the zipped artifact. <del>The resulting DMG for now crashes however, probably due to the patch on `libiconv.2.dylib` not having been implemented yet. So, maybe you may still want to accept this PR on a branch instead, however,</del> it does not interfere with anything, so `dev` is safe.

For a list of things to do related to this PR, check #5550 

We can also think about moving Travis CI builds into here as well later on, to have all CI and releases automated in the same way.