### PR TITLE
Prepend DATADIR only once to LENSFUNDBDIR, see #5622

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,10 +252,6 @@ if(NOT DEFINED APPDATADIR)
     endif()
 endif()
 
-if(DEFINED LENSFUNDBDIR AND NOT IS_ABSOLUTE "${LENSFUNDBDIR}")
-    set(LENSFUNDBDIR "${DATADIR}/${LENSFUNDBDIR}")
-endif()
-
 if(APPLE)
     if("${CODESIGNID}")
         set(CODESIGNID "${CODESIGNID}" CACHE STRING "Codesigning Identity")


### PR DESCRIPTION
DATADIR is also prepended to a relative LENSFUNDBDIR in rtengine::init.
This removal in CMakeLists.txt keeps the cmake argument LENSFUNDBDIR
unmodified in the ~/.config/RawTherapee*/options file.

This fixes a path like
   ../../Resources/../../Resources/./share/lensfun
for LENSFUNDBDIR=./share/lensfun under macOS.
