### PR TITLE
Bugfix/Improvement for macOS environnement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ set(CACHE_NAME_SUFFIX
     ""
     CACHE STRING "RawTherapee's cache folder suffix")
 
+# For macOS only, OSX_DEV_BUILD option allows using relative paths instead of absolute
+# paths. Consequently, for development builds, application can be launching without
+# being bundled. However, file access can be restricted for some folder.
+option(OSX_DEV_BUILD "Generate macOS development builds" OFF)
+
 # By default we don't use a specific processor target, so PROC_TARGET_NUMBER is
 # set to 0. Specify other values to optimize for specific processor architecture
 # as listed in ProcessorTargets.cmake:

--- a/rtgui/config.h.in
+++ b/rtgui/config.h.in
@@ -22,8 +22,9 @@
 
 #cmakedefine BUILD_BUNDLE
 #cmakedefine HAVE_UNALIGNED_MALLOC
+#cmakedefine OSX_DEV_BUILD
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(OSX_DEV_BUILD)
 #define DATA_SEARCH_PATH "/Applications/RawTherapee.app/Contents/Resources/share"
 #define DOC_SEARCH_PATH "/Applications/RawTherapee.app/Contents/Resources"
 #define CREDITS_SEARCH_PATH "/Applications/RawTherapee.app/Contents/Resources"

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -255,6 +255,7 @@ RTWindow *create_rt_window()
 
     //gdk_threads_enter ();
     RTWindow *rtWindow = new RTWindow();
+    rtWindow->setWindowSize(); // Need to be called after RTWindow creation to work with all OS Windows Manager
     return rtWindow;
 }
 

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -2325,18 +2325,8 @@ void Options::load(bool lightweight)
     const gchar* path;
     Glib::ustring dPath;
 
-#ifdef __APPLE__
-    // Build Application Support directory path for macOS.
-    const char* homedir = g_getenv("HOME"); // This returns the current container data dir in ~/Library
-    std::string homebuf{homedir};
-    int homelength = strlen(homebuf.c_str());
-    homebuf[homelength-44] = '\0'; // Terminate string after ${HOME}/Library
-    std::string homeconfig{homebuf};
-    std::strcat(&homeconfig[0], "/Application Support/RawTherapee/config");
-    path = homeconfig.c_str();
-#else
     path = g_getenv("RT_SETTINGS");
-#endif
+
     if (path != nullptr) {
         rtdir = Glib::ustring(path);
 
@@ -2356,7 +2346,11 @@ void Options::load(bool lightweight)
         }
 
 #else
+    #ifdef __APPLE__
+        rtdir = Glib::build_filename(Glib::ustring(g_get_home_dir()), "/Library/Application Support/", Glib::ustring(CACHEFOLDERNAME), "/config/");
+    #else
         rtdir = Glib::build_filename(Glib::ustring(g_get_user_config_dir()), Glib::ustring(CACHEFOLDERNAME));
+    #endif
 #endif
     }
 
@@ -2378,14 +2372,9 @@ void Options::load(bool lightweight)
         rtdir = Glib::build_filename(argv0, "mysettings");
     }
 
-    // Modify the path of the cache folder to the one provided in RT_CACHE environment variable. Build the cache folder name in macOS.
-#ifdef __APPLE__
-    std::string homecache{homebuf};
-    std::strcat(&homecache[0], "/Application Support/RawTherapee/cache");
-    path = homecache.c_str();
-#else
+    // Modify the path of the cache folder to the one provided in RT_CACHE environment variable.
     path = g_getenv("RT_CACHE");
-#endif
+
     if (path != nullptr) {
         cacheBaseDir = Glib::ustring(path);
 
@@ -2400,7 +2389,11 @@ void Options::load(bool lightweight)
 #ifdef WIN32
         cacheBaseDir = Glib::build_filename(rtdir, "cache");
 #else
+    #ifdef __APPLE__
+        cacheBaseDir = Glib::build_filename(Glib::ustring(g_get_home_dir()), "/Library/Application Support/", Glib::ustring(CACHEFOLDERNAME), "/cache/");
+    #else
         cacheBaseDir = Glib::build_filename(Glib::ustring(g_get_user_cache_dir()), Glib::ustring(CACHEFOLDERNAME));
+    #endif
 #endif
     }
 

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -280,23 +280,6 @@ RTWindow::RTWindow ()
     set_default_size (options.windowWidth, options.windowHeight);
     set_modal (false);
 
