### PR TITLE
Do not set math errno

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=delete-incomplete")
 
 # Do net set math errno, as we never check its value.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-math-errno")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-math-errno")
 
 # Special treatment for x87 and x86-32 SSE (see GitHub issue #4324)
 include(FindX87Math)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,9 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PROC_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=unused-label")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=delete-incomplete")
 
+# Do net set math errno, as we never check its value.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-math-errno")
+
 # Special treatment for x87 and x86-32 SSE (see GitHub issue #4324)
 include(FindX87Math)
 if(HAVE_X87_MATH)


### PR DESCRIPTION
In RT we never check [math errno](http://www.cplusplus.com/reference/cerrno/errno/).
Some functions (for example std::sqrt set errno and because they have to do that, loops calling such functions will not be vecorized by the compiler.

This example-code will not be vectorized:
```C++
#include <cmath>

void sqrtrow(float *data, int width) {

    for (int i = 0; i < width; ++i) {
        data[i] = std::sqrt(data[i]);
    }
}
```

If we use `-fno-math-errno`, the errno will not be set and the loop will be vectorized by the compiler

Any objections to use this flag?