### PR TITLE
Fix various typos

### DIFF
--- a/rtengine/colortemp.cc
+++ b/rtengine/colortemp.cc
@@ -2898,15 +2898,15 @@ void ColorTemp::icieCAT02float(float Xw, float Yw, float Zw, float &iCAM02BB00, 
     float D = adap / 2.;
 
     //white destination Wd : RT use always D50
-    cam_dest[0] = INVCAT02[0][0] * whiteD50p[0] + INVCAT02[0][1] * whiteD50p[1] + INVCAT02[0][2] * whiteD50p[2]; //Cone reponse RoD
+    cam_dest[0] = INVCAT02[0][0] * whiteD50p[0] + INVCAT02[0][1] * whiteD50p[1] + INVCAT02[0][2] * whiteD50p[2]; //Cone response RoD
     cam_dest[1] = INVCAT02[1][0] * whiteD50p[0] + INVCAT02[1][1] * whiteD50p[1] + INVCAT02[1][2] * whiteD50p[2]; //GaD
     cam_dest[2] = INVCAT02[2][0] * whiteD50p[0] + INVCAT02[2][1] * whiteD50p[1] + INVCAT02[2][2] * whiteD50p[2]; //BeD
 
     //origin white Ws : A, D65, custom, etc.
-    cam_orig[0] = INVCAT02[0][0] * Xw + INVCAT02[0][1] * Yw + INVCAT02[0][2] * Zw; //Cone reponse RoS
+    cam_orig[0] = INVCAT02[0][0] * Xw + INVCAT02[0][1] * Yw + INVCAT02[0][2] * Zw; //Cone response RoS
     cam_orig[1] = INVCAT02[1][0] * Xw + INVCAT02[1][1] * Yw + INVCAT02[1][2] * Zw;
     cam_orig[2] = INVCAT02[2][0] * Xw + INVCAT02[2][1] * Yw + INVCAT02[2][2] * Zw;
-//   cam_orig[0] = CAT02[0][0] * Xw + CAT02[0][1] * Yw + CAT02[0][2] * Zw; //Cone reponse RoS
+//   cam_orig[0] = CAT02[0][0] * Xw + CAT02[0][1] * Yw + CAT02[0][2] * Zw; //Cone response RoS
 //   cam_orig[1] = CAT02[1][0] * Xw + CAT02[1][1] * Yw + CAT02[1][2] * Zw;
     //  cam_orig[2] = CAT02[2][0] * Xw + CAT02[2][1] * Yw + CAT02[2][2] * Zw;
 
@@ -3624,7 +3624,7 @@ void ColorTemp::tempxy(bool separated, int repref, float **Tx, float **Ty, float
         double XX;
         double ZZ;
     } WbTxyz;
-    //probbaly can be "passed" with rawimagesource.cc but I don't know how to do.
+    //probably can be "passed" with rawimagesource.cc but I don't know how to do this.
     constexpr WbTxyz Txyz[118] = {//temperature Xwb Zwb 118 values - same table as in Rawimagesource.cc  x wb and y wb are calculated after
         {2001., 1.273842, 0.145295},
         {2101., 1.244008, 0.167533},

--- a/rtengine/filmnegativeproc.cc
+++ b/rtengine/filmnegativeproc.cc
@@ -214,7 +214,7 @@ bool rtengine::RawImageSource::getFilmNegativeExponents(Coord2D spotA, Coord2D s
     std::array<float, 3> denseVals;
 
     // Get channel averages in the two spots, sampling from the original ri->data buffer.
-    // NOTE: rawData values might be affected by CA corection, FlatField, etc, so:
+    // NOTE: rawData values might be affected by CA correction, FlatField, etc, so:
     //   rawData[y][x] == (ri->data[y][x] - cblacksom[c]) * scale_mul[c]
     // is not always true. To calculate exponents on the exact values, we should keep
     // a copy of the rawData buffer after preprocessing. Worth the memory waste?
@@ -330,7 +330,7 @@ void rtengine::RawImageSource::filmNegativeProcess(const procparams::FilmNegativ
     // If film base values are set in params, use those
     if (filmBaseValues[0] <= 0.f) {
         // ...otherwise, the film negative tool might have just been enabled on this image,
-        // whithout any previous setting. So, estimate film base values from channel medians
+        // without any previous setting. So, estimate film base values from channel medians
 
         std::array<float, 3> medians;
 

--- a/rtengine/ipdehaze.cc
+++ b/rtengine/ipdehaze.cc
@@ -464,7 +464,7 @@ void ImProcFunctions::dehaze(Imagefloat *img, const DehazeParams &dehazeParams)
 
 void ImProcFunctions::dehazeloc(Imagefloat *img, const DehazeParams &dehazeParams)
 {
-    //J.Desmis 12 2019 - this version derived from ART, is slower than the main from maximimum 10% - probably use of SSE
+    //J.Desmis 12 2019 - this version derived from ART, is slower than the main from maximum 10% - probably use of SSE
     //Probably Ingo could solved this problem in some times
    BENCHFUN 
     if (!dehazeParams.enabled || dehazeParams.strength == 0.0) {

--- a/rtengine/iplocalcontrast.cc
+++ b/rtengine/iplocalcontrast.cc
@@ -53,7 +53,7 @@ void ImProcFunctions::localContrast(LabImage *lab, float **destination, const rt
         gaussianBlur(lab->L, buf, width, height, sigma);
     } else {
         float kr = 1.f;
-        //emprical adjustement between FFTW radius and Gaussainblur
+        //emprical adjustment between FFTW radius and Gaussainblur
         //under 50 ==> 10.f
         //above 400 ==> 1.f
         if(settings->fftwsigma == false) {//empirical formula

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -188,7 +188,7 @@ float calcLocalFactor(const float lox, const float loy, const float lcx, const f
     const float kelip = dx / dy;
     const float belip = rtengine::max(0.0001f, std::sqrt((rtengine::SQR((lox - lcx) / kelip) + rtengine::SQR(loy - lcy)))); //determine position ellipse ==> a and b
 
-    //gradient allows differenciation between transition x and y
+    //gradient allows differentiation between transition x and y
     const float rapy = std::fabs((loy - lcy) / belip);
     const float aelip = belip * kelip;
     const float degrad = aelip / dx;
@@ -206,7 +206,7 @@ float calcLocalFactorrect(const float lox, const float loy, const float lcx, con
     const float ky = loy - lcy;
 
     float ref;
-    //gradient allows differenciation between transition x and y
+    //gradient allows differentiation between transition x and y
     if (std::fabs(kx / (ky + eps)) < krap) {
         ref = std::sqrt(rtengine::SQR(dy) * (1.f + rtengine::SQR(kx / (ky + eps))));
     } else {
@@ -1455,7 +1455,7 @@ static void calcTransition(const float lox, const float loy, const float ach, co
 }
 
 // Copyright 2018 Alberto Griggio <alberto.griggio@gmail.com>
-//J.Desmis 12 2019 - I will try to port a raw process in local adjustements
+//J.Desmis 12 2019 - I will try to port a raw process in local adjustments
 // I choose this one because, it is "new"
 // Perhaps - probably no result, but perhaps ??
 
@@ -1523,7 +1523,7 @@ float find_gray(float source_gray, float target_gray)
 void ImProcFunctions::log_encode(Imagefloat *rgb, const struct local_params & lp, bool multiThread, int bfw, int bfh)
 {
     /* J.Desmis 12 2019
-        small adaptations to local adjustements
+        small adaptations to local adjustments
         replace log2 by log(lp.baselog) allows diferentiation between low and high lights
     */
     BENCHFUN
@@ -1679,7 +1679,7 @@ void ImProcFunctions::log_encode(Imagefloat *rgb, const struct local_params & lp
 void ImProcFunctions::getAutoLogloc(int sp, ImageSource *imgsrc, float *sourceg, float *blackev, float *whiteev, bool *Autogr, int fw, int fh, float xsta, float xend, float ysta, float yend, int SCALE)
 {
     BENCHFUN
-//adpatation to local adjustements Jacques Desmis 12 2019
+//adpatation to local adjustments Jacques Desmis 12 2019
     const PreviewProps pp(0, 0, fw, fh, SCALE);
 
     Imagefloat img(int(fw / SCALE + 0.5), int(fh / SCALE + 0.5));
@@ -1793,7 +1793,7 @@ void tone_eq(array2D<float> &R, array2D<float> &G, array2D<float> &B, const stru
 // adapted from the tone equalizer of darktable
 /*
     Copyright 2019 Alberto Griggio <alberto.griggio@gmail.com>
-    Small adaptation to Local Adjustement 10 2019 Jacques Desmis <jdesmis@gmail.com>
+    Small adaptation to Local Adjustment 10 2019 Jacques Desmis <jdesmis@gmail.com>
     This file is part of darktable,
     copyright (c) 2018 Aurelien Pierre.
 
@@ -2019,7 +2019,7 @@ void tone_eq(array2D<float> &R, array2D<float> &G, array2D<float> &B, const stru
 
 void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab)
 {
-    //be carefull quasi duplicate with branch cat02wb
+    //be careful quasi duplicate with branch cat02wb
     BENCHFUN
 
     int width = lab->W, height = lab->H;
@@ -5902,13 +5902,13 @@ void ImProcFunctions::BlurNoise_Local(LabImage *tmp1, LabImage * originalmask, f
 
                 const float maxdifab = rtengine::max(std::fabs(difa), std::fabs(difb));
 
-                if (blshow && lp.colorde < 0) { //show modifications whith use "b"
+                if (blshow && lp.colorde < 0) { //show modifications with use "b"
                     //  (origshow && lp.colorde < 0) { //original Retinex
                     transformed->a[y][x] = 0.f;
                     transformed->b[y][x] = ampli * 8.f * difL * reducdE;
                     transformed->L[y][x] = CLIP(12000.f + 0.5f * ampli * difL);
 
-                } else if (blshow && lp.colorde > 0) {//show modifications whithout use "b"
+                } else if (blshow && lp.colorde > 0) {//show modifications without use "b"
                     if (difL < 1000.f) {//if too low to be view use ab
                         difL += 0.5f * maxdifab;
                     }
@@ -5939,7 +5939,7 @@ void ImProcFunctions::BlurNoise_Local(LabImage *tmp1, LabImage * originalmask, f
 
 void ImProcFunctions::transit_shapedetect2(int call, int senstype, const LabImage * bufexporig, const LabImage * bufexpfin, LabImage * originalmask, const float hueref, const float chromaref, const float lumaref, float sobelref, float meansobel, float ** blend2, struct local_params & lp, LabImage * original, LabImage * transformed, int cx, int cy, int sk)
 {
-    //initialize coordonates
+    //initialize coordinates
     int ystart = rtengine::max(static_cast<int>(lp.yc - lp.lyT) - cy, 0);
     int yend = rtengine::min(static_cast<int>(lp.yc + lp.ly) - cy, original->H);
     int xstart = rtengine::max(static_cast<int>(lp.xc - lp.lxL) - cx, 0);
@@ -6157,7 +6157,7 @@ void ImProcFunctions::transit_shapedetect2(int call, int senstype, const LabImag
                 float localFactor = 1.f;
                 const float achm = lp.trans / 100.f;
 
-                //claculate transition
+                //calculate transition
                 if (lp.shapmet == 0) {
                     calcTransition(lox, loy, achm, lp, zone, localFactor);
                 } else /*if (lp.shapmet == 1)*/ {
@@ -6173,7 +6173,7 @@ void ImProcFunctions::transit_shapedetect2(int call, int senstype, const LabImag
 
                 float rsob = 0.f;
 
-                //claculate additive sobel to deltaE
+                //calculate additive sobel to deltaE
                 if (blend2 && ((senstype == 1 && lp.struexp > 0.f) || ((senstype == 0) && lp.struco > 0.f))) {
                     const float csob = xlogf(1.f + rtengine::min(blend2[y][x] / 100.f, 60.f) + 0.001f);
 
@@ -6233,13 +6233,13 @@ void ImProcFunctions::transit_shapedetect2(int call, int senstype, const LabImag
                     const float difb = factorx * realstrbdE;
                     float maxdifab = rtengine::max(std::fabs(difa), std::fabs(difb));
 
-                    if ((expshow || vibshow || colshow || SHshow || tmshow || lcshow || origshow) && lp.colorde < 0) { //show modifications whith use "b"
+                    if ((expshow || vibshow || colshow || SHshow || tmshow || lcshow || origshow) && lp.colorde < 0) { //show modifications with use "b"
                         //  (origshow && lp.colorde < 0) { //original Retinex
                         transformed->a[y + ystart][x + xstart] = 0.f;
                         transformed->b[y + ystart][x + xstart] = ampli * 8.f * diflc * reducdE;
                         transformed->L[y + ystart][x + xstart] = CLIP(12000.f + 0.5f * ampli * diflc);
 
-                    } else if ((expshow || vibshow || colshow || SHshow || tmshow || lcshow || origshow) && lp.colorde > 0) {//show modifications whithout use "b"
+                    } else if ((expshow || vibshow || colshow || SHshow || tmshow || lcshow || origshow) && lp.colorde > 0) {//show modifications without use "b"
                         if (diflc < 1000.f) {//if too low to be view use ab
                             diflc += 0.5f * maxdifab;
                         }
@@ -6348,19 +6348,19 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
     /*
         ** Jacques Desmis june 2019 - inspired by Copyright 2013 IPOL Image Processing On Line http://www.ipol.im/
         ** when I read documentation on various FFT blur we found 2 possibilities
-        ** 0) kernel gauss is used with "normal" datas
+        ** 0) kernel gauss is used with "normal" data
         ** 1) kernel gauss is used with FFT
         ** fftkern allows to change 0) or 1) and test  It seems the good solution is with 0, but I keep the code in case of ??
 
-        ** input real datas to blur
-        ** output real datas blurred with radius
+        ** input real data to blur
+        ** output real data blurred with radius
         ** bfw bfh width and high area
         ** radius = sigma for kernel
         ** n_x n_y relative width and high for kernel
         ** Gaussian blur is given by G(x,y) = (1/2*PI*sigma) * exp(-(x2 + y2) / 2* sigma2)
-        ** its traduction in Fourier transform is G(x,y) =  exp((-sigma)*(PI * x2 + PI * y2)), for some authors it is not sigma but sigma^2..I have tried...huge diffrences with Gaussianblur
+        ** its traduction in Fourier transform is G(x,y) =  exp((-sigma)*(PI * x2 + PI * y2)), for some authors it is not sigma but sigma^2..I have tried...huge differences with Gaussianblur
         ** after several test the only result that works very well is with fftkern = 0 and algo = 0, and as there is differences with Gaussianblur, I put an empirical correction in Ipretinex and Iplocalcontrast
-        ** you can enabled or disabled this function with rtsettings.fftwsigma in options. By defaut empirical formula is disabled
+        ** you can enabled or disabled this function with rtsettings.fftwsigma in options. By default empirical formula is disabled
         ** in fact no importance....if it is this function (for sigma) or another... we are not in research :)
     */
     BENCHFUN
@@ -6373,22 +6373,22 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
 #endif
 
 
-    float *out; //for FFT datas
+    float *out; //for FFT data
     float *kern = nullptr;//for kernel gauss
     float *outkern = nullptr;//for FFT kernel
     fftwf_plan p;
     fftwf_plan pkern;//plan for FFT
     int image_size, image_sizechange;
     float n_x = 1.f;
-    float n_y = 1.f;//relative coordonates for kernel Gauss
+    float n_y = 1.f;//relative coordinates for kernel Gauss
     float radsig = 1.f;
 
-    out = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real datas for FFT
+    out = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real data for FFT
 
     if (fftkern == 1) { //allocate memory FFT if kernel fft = 1
         // kern = new float[bfw * bfh];
-        kern = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real datas for FFT
-        outkern = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real datas for FFT
+        kern = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real data for FFT
+        outkern = (float*) fftwf_malloc(sizeof(float) * (bfw * bfh));//allocate real data for FFT
     }
 
     /*compute the Fourier transform of the input data*/
@@ -6441,7 +6441,7 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
             int index = j * bfw;
 
             for (int i = 0; i < bfw; i++) {
-                out[i + index] *= outkern[i + index];    //apply Gauss kernel whith FFT
+                out[i + index] *= outkern[i + index];    //apply Gauss kernel with FFT
             }
         }
 
@@ -6450,7 +6450,7 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
 
         //   delete [] kern;
 
-    } else if (fftkern == 0) {//whithout FFT kernel
+    } else if (fftkern == 0) {//without FFT kernel
         if (algo == 0) {
 #ifdef _OPENMP
             #pragma omp parallel for if (multiThread)
@@ -6459,7 +6459,7 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
                 int index = j * bfw;
 
                 for (int i = 0; i < bfw; i++) {
-                    out[i + index] *= exp((float)(-radius) * (n_x * i * i + n_y * j * j));    //apply Gauss kernel whithout FFT - some authors says radius*radius but differences with Gaussianblur
+                    out[i + index] *= exp((float)(-radius) * (n_x * i * i + n_y * j * j));    //apply Gauss kernel without FFT - some authors says radius*radius but differences with Gaussianblur
                 }
             }
         } else if (algo == 1) {
@@ -6482,7 +6482,7 @@ void ImProcFunctions::fftw_convol_blur(float * input, float * output, int bfw, i
 #ifdef _OPENMP
     #pragma omp parallel for if (multiThread)
 #endif
-    for (int index = 0; index < image_size; index++) { //restore datas
+    for (int index = 0; index < image_size; index++) { //restore data
         output[index] /= image_sizechange;
     }
 
@@ -8393,8 +8393,8 @@ void ImProcFunctions::DeNoise(int call, int del, float * slidL, float * slida, f
 //local denoise
     //all these variables are to prevent use of denoise when non necessary
     // but with qualmet = 2 (default for best quality) we must denoise chroma with little values to prevent artifacts due to variations of Hue
-    // but if user select volontary denoise, it is that choice the good (prioritary)
-    bool execcolor = (lp.chro != 0.f || lp.ligh != 0.f || lp.cont != 0); // only if one slider ore more is engaged
+    // but if user select voluntary denoise, it is that choice the good (prioritary)
+    bool execcolor = (lp.chro != 0.f || lp.ligh != 0.f || lp.cont != 0); // only if one slider or more is engaged
     bool execbdl = (lp.mulloc[0] != 1.f || lp.mulloc[1] != 1.f || lp.mulloc[2] != 1.f || lp.mulloc[3] != 1.f || lp.mulloc[4] != 1.f || lp.mulloc[5] != 1.f) ;//only if user want cbdl
     bool execdenoi = noiscfactiv && ((lp.colorena && execcolor) || (lp.tonemapena && lp.strengt != 0.f) || (lp.cbdlena && execbdl) || (lp.sfena && lp.strng > 0.f) || (lp.lcena && lp.lcamount > 0.f) || (lp.sharpena && lp.shrad > 0.42) || (lp.retiena && lp.str > 0.f)  || (lp.exposena && lp.expcomp != 0.f)  || (lp.expvib && lp.past != 0.f));
     bool execmaskden = (lp.showmaskblmet == 2 || lp.enablMask || lp.showmaskblmet == 3 || lp.showmaskblmet == 4) && lp.smasktyp != 0;
@@ -10292,8 +10292,8 @@ void ImProcFunctions::Lab_Local(
 
             const std::unique_ptr<LabImage> bufgbi(new LabImage(GW, GH));
 
-            //here mask is used with plein image for normal and inverse
-            //if it is possible to optimze with maskcalccol(), I don't to preserv lisibility
+            //here mask is used with plain image for normal and inverse
+            //if it is possible to optimize with maskcalccol(), I don't to preserve visibility
             if (lp.showmaskblmet == 0 || lp.showmaskblmet == 1  || lp.showmaskblmet == 2 || lp.showmaskblmet == 4 || lp.enablMask) {
 
                 if (lp.blurmet == 0) {
@@ -11415,7 +11415,7 @@ void ImProcFunctions::Lab_Local(
                                     maxdE, mindE, maxdElim, mindElim, lp.iterat, limscope, sco
                                    );
 
-                        if (lp.showmasktmmet == 3) {//dispaly mask
+                        if (lp.showmasktmmet == 3) {//display mask
                             showmask(lumask, lp, xstart, ystart, cx, cy, bfw, bfh, tmp1.get(), transformed, bufmaskorigtm.get(), 0);
 
                             return;
@@ -12068,7 +12068,7 @@ void ImProcFunctions::Lab_Local(
 
                     }
                 } else if (lp.locmet == 1) { //wavelet && sk ==1
-                    int wavelet_level = 1 + params->locallab.spots.at(sp).csthreshold.getBottomRight();//retriev with +1 maximum wavelet_level
+                    int wavelet_level = 1 + params->locallab.spots.at(sp).csthreshold.getBottomRight();//retrieve with +1 maximum wavelet_level
                     float mL = params->locallab.spots.at(sp).clarilres / 100.f;
                     float mC = params->locallab.spots.at(sp).claricres / 100.f;
                     float softr = params->locallab.spots.at(sp).clarisoft;
@@ -12336,7 +12336,7 @@ void ImProcFunctions::Lab_Local(
                 }
             }
 
-            //sharpen only square area instaed of all image
+            //sharpen only square area instead of all image
             ImProcFunctions::deconvsharpeningloc(bufsh, hbuffer, bfw, bfh, loctemp, params->locallab.spots.at(sp).shardamping, (double)params->locallab.spots.at(sp).sharradius, params->locallab.spots.at(sp).shariter, params->locallab.spots.at(sp).sharamount, params->locallab.spots.at(sp).sharcontrast, (double)params->locallab.spots.at(sp).sharblur, 1);
         } else { //call from dcrop.cc
             ImProcFunctions::deconvsharpeningloc(original->L, shbuffer, bfw, bfh, loctemp, params->locallab.spots.at(sp).shardamping, (double)params->locallab.spots.at(sp).sharradius, params->locallab.spots.at(sp).shariter, params->locallab.spots.at(sp).sharamount, params->locallab.spots.at(sp).sharcontrast, (double)params->locallab.spots.at(sp).sharblur, sk);
@@ -12627,7 +12627,7 @@ void ImProcFunctions::Lab_Local(
 
                 float divchro = maxChro;
 
-                //first step change saturation whithout Retinex ==> gain of time and memory
+                //first step change saturation without Retinex ==> gain of time and memory
                 float satreal = lp.str * params->locallab.spots.at(sp).chrrt / 100.f;
 
                 if (params->locallab.spots.at(sp).chrrt <= 0.2f) {
@@ -12954,7 +12954,7 @@ void ImProcFunctions::Lab_Local(
                     }
                 }
 
-                //first step change saturation whithout Retinex ==> gain of time and memory
+                //first step change saturation without Retinex ==> gain of time and memory
                 float satreal = lp.str * params->locallab.spots.at(sp).chrrt / 100.f;
 
                 if (params->locallab.spots.at(sp).chrrt <= 0.2f) {
@@ -14604,7 +14604,7 @@ void ImProcFunctions::Lab_Local(
         }
     }
 
-// Gamut and Munsell control - very important do not desactivated to avoid crash
+// Gamut and Munsell control - very important do not deactivated to avoid crash
     if (params->locallab.spots.at(sp).avoid) {
         const float ach = lp.trans / 100.f;
 

--- a/rtengine/ipretinex.cc
+++ b/rtengine/ipretinex.cc
@@ -1243,7 +1243,7 @@ void ImProcFunctions::MSRLocal(int call, int sp, bool fftw, int lum, float** red
 
         for (int scale = scal - 1; scale >= 0; --scale) {
             //    printf("retscale=%f scale=%i \n", mulradiusfftw * RetinexScales[scale], scale);
-            //emprical adjustement between FFTW radius and Gaussainblur
+            //emprical adjustment between FFTW radius and Gaussainblur
             //under 50 ==> 10.f
             // 400 ==> 1.f
             float sigm = 1.f;
@@ -1587,7 +1587,7 @@ void ImProcFunctions::MSRLocal(int call, int sp, bool fftw, int lum, float** red
                         }
 
                         //but we don't update mean stddv for display only...
-                        copylum[i][j] = gan * luminance[i][j];//update datas for display
+                        copylum[i][j] = gan * luminance[i][j];//update data for display
                         float cd = gan * cdfactor * luminance[i][j] + offse;
 
                         cdmax = cd > cdmax ? cd : cdmax;
@@ -1647,7 +1647,7 @@ void ImProcFunctions::MSRLocal(int call, int sp, bool fftw, int lum, float** red
                           );
         }
 
-        //mask does not interfered with datas displayed
+        //mask does not interfered with data displayed
 
         Tmean = mean;
         Tsigma = stddv;

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -861,11 +861,11 @@ void ImProcFunctions::ip_wavelet(LabImage * lab, LabImage * dst, int kall, const
 
                 if (exblurL) {
                     if (cp.mul[0] == 0.f) {
-                        cp.mul[0] = 0.01f;//to always enable WaveletcontAllL if no contrast is nead
+                        cp.mul[0] = 0.01f;//to always enable WaveletcontAllL if no contrast is needed
                     }
                 }
 
-                if (!exblurL && cp.contrast == 0.f && cp.blurres == 0.f && !cp.tonemap && cp.conres == 0.f && cp.conresH == 0.f && cp.val == 0  && !ref0 && params->wavelet.CLmethod == "all") { // no processing of residual L  or edge=> we probably can reduce the number of levels
+                if (!exblurL && cp.contrast == 0.f && cp.blurres == 0.f && !cp.tonemap && cp.conres == 0.f && cp.conresH == 0.f && cp.val == 0  && !ref0 && params->wavelet.CLmethod == "all") { // no processing of residual L or edge=> we probably can reduce the number of levels
                     while (levwavL > 0 && cp.mul[levwavL - 1] == 0.f) { // cp.mul[level] == 0.f means no changes to level
                         levwavL--;
                     }
@@ -2515,7 +2515,7 @@ void ImProcFunctions::WaveletcontAllAB(LabImage * labco, float ** varhue, float 
                 int jj = i - ii * W_L;
                 float LL = (labco->L[ii * 2][jj * 2]) / 327.68f; //I use labco but I can use also WavCoeffs_L0 (more exact but more memory)
 
-                float sca = 1.f; //amplifer - reducter...about 1, but perhaps 0.6 or 1.3
+                float sca = 1.f; //amplifier - reducter...about 1, but perhaps 0.6 or 1.3
 
                 if (useChannelA) { //green red (little magenta)
                     //transition to avoid artifacts with 6 between 30 to 36 and  63 to 69

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -4131,7 +4131,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && radmasklc == other.radmasklc
         && chromasklc == other.chromasklc
         && Lmasklccurve == other.Lmasklccurve
-        // Constrast by detail levels
+        // Contrast by detail levels
         && visicbdl == other.visicbdl
         && expcbdl == other.expcbdl
         && complexcbdl == other.complexcbdl

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -4423,17 +4423,17 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
 
     1) for the current raw file we create a table for each temp of RGB multipliers
     2) then, I choose the "camera temp" to initialize calculation (why not)
-    3) for this temp, I calculated XYZ values for the 201 spectral datas
+    3) for this temp, I calculated XYZ values for the 201 spectral data
     4) then I create for the image an "histogram", but for xyY (CIE 1931 color space or CIE 1964 (default))
-    5) for each pixel (in fact to accelerate only 1/5 for and 1/5 for y), I determine for each couple xy, the number of occurences, can be change by Itcwb_precis to 3 or 9
+    5) for each pixel (in fact to accelerate only 1/5 for and 1/5 for y), I determine for each couple xy, the number of occurrences, can be change by Itcwb_precis to 3 or 9
     6) I sort this result in ascending order
     7) in option we can sort in another manner to take into account chroma : chromax = x - white point x, chromay = y - white point y
-    8) then I compare this result, with spectral datas found above in 3) with deltaE (limited to chroma)
-    9) at this point we have xyY values that match Camera temp, and spectral datas associated
+    8) then I compare this result, with spectral data found above in 3) with deltaE (limited to chroma)
+    9) at this point we have xyY values that match Camera temp, and spectral data associated
     10) then I recalculate RGB values from xyY histogram
     11) after, I vary temp, between 2000K to 12000K
     12) RGB values are recalculated from 10) with RGB multipliers, and then xyY are calculated for each temp
-    13) spectral datas choose are recalculated with temp between 2000K to 12000K with matrix spectral calculation, that leads to xyY values
+    13) spectral data choose are recalculated with temp between 2000K to 12000K with matrix spectral calculation, that leads to xyY values
     14) I calculated for each couple xy, Student correlation (without Snedecor test)
     15) the good result, is the best correlation
     16) we have found the best temperature where color image and color references are correlate
@@ -4990,7 +4990,7 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
 
     chrom wbchro[sizcu4];
     const float swpr = Txyz[repref].XX + Txyz[repref].ZZ + 1.f;
-    const float xwpr = Txyz[repref].XX / swpr;//white point for tt in xy coordiantes
+    const float xwpr = Txyz[repref].XX / swpr;//white point for tt in xy coordinates
     const float ywpr = 1.f / swpr;
 
     for (int i = 0; i < sizcu4; ++i) { //take the max values
@@ -5021,7 +5021,7 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
         std::sort(wbchro, wbchro + sizcu4, wbchro[0]);
     }
 
-    const int maxval = rtengine::LIM(settings->itcwb_thres, 10, 55);//max values of color to find correllation
+    const int maxval = rtengine::LIM(settings->itcwb_thres, 10, 55);//max values of color to find correlation
 
     sizcurr2ref = rtengine::min(sizcurr2ref, maxval);    //keep about the biggest values,
 
@@ -5035,7 +5035,7 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
         }
     }
 
-    //calculate deltaE xx to find best values of spectrals datas - limited to chroma values
+    //calculate deltaE xx to find best values of spectrals data - limited to chroma values
     int maxnb = rtengine::LIM(settings->itcwb_sizereference, 1, 5);
 
     if (settings->itcwb_thres > 55) {
@@ -5203,8 +5203,8 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
                         reff_spect_xxyy[2 * kkg + 1][tt] = reff_spect_xxyy_prov[2 * i + 1][tt];
                     }
                 }
-                //now we have good spectral datas
-                //claculate student correlation
+                //now we have good spectral data
+                //calculate student correlation
                 const float abstudgr = std::fabs(studentXY(xxyycurr_reduc, reff_spect_xxyy, 2 * w, 2 * kkg, tt));
 
                 if (abstudgr < minstudgr) {  // find the minimum Student

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -723,7 +723,7 @@ bool ControlSpotPanel::blockTreeviewSearch(GdkEventKey* event)
         }
     }
 
-    // Otherwise key action is transfered to treeview widget
+    // Otherwise key action is transferred to treeview widget
     return false;
 }
 
@@ -734,7 +734,7 @@ bool ControlSpotPanel::onSpotSelectionEvent(GdkEventButton* event)
         return true;
     }
 
-    // Otherwise selection action is transfered to treeview widget
+    // Otherwise selection action is transferred to treeview widget
     return false;
 }
 

--- a/rtgui/locallab.cc
+++ b/rtgui/locallab.cc
@@ -943,7 +943,7 @@ void Locallab::setDefaults(const rtengine::procparams::ProcParams* defParams, co
     // Set default values in spot panel control
     expsettings->setDefaults(defParams, pedited);
 
-    // Set defaut values in Locallab tools
+    // Set default values in Locallab tools
     for (auto tool : locallabTools) {
         tool->setDefaults(defParams, pedited);
     }

--- a/rtgui/locallabtools.cc
+++ b/rtgui/locallabtools.cc
@@ -227,7 +227,7 @@ void LocallabTool::removeLocallabTool(bool raiseEvent)
         disableListener();
         exp->setEnabled(false);
         enableListener();
-        // Note: Mask views are all resetted when removing tool (in toolpanelcoord.cc)
+        // Note: Mask views are all reset when removing tool (in toolpanelcoord.cc)
 
         // Raise event if required refreshing image
         if (raiseEvent && listener) {
@@ -1892,7 +1892,7 @@ void LocallabColor::inversChanged()
 {
     updateColorGUI1(); // Update GUI according to invers button state
 
-    // This event is called to transmit potentially resetted mask state
+    // This event is called to transmit potentially reset mask state
     if (listener) {
         listener->panelChanged(EvlocallabshowmaskMethod, "");
     }
@@ -3105,7 +3105,7 @@ void LocallabExposure::inversexChanged()
     // Update exposure GUI according to inversex button state
     updateExposureGUI3();
 
-    // This event is called to transmit potentially resetted mask state
+    // This event is called to transmit potentially reset mask state
     if (listener) {
         listener->panelChanged(EvlocallabshowmaskMethod, "");
     }
@@ -4002,7 +4002,7 @@ void LocallabShadow::inversshChanged()
     // Update shadow highlight GUI according to inverssh button state
     updateShadowGUI1();
 
-    // This event is called to transmit potentially resetted mask state
+    // This event is called to transmit potentially reset mask state
     if (listener) {
         listener->panelChanged(EvlocallabshowmaskMethod, "");
     }
@@ -5136,7 +5136,7 @@ void LocallabSoft::softMethodChanged()
     // Update soft light GUI according to softMethod combobox
     updateSoftGUI();
 
-    // This event is called to transmit potentially resetted mask state
+    // This event is called to transmit potentially reset mask state
     if (listener) {
         listener->panelChanged(EvlocallabshowmaskMethod, "");
     }

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -2068,7 +2068,7 @@ void LocallabSharp::showmasksharMethodChanged()
 LocallabContrast::LocallabContrast():
     LocallabTool(this, M("TP_LOCALLAB_LC_TOOLNAME"), M("TP_LOCALLAB_LOC_CONTRAST"), true),
 
-    // Local constrast specific widgets
+    // Local contrast specific widgets
     localcontMethod(Gtk::manage(new MyComboBoxText())),
     lcradius(Gtk::manage(new Adjuster(M("TP_LOCALCONTRAST_RADIUS"), 10, 100, 1, 80))),
     lcamount(Gtk::manage(new Adjuster(M("TP_LOCALCONTRAST_AMOUNT"), 0, 1.0, 0.01, 0))),

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -602,8 +602,8 @@ void Options::setDefaults()
     rtSettings.reduchigh = 0.85;//transition for luminance in scope
     rtSettings.reduclow = 0.85;//transition for luminance out scope
     rtSettings.detectshape = true;//experimental new detection shape
-    rtSettings.previewselection = 5;//betwen 1 to 40
-    rtSettings.cbdlsensi = 1.0;//betwen 0.001 to 1
+    rtSettings.previewselection = 5;//between 1 to 40
+    rtSettings.cbdlsensi = 1.0;//between 0.001 to 1
     rtSettings.fftwsigma = true; //choice between sigma^2 or empirical formula
 
     rtSettings.itcwb_thres = 34;//between 10 to 55

--- a/rtgui/toolbar.h
+++ b/rtgui/toolbar.h
@@ -65,7 +65,7 @@ protected:
     ToolMode current;
     bool allowNoTool;
     bool editingMode;  // true if the cursor is being used to remotely edit tool's values
-    bool blockEdit; // true if edit tool shoudn't be disabled when pressing hand button or h/H key
+    bool blockEdit; // true if edit tool shouldn't be disabled when pressing hand button or h/H key
     sigc::connection  handConn;
     sigc::connection  wbConn;
     sigc::connection  cpConn;

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -519,7 +519,7 @@ void ToolPanelCoordinator::panelChanged(const rtengine::ProcEvent& event, const 
     /*
      * Manage Locallab mask visibility:
      * - Mask preview is updated when choosing a mask preview method
-     * - Mask preview is also updated when modifying (to avoid hidding a potentially visible mask combobox):
+     * - Mask preview is also updated when modifying (to avoid hiding a potentially visible mask combobox):
      *   - Color&Light invers
      *   - Exposure inversex
      *   - Shadow Highlight inverssh

--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -106,7 +106,7 @@ __EOS__
 
 minimum_macos_version=${MINIMUM_SYSTEM_VERSION}
 
-# Retreive cached values from cmake
+# Retrieve cached values from cmake
 
 #In: LOCAL_PREFIX:STRING=/opt
 #Out: /opt


### PR DESCRIPTION
Found via  codespell v2.0.dev0  
```
codespell -q 3 -S ./rtdata/languages -L alph,amin,autor,ba,bloc,bord,byteorder,cas,chang,childs,currentry,developpement,dof,dum,fo,foto,fro,hist,inbetween,interm,ist,iten,ith,lonly,makro,nd,ois,optio,portugues,preserv,reall,skipp,som,spred,substracted,tbe,thre,tim,ueadn,uint,unselect,vektor
```