### PR TITLE
Make libcanberra optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,11 @@ endif()
 
 # Check for libcanberra-gtk3 (sound events on Linux):
 if(UNIX AND (NOT APPLE))
-    pkg_check_modules(CANBERRA-GTK REQUIRED libcanberra-gtk3)
+    option(USE_LIBCANBERRA "Build with libcanberra" ON)
+    if(USE_LIBCANBERRA)
+       pkg_check_modules(CANBERRA-GTK REQUIRED libcanberra-gtk3)
+       add_definitions(-DUSE_CANBERRA)
+    endif()
 endif()
 
 if(WITH_MYFILE_MMAP)

--- a/rtgui/soundman.cc
+++ b/rtgui/soundman.cc
@@ -26,7 +26,7 @@
 #include <mmsystem.h>
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) && defined(USE_CANBERRA)
 #include <canberra-gtk.h>
 #endif
 
@@ -67,7 +67,7 @@ void SoundManager::playSoundAsync(const Glib::ustring &sound)
     wchar_t *wfilename = (wchar_t*)g_utf8_to_utf16 (sound.c_str(), -1, NULL, NULL, NULL);
     PlaySoundW(wfilename, NULL, sndParam);
     g_free( wfilename );
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(USE_CANBERRA)
     ca_context_play(ca_gtk_context_get(), 0, CA_PROP_EVENT_ID, sound.c_str(), CA_PROP_MEDIA_FILENAME, sound.c_str(), NULL);
 #endif
 }


### PR DESCRIPTION
It is the only X11 dep in RawTherapee, so here is an option to
compile without libcanberra. This will completely disables sounds
for long operations on Linux, but canberra is enabled by default.