### PR TITLE
CMakeLists.txt LENSFUNDBDIR partial regress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,12 @@ if(NOT DEFINED APPDATADIR)
     endif()
 endif()
 
+if (NOT APPLE)
+    if(DEFINED LENSFUNDBDIR AND NOT IS_ABSOLUTE "${LENSFUNDBDIR}") 
+        set(LENSFUNDBDIR "${DATADIR}/${LENSFUNDBDIR}") 
+    endif()
+endif()
+
 if(APPLE)
     if("${CODESIGNID}")
         set(CODESIGNID "${CODESIGNID}" CACHE STRING "Codesigning Identity")


### PR DESCRIPTION
Restores a few lines in CMakeLists.txt 2cc8918 removed, applying to certain use cases on non-APPLE systems.