### PR TITLE
Fix frequent crash under MacOS, see #5596

### DIFF
--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -55,6 +55,8 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     fslistener(nullptr),
     iatlistener(nullptr),
     hbToolBar1STB(nullptr),
+    progressImage(nullptr),
+    progressLabel(nullptr),
     hasValidCurrentEFS(false),
     filterPanel(nullptr),
     exportPanel(nullptr),
@@ -705,34 +707,37 @@ void FileCatalog::_refreshProgressBar ()
     // The second, usually longer pass is done multithreaded down in the single entries and is NOT measured by this
     if (!inTabMode && (!previewsToLoad || std::floor(100.f * previewsLoaded / previewsToLoad) != std::floor(100.f * (previewsLoaded - 1) / previewsToLoad))) {
         GThreadLock lock; // All GUI access from idle_add callbacks or separate thread HAVE to be protected
-        Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
-        Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
-        Gtk::Label *label = nullptr;
 
+        if (!progressImage || !progressLabel) {
+            // create tab label once
+            Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
+            Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
+            progressImage = Gtk::manage(new RTImage("folder-closed.png"));
+            progressLabel = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER")));
+            grid->attach_next_to(*progressImage, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+            grid->attach_next_to(*progressLabel, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+            grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
+            grid->show_all();
+            if (options.mainNBVertical) {
+                progressLabel->set_angle(90);
+            }
+            if (nb) {
+                nb->set_tab_label(*filepanel, *grid);
+            }
+        }
         if (!previewsToLoad) {
-            grid->attach_next_to(*Gtk::manage(new RTImage("folder-closed.png")), options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+            progressImage->changeImage("folder-closed.png");
             int filteredCount = min(fileBrowser->getNumFiltered(), previewsLoaded);
-
-            label = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER") +
-                                               (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " (")
-                                               + Glib::ustring::format(previewsLoaded) +
-                                               (filteredCount != previewsLoaded ? "]" : ")")));
+            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") +
+                                    (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " (")
+                                    + Glib::ustring::format(previewsLoaded) +
+                                    (filteredCount != previewsLoaded ? "]" : ")"));
         } else {
-            grid->attach_next_to(*Gtk::manage(new RTImage("magnifier.png")), options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-            label = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER") + " [" + Glib::ustring::format(std::fixed, std::setprecision(0), std::setw(3), (double)previewsLoaded / previewsToLoad * 100 ) + "%]" ));
+            progressImage->changeImage("magnifier.png");
+            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") + " ["
+                                    + Glib::ustring::format(previewsLoaded) + "/"
+                                    + Glib::ustring::format(previewsToLoad) + "]" );
             filepanel->loadingThumbs("", (double)previewsLoaded / previewsToLoad);
-        }
-
-        if (options.mainNBVertical) {
-            label->set_angle(90);
-        }
-
-        grid->attach_next_to(*label, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-        grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
-        grid->show_all();
-
-        if (nb) {
-            nb->set_tab_label(*filepanel, *grid);
         }
     }
 }

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -124,6 +124,9 @@ private:
     Gtk::Button* zoomInButton;
     Gtk::Button* zoomOutButton;
 
+    RTImage* progressImage;
+    Gtk::Label* progressLabel;
+
     MyMutex dirEFSMutex;
     ExifFilterSettings dirEFS;
     ExifFilterSettings currentEFS;


### PR DESCRIPTION
So far new Gtk::Grid, RTImage and Gtk::Label were created for each update during load of previews. This leads to a crash under MacOS in many cases (either immediately at startup or when changing the image directory), see #5596.
This fix creates the widgets only once.
Moreover, the progress is shown in absolute numbers, e.g. `50/200` instead of `25%`, because the percentage is already shown in the separate progress bar.