-    Gdk::Rectangle lMonitorRect;
-    get_screen()->get_monitor_geometry (std::min (options.windowMonitor, Gdk::Screen::get_default()->get_n_monitors() - 1), lMonitorRect);
-
-    if (options.windowMaximized) {
-        move (lMonitorRect.get_x(), lMonitorRect.get_y());
-        maximize();
-    } else {
-        unmaximize();
-        resize (options.windowWidth, options.windowHeight);
-
-        if (options.windowX <= lMonitorRect.get_x() + lMonitorRect.get_width() && options.windowY <= lMonitorRect.get_y() + lMonitorRect.get_height()) {
-            move (options.windowX, options.windowY);
-        } else {
-            move (lMonitorRect.get_x(), lMonitorRect.get_y());
-        }
-    }
-
     on_delete_has_run = false;
     is_fullscreen = false;
     property_destroy_with_parent().set_value (false);
@@ -1098,6 +1081,44 @@ bool RTWindow::splashClosed (GdkEventAny* event)
     splash = nullptr;
     showErrors();
     return true;
+}
+
+void RTWindow::setWindowSize ()
+{
+    Gdk::Rectangle lMonitorRect;
+    get_screen()->get_monitor_geometry (std::min (options.windowMonitor, Gdk::Screen::get_default()->get_n_monitors() - 1), lMonitorRect);
+
+#ifdef __APPLE__
+    // Get macOS menu bar height
+    const Gdk::Rectangle lWorkAreaRect = get_screen()->get_monitor_workarea (std::min (options.windowMonitor, Gdk::Screen::get_default()->get_n_monitors() - 1));
+    const int macMenuBarHeight = lWorkAreaRect.get_y();
+#endif
+
+    if (options.windowMaximized) {
+#ifdef __APPLE__
+        move (lMonitorRect.get_x(), lMonitorRect.get_y() + macMenuBarHeight);
+#else
+        move (lMonitorRect.get_x(), lMonitorRect.get_y());
+#endif
+        maximize();
+    } else {
+        unmaximize();
+        resize (options.windowWidth, options.windowHeight);
+
+#ifdef __APPLE__
+        if (options.windowX <= lMonitorRect.get_x() + lMonitorRect.get_width() && options.windowY <= lMonitorRect.get_y() + lMonitorRect.get_height() - macMenuBarHeight) {
+            move (options.windowX, options.windowY + macMenuBarHeight);
+        } else {
+            move (lMonitorRect.get_x(), lMonitorRect.get_y() + macMenuBarHeight);
+        }
+#else
+        if (options.windowX <= lMonitorRect.get_x() + lMonitorRect.get_width() && options.windowY <= lMonitorRect.get_y() + lMonitorRect.get_height()) {
+            move (options.windowX, options.windowY);
+        } else {
+            move (lMonitorRect.get_x(), lMonitorRect.get_y());
+        }
+#endif
+    }
 }
 
 void RTWindow::set_title_decorated (Glib::ustring fname)

--- a/rtgui/rtwindow.h
+++ b/rtgui/rtwindow.h
@@ -123,6 +123,7 @@ public:
     {
         return is_fullscreen;
     }
+    void setWindowSize ();
     void set_title_decorated (Glib::ustring fname);
     void closeOpenEditors();
     void setEditorMode (bool tabbedUI);


### PR DESCRIPTION
@Benitoite 
Improvement:
- Introduced the `OSX_DEV_BUILD` cMake option which allows using relative path for RT data in order to be directly executed without being bundled. This will save time when developing RT in macOS environnement.

Bug-fixes:
- In `dev` branch, RT cache/config folder was located in `~/Application Support/RawTherapee` instead of `~/Library/Application Support/RawTherapee` (as in v5.8 release and described in RawPedia). Moreover, `CACHE_NAME_SUFFIX` cMake option was not anymore considered to name cache/config folder.
- RT window size/position is now correctly restored, fixes #3209.

Pierre