### PR TITLE
Delayed GUI updates

### DIFF
--- a/rtgui/adjuster.cc
+++ b/rtgui/adjuster.cc
@@ -36,7 +36,7 @@ double one2one(double val)
 }
 }
 
-Adjuster::Adjuster (
+Adjuster::Adjuster(
     Glib::ustring vlabel,
     double vmin,
     double vmax,
@@ -45,10 +45,8 @@ Adjuster::Adjuster (
     Gtk::Image *imgIcon1,
     Gtk::Image *imgIcon2,
     double2double_fun slider2value,
-    double2double_fun value2slider)
-
-    :
-
+    double2double_fun value2slider
+) :
     adjustmentName(std::move(vlabel)),
     grid(nullptr),
     label(nullptr),
@@ -68,8 +66,7 @@ Adjuster::Adjuster (
     logPivot(0),
     logAnchorMiddle(false),
     value2slider(value2slider ? value2slider : &one2one),
-    slider2value(slider2value ? slider2value : &one2one),
-    delay(options.adjusterMinDelay)
+    slider2value(slider2value ? slider2value : &one2one)
 
 {
     set_hexpand(true);
@@ -265,7 +262,7 @@ void Adjuster::sliderReleased (GdkEventButton* event)
 void Adjuster::spinReleased (GdkEventButton* event)
 {
 
-    if ((event != nullptr) && delay == 0) {
+    if (event) {
         spinChange.cancel();
 
         notifyListener();
@@ -321,7 +318,7 @@ double Adjuster::shapeValue (double a) const
 void Adjuster::setLimits (double vmin, double vmax, double vstep, double vdefault)
 {
     sliderChange.block(true);
-    spinChange.block();
+    spinChange.block(true);
 
     double pow10 = vstep;
     for (digits = 0; std::fabs(pow10 - floor(pow10)) > 0.000000000001; digits++, pow10 *= 10.0);
@@ -339,7 +336,7 @@ void Adjuster::setLimits (double vmin, double vmax, double vstep, double vdefaul
     setSliderValue(addMode ? shapeVal : value2slider(shapeVal));
 
     sliderChange.block(false);
-    spinChange.unblock();
+    spinChange.block(false);
 }
 
 void Adjuster::setAddMode(bool addM)
@@ -364,7 +361,7 @@ void Adjuster::setAddMode(bool addM)
     }
 }
 
-void Adjuster::spinChanged ()
+void Adjuster::spinChanged()
 {
     if (adjusterListener && !blocked) {
         if (!buttonReleaseSlider.connected() || afterReset) {
@@ -610,7 +607,7 @@ void Adjuster::setSliderValue(double val)
 
 void Adjuster::setLogScale(double base, double pivot, bool anchorMiddle)
 {
-    spinChange.block();
+    spinChange.block(true);
     sliderChange.block(true);
 
     const double cur = getSliderValue();
@@ -620,7 +617,7 @@ void Adjuster::setLogScale(double base, double pivot, bool anchorMiddle)
     setSliderValue(cur);
     
     sliderChange.block(false);
-    spinChange.unblock();
+    spinChange.block(false);
 }
 
 bool Adjuster::getAutoValue() const
@@ -679,4 +676,10 @@ bool Adjuster::block(bool isBlocked)
 bool Adjuster::getAddMode() const
 {
     return addMode;
+}
+
+void Adjuster::setDelay(unsigned int min_delay_ms, unsigned int max_delay_ms)
+{
+    spinChange.setDelay(min_delay_ms, max_delay_ms);
+    sliderChange.setDelay(min_delay_ms, max_delay_ms);
 }

--- a/rtgui/adjuster.h
+++ b/rtgui/adjuster.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "editedstate.h"
+#include "delayedconnection.h"
 #include "guiutils.h"
 
 class Adjuster;
@@ -46,9 +47,8 @@ protected:
     Gtk::Button* reset;
     Gtk::CheckButton* automatic;
     AdjusterListener* adjusterListener;
-    sigc::connection delayConnection;
-    sigc::connection spinChange;
-    sigc::connection sliderChange;
+    DelayedConnection<> spinChange;
+    DelayedConnection<> sliderChange;
     sigc::connection editedChange;
     sigc::connection autoChange;
     sigc::connection buttonReleaseSlider;
@@ -62,7 +62,6 @@ protected:
     bool afterReset;
     bool blocked;
     bool addMode;
-    bool eventPending;
     double vMin;
     double vMax;
     double vStep;

--- a/rtgui/adjuster.h
+++ b/rtgui/adjuster.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "editedstate.h"
-#include "delayedconnection.h"
+#include "delayed.h"
 #include "guiutils.h"
 
 class Adjuster;

--- a/rtgui/adjuster.h
+++ b/rtgui/adjuster.h
@@ -36,7 +36,6 @@ typedef double(*double2double_fun)(double val);
 
 class Adjuster final : public Gtk::Grid
 {
-
 protected:
     Glib::ustring adjustmentName;
     Gtk::Grid* grid;
@@ -77,11 +76,18 @@ protected:
     void setSliderValue(double val);
 
 public:
-
-    int delay;
-
-    Adjuster (Glib::ustring vlabel, double vmin, double vmax, double vstep, double vdefault, Gtk::Image *imgIcon1 = nullptr, Gtk::Image *imgIcon2 = nullptr, double2double_fun slider2value = nullptr, double2double_fun value2slider = nullptr);
-    ~Adjuster () override;
+    Adjuster(
+        Glib::ustring vlabel,
+        double vmin,
+        double vmax,
+        double vstep,
+        double vdefault,
+        Gtk::Image *imgIcon1 = nullptr,
+        Gtk::Image *imgIcon2 = nullptr,
+        double2double_fun slider2value = nullptr,
+        double2double_fun value2slider = nullptr
+    );
+    ~Adjuster() override;
 
     // Add an "Automatic" checkbox next to the reset button.
     void addAutoButton(const Glib::ustring &tooltip = "");
@@ -126,4 +132,5 @@ public:
     void trimValue (float &val) const;
     void trimValue (int &val) const;
     void setLogScale(double base, double pivot, bool anchorMiddle = false);
+    void setDelay(unsigned int min_delay_ms, unsigned int max_delay_ms = 0);
 };

--- a/rtgui/bayerpreprocess.cc
+++ b/rtgui/bayerpreprocess.cc
@@ -37,18 +37,14 @@ BayerPreProcess::BayerPreProcess() : FoldableToolPanel(this, "bayerpreprocess", 
     lineDenoise = Gtk::manage(new Adjuster(M("TP_PREPROCESS_LINEDENOISE"), 0, 1000, 1, 0));
     lineDenoise->setAdjusterListener(this);
 
-    if (lineDenoise->delay < options.adjusterMaxDelay) {
-        lineDenoise->delay = options.adjusterMaxDelay;
-    }
+    lineDenoise->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     lineDenoise->show();
 
     greenEqThreshold = Gtk::manage(new Adjuster(M("TP_PREPROCESS_GREENEQUIL"), 0, 100, 1, 0));
     greenEqThreshold->setAdjusterListener(this);
 
-    if (greenEqThreshold->delay < options.adjusterMaxDelay) {
-        greenEqThreshold->delay = options.adjusterMaxDelay;
-    }
+    greenEqThreshold->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     greenEqThreshold->show();
 

--- a/rtgui/bayerprocess.cc
+++ b/rtgui/bayerprocess.cc
@@ -60,9 +60,7 @@ BayerProcess::BayerProcess () :
     dualDemosaicContrast->setAdjusterListener(this);
     dualDemosaicContrast->addAutoButton(M("TP_RAW_DUALDEMOSAICAUTOCONTRAST_TOOLTIP"));
     dualDemosaicContrast->setAutoValue(true);
-    if (dualDemosaicContrast->delay < options.adjusterMaxDelay) {
-        dualDemosaicContrast->delay = options.adjusterMaxDelay;
-    }
+    dualDemosaicContrast->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     dualDemosaicContrast->show();
     dualDemosaicOptions->pack_start(*dualDemosaicContrast);
@@ -72,9 +70,7 @@ BayerProcess::BayerProcess () :
     border = Gtk::manage(new Adjuster(M("TP_RAW_BORDER"), 0, 16, 1, 4));
     border->setAdjusterListener (this);
 
-    if (border->delay < options.adjusterMaxDelay) {
-        border->delay = options.adjusterMaxDelay;
-    }
+    border->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     border->show();
     borderbox->pack_start(*border);
@@ -96,22 +92,17 @@ BayerProcess::BayerProcess () :
     ccSteps = Gtk::manage (new Adjuster (M("TP_RAW_FALSECOLOR"), 0, 5, 1, 0 ));
     ccSteps->setAdjusterListener (this);
 
-    if (ccSteps->delay < options.adjusterMaxDelay) {
-        ccSteps->delay = options.adjusterMaxDelay;
-    }
+    ccSteps->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     ccSteps->show();
     pack_start( *ccSteps, Gtk::PACK_SHRINK, 4);
-
 
     dcbOptions = Gtk::manage (new Gtk::VBox ());
 
     dcbIterations = Gtk::manage (new Adjuster (M("TP_RAW_DCBITERATIONS"), 0, 5, 1, 2));
     dcbIterations->setAdjusterListener (this);
 
-    if (dcbIterations->delay < options.adjusterMaxDelay) {
-        dcbIterations->delay = options.adjusterMaxDelay;
-    }
+    dcbIterations->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     dcbIterations->show();
     dcbEnhance = Gtk::manage (new CheckBox(M("TP_RAW_DCBENHANCE"), multiImage));
@@ -126,9 +117,7 @@ BayerProcess::BayerProcess () :
     lmmseIterations->setAdjusterListener (this);
     lmmseIterations->set_tooltip_markup (M("TP_RAW_LMMSE_TOOLTIP"));
 
-    if (lmmseIterations->delay < options.adjusterMaxDelay) {
-        lmmseIterations->delay = options.adjusterMaxDelay;
-    }
+    lmmseIterations->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     lmmseIterations->show();
     lmmseOptions->pack_start(*lmmseIterations);
@@ -209,9 +198,7 @@ BayerProcess::BayerProcess () :
     pixelShiftSigma->set_tooltip_text (M("TP_RAW_PIXELSHIFTSIGMA_TOOLTIP"));
     pixelShiftSigma->setAdjusterListener (this);
 
-    if (pixelShiftSigma->delay < options.adjusterMaxDelay) {
-        pixelShiftSigma->delay = options.adjusterMaxDelay;
-    }
+    pixelShiftSigma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     pixelShiftSigma->show();
     pixelShiftOptions->pack_start(*pixelShiftSigma);
@@ -221,9 +208,7 @@ BayerProcess::BayerProcess () :
     pixelShiftSmooth->set_tooltip_text (M("TP_RAW_PIXELSHIFTSMOOTH_TOOLTIP"));
     pixelShiftSmooth->setAdjusterListener (this);
 
-    if (pixelShiftSmooth->delay < options.adjusterMaxDelay) {
-        pixelShiftSmooth->delay = options.adjusterMaxDelay;
-    }
+    pixelShiftSmooth->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     pixelShiftSmooth->show();
     pixelShiftOptions->pack_start(*pixelShiftSmooth);
@@ -232,9 +217,7 @@ BayerProcess::BayerProcess () :
     pixelShiftEperIso->set_tooltip_text(M("TP_RAW_PIXELSHIFTEPERISO_TOOLTIP"));
     pixelShiftEperIso->setAdjusterListener (this);
 
-    if (pixelShiftEperIso->delay < options.adjusterMaxDelay) {
-        pixelShiftEperIso->delay = options.adjusterMaxDelay;
-    }
+    pixelShiftEperIso->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     pixelShiftEperIso->show();
     pixelShiftOptions->pack_start(*pixelShiftEperIso);

--- a/rtgui/bayerrawexposure.cc
+++ b/rtgui/bayerrawexposure.cc
@@ -31,33 +31,25 @@ BayerRAWExposure::BayerRAWExposure () : FoldableToolPanel(this, "bayerrawexposur
     PexBlack1 = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_1"), -2048, 2048, 1.0, 0)); //black level
     PexBlack1->setAdjusterListener (this);
 
-    if (PexBlack1->delay < options.adjusterMaxDelay) {
-        PexBlack1->delay = options.adjusterMaxDelay;
-    }
+    PexBlack1->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlack1->show();
     PexBlack2 = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_2"), -2048, 2048, 1.0, 0)); //black level
     PexBlack2->setAdjusterListener (this);
 
-    if (PexBlack2->delay < options.adjusterMaxDelay) {
-        PexBlack2->delay = options.adjusterMaxDelay;
-    }
+    PexBlack2->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlack2->show();
     PexBlack3 = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_3"), -2048, 2048, 1.0, 0)); //black level
     PexBlack3->setAdjusterListener (this);
 
-    if (PexBlack3->delay < options.adjusterMaxDelay) {
-        PexBlack3->delay = options.adjusterMaxDelay;
-    }
+    PexBlack3->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlack3->show();
     PexBlack0 = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_0"), -2048, 2048, 1.0, 0)); //black level
     PexBlack0->setAdjusterListener (this);
 
-    if (PexBlack0->delay < options.adjusterMaxDelay) {
-        PexBlack0->delay = options.adjusterMaxDelay;
-    }
+    PexBlack0->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlack0->show();
     PextwoGreen = Gtk::manage(new CheckBox(M("TP_RAWEXPOS_TWOGREEN"), multiImage));// two green

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -244,9 +244,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     degree  = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CIECAT_DEGREE"),    0.,  100.,  1.,   90.));
 
-    if (degree->delay < options.adjusterMaxDelay) {
-        degree->delay = options.adjusterMaxDelay;
-    }
+    degree->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     degree->throwOnButtonRelease();
     degree->addAutoButton (M ("TP_COLORAPP_CAT02ADAPTATION_TOOLTIP"));
@@ -325,9 +323,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 //   adapscen = Gtk::manage (new Adjuster (M ("TP_COLORAPP_ABSOLUTELUMINANCE"), 0.01, 16384., 0.001, 2000.)); // EV -7  ==> EV 17
     adapscen = Gtk::manage (new Adjuster (M ("TP_COLORAPP_ABSOLUTELUMINANCE"), MINLA0, MAXLA0, 0.01, 1997.4, NULL, NULL, &wbSlider2la, &wbla2Slider));
 
-    if (adapscen->delay < options.adjusterMaxDelay) {
-        adapscen->delay = options.adjusterMaxDelay;
-    }
+    adapscen->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     adapscen->throwOnButtonRelease();
     adapscen->addAutoButton();
@@ -335,9 +331,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     ybscen = Gtk::manage (new Adjuster (M ("TP_COLORAPP_MEANLUMINANCE"), 1, 90, 1, 18));
 
-    if (ybscen->delay < options.adjusterMaxDelay) {
-        ybscen->delay = options.adjusterMaxDelay;
-    }
+    ybscen->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     ybscen->throwOnButtonRelease();
     ybscen->addAutoButton();
@@ -386,9 +380,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     jlight = Gtk::manage (new Adjuster (M ("TP_COLORAPP_LIGHT"), -100.0, 100.0, 0.1, 0.));
 
-    if (jlight->delay < options.adjusterMaxDelay) {
-        jlight->delay = options.adjusterMaxDelay;
-    }
+    jlight->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     jlight->throwOnButtonRelease();
     jlight->set_tooltip_markup (M ("TP_COLORAPP_LIGHT_TOOLTIP"));
@@ -396,9 +388,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     qbright = Gtk::manage (new Adjuster (M ("TP_COLORAPP_BRIGHT"), -100.0, 100.0, 0.1, 0.));
 
-    if (qbright->delay < options.adjusterMaxDelay) {
-        qbright->delay = options.adjusterMaxDelay;
-    }
+    qbright->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     qbright->throwOnButtonRelease();
     qbright->set_tooltip_markup (M ("TP_COLORAPP_BRIGHT_TOOLTIP"));
@@ -406,9 +396,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     chroma = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CHROMA"), -100.0, 100.0, 0.1, 0.));
 
-    if (chroma->delay < options.adjusterMaxDelay) {
-        chroma->delay = options.adjusterMaxDelay;
-    }
+    chroma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     chroma->throwOnButtonRelease();
     chroma->set_tooltip_markup (M ("TP_COLORAPP_CHROMA_TOOLTIP"));
@@ -417,9 +405,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     schroma = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CHROMA_S"), -100.0, 100.0, 0.1, 0.));
 
-    if (schroma->delay < options.adjusterMaxDelay) {
-        schroma->delay = options.adjusterMaxDelay;
-    }
+    schroma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     schroma->throwOnButtonRelease();
     schroma->set_tooltip_markup (M ("TP_COLORAPP_CHROMA_S_TOOLTIP"));
@@ -427,9 +413,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     mchroma = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CHROMA_M"), -100.0, 100.0, 0.1, 0.));
 
-    if (mchroma->delay < options.adjusterMaxDelay) {
-        mchroma->delay = options.adjusterMaxDelay;
-    }
+    mchroma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     mchroma->throwOnButtonRelease();
     mchroma->set_tooltip_markup (M ("TP_COLORAPP_CHROMA_M_TOOLTIP"));
@@ -437,9 +421,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     rstprotection = Gtk::manage ( new Adjuster (M ("TP_COLORAPP_RSTPRO"), 0., 100., 0.1, 0.) );
 
-    if (rstprotection->delay < options.adjusterMaxDelay) {
-        rstprotection->delay = options.adjusterMaxDelay;
-    }
+    rstprotection->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     rstprotection->throwOnButtonRelease();
     rstprotection->set_tooltip_markup (M ("TP_COLORAPP_RSTPRO_TOOLTIP"));
@@ -447,9 +429,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     contrast = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CONTRAST"), -100.0, 100.0, 0.1, 0.));
 
-    if (contrast->delay < options.adjusterMaxDelay) {
-        contrast->delay = options.adjusterMaxDelay;
-    }
+    contrast->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     contrast->throwOnButtonRelease();
     contrast->set_tooltip_markup (M ("TP_COLORAPP_CONTRAST_TOOLTIP"));
@@ -457,9 +437,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     qcontrast = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CONTRAST_Q"), -100.0, 100.0, 0.1, 0.));
 
-    if (qcontrast->delay < options.adjusterMaxDelay) {
-        qcontrast->delay = options.adjusterMaxDelay;
-    }
+    qcontrast->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     qcontrast->throwOnButtonRelease();
     qcontrast->set_tooltip_markup (M ("TP_COLORAPP_CONTRAST_Q_TOOLTIP"));
@@ -468,9 +446,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     colorh = Gtk::manage (new Adjuster (M ("TP_COLORAPP_HUE"), -100.0, 100.0, 0.1, 0.));
 
-    if (colorh->delay < options.adjusterMaxDelay) {
-        colorh->delay = options.adjusterMaxDelay;
-    }
+    colorh->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     colorh->throwOnButtonRelease();
     colorh->set_tooltip_markup (M ("TP_COLORAPP_HUE_TOOLTIP"));
@@ -618,9 +594,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 //   adaplum = Gtk::manage (new Adjuster (M ("TP_COLORAPP_ABSOLUTELUMINANCE"), 0.1,  16384., 0.1,   16.));
     adaplum = Gtk::manage (new Adjuster (M ("TP_COLORAPP_ABSOLUTELUMINANCE"), MINLA0, MAXLA0, 0.01, 16, NULL, NULL, &wbSlider2la, &wbla2Slider));
 
-    if (adaplum->delay < options.adjusterMaxDelay) {
-        adaplum->delay = options.adjusterMaxDelay;
-    }
+    adaplum->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     adaplum->throwOnButtonRelease();
     adaplum->set_tooltip_markup (M ("TP_COLORAPP_VIEWING_ABSOLUTELUMINANCE_TOOLTIP"));
@@ -631,9 +605,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
 
     degreeout  = Gtk::manage (new Adjuster (M ("TP_COLORAPP_CIECAT_DEGREE"),    0.,  100.,  1.,   90.));
 
-    if (degreeout->delay < options.adjusterMaxDelay) {
-        degreeout->delay = options.adjusterMaxDelay;
-    }
+    degreeout->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     degreeout->throwOnButtonRelease();
     degreeout->addAutoButton (M ("TP_COLORAPP_CAT02ADAPTATION_TOOLTIP"));
@@ -694,9 +666,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
     */
     badpixsl = Gtk::manage (new Adjuster (M ("TP_COLORAPP_BADPIXSL"), 0,  2, 1,  0));
 
-    if (badpixsl->delay < options.adjusterMaxDelay) {
-        badpixsl->delay = options.adjusterMaxDelay;
-    }
+    badpixsl->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     badpixsl->throwOnButtonRelease();
     badpixsl->set_tooltip_markup (M ("TP_COLORAPP_BADPIXSL_TOOLTIP"));

--- a/rtgui/colortoning.cc
+++ b/rtgui/colortoning.cc
@@ -488,11 +488,11 @@ ColorToning::ColorToning () : FoldableToolPanel(this, "colortoning", M("TP_COLOR
 
     pack_start(*labRegionBox, Gtk::PACK_EXPAND_WIDGET, 4);
 
-    labRegionSaturation->delay = options.adjusterMaxDelay;
-    labRegionSlope->delay = options.adjusterMaxDelay;
-    labRegionOffset->delay = options.adjusterMaxDelay;
-    labRegionPower->delay = options.adjusterMaxDelay;
-    labRegionMaskBlur->delay = options.adjusterMaxDelay;
+    labRegionSaturation->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    labRegionSlope->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    labRegionOffset->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    labRegionPower->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    labRegionMaskBlur->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
     //------------------------------------------------------------------------
 
     show_all();

--- a/rtgui/delayed.h
+++ b/rtgui/delayed.h
@@ -55,13 +55,13 @@ namespace delayed_helper
 
     // See https://aherrmann.github.io/programming/2016/02/28/unpacking-tuples-in-cpp14/
     template<typename F, typename T, size_t... Is>
-    constexpr void apply_impl(F f, T t, index_sequence<Is...>)
+    void apply_impl(F f, T t, index_sequence<Is...>)
     {
         f(std::get<Is>(t)...);
     }
 
     template <typename T, typename F>
-    constexpr void apply(F f, T t)
+    void apply(F f, T t)
     {
         apply_impl(f, t, make_index_sequence<std::tuple_size<T>{}>{});
     }

--- a/rtgui/delayed.h
+++ b/rtgui/delayed.h
@@ -20,13 +20,136 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <tuple>
 
 #include <glibmm/main.h>
 #include <glibmm/signalproxy.h>
 
+#include "../rtengine/noncopyable.h"
+
+namespace delayed_helper
+{
+
+    // C++14
+
+    // See https://gist.github.com/ntessore/dc17769676fb3c6daa1f
+    template<std::size_t... Is>
+    struct index_sequence
+    {
+    };
+
+    template<std::size_t N, std::size_t... Is>
+    struct make_index_sequence :
+        make_index_sequence<N-1, N-1, Is...>
+    {
+    };
+
+    template<std::size_t... Is>
+    struct make_index_sequence<0, Is...> :
+        index_sequence<Is...>
+    {
+    };
+
+    // C++17
+
+    // See https://aherrmann.github.io/programming/2016/02/28/unpacking-tuples-in-cpp14/
+    template<typename F, typename T, size_t... Is>
+    constexpr void apply_impl(F f, T t, index_sequence<Is...>)
+    {
+        f(std::get<Is>(t)...);
+    }
+
+    template <typename T, typename F>
+    constexpr void apply(F f, T t)
+    {
+        apply_impl(f, t, make_index_sequence<std::tuple_size<T>{}>{});
+    }
+
+}
+
 template<typename... Ts>
-class DelayedConnection final
+class DelayedCall final :
+    public rtengine::NonCopyable
+{
+public:
+    DelayedCall(std::function<void (Ts...)> _function, unsigned int _min_delay_ms, unsigned int _max_delay_ms = 0) :
+        function(_function),
+        min_delay_ms(_min_delay_ms),
+        max_delay_ms(_max_delay_ms)
+    {
+    }
+
+    DelayedCall(unsigned int _min_delay_ms, unsigned int _max_delay_ms = 0) :
+        DelayedCall({}, _min_delay_ms, _max_delay_ms)
+    {
+    }
+
+    void setFunction(std::function<void (Ts...)> function)
+    {
+        this->function = function;
+    }
+
+    void operator ()(Ts... ts)
+    {
+        if (!function) {
+            return;
+        }
+
+        if (!min_delay_ms) {
+            function(ts...);
+            return;
+        }
+
+        params = std::make_tuple(ts...);
+
+        min_timeout.disconnect();
+        min_timeout = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DelayedCall::onMinTimeout), min_delay_ms);
+
+        if (max_delay_ms && !max_timeout.connected()) {
+            max_timeout = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DelayedCall::onMaxTimeout), max_delay_ms);
+        }
+    }
+
+    void cancel()
+    {
+        min_timeout.disconnect();
+        max_timeout.disconnect();
+    }
+
+private:
+    bool onMinTimeout()
+    {
+        max_timeout.disconnect();
+        if (function) {
+            delayed_helper::apply(function, params);
+        }
+        return false;
+    }
+
+    bool onMaxTimeout()
+    {
+        min_timeout.disconnect();
+        if (function) {
+            delayed_helper::apply(function, params);
+        }
+        return false;
+    }
+
+    std::function<void (Ts...)> function;
+
+    unsigned int min_delay_ms;
+    unsigned int max_delay_ms;
+
+    sigc::connection min_timeout;
+    sigc::connection max_timeout;
+
+    std::tuple<Ts...> params;
+};
+
+template<typename... Ts>
+class DelayedConnection final :
+    public rtengine::NonCopyable
 {
 public:
     DelayedConnection(unsigned int _min_delay_ms, unsigned int _max_delay_ms = 0) :
@@ -45,15 +168,11 @@ public:
     void block(bool value = true)
     {
         signal.block(value);
-        min_timeout.block(value);
-        max_timeout.block(value);
     }
 
     void unblock()
     {
         signal.unblock();
-        min_timeout.unblock();
-        max_timeout.unblock();
     }
 
     void cancel()
@@ -96,50 +215,15 @@ private:
     bool onMinTimeout()
     {
         max_timeout.disconnect();
-        apply(params, slot);
+        delayed_helper::apply(slot, params);
         return false;
     }
 
     bool onMaxTimeout()
     {
         min_timeout.disconnect();
-        apply(params, slot);
+        delayed_helper::apply(slot, params);
         return false;
-    }
-
-    // C++14
-
-    // See https://gist.github.com/ntessore/dc17769676fb3c6daa1f
-    template<std::size_t... Is>
-    struct index_sequence
-    {
-    };
-
-    template<std::size_t N, std::size_t... Is>
-    struct make_index_sequence :
-        make_index_sequence<N-1, N-1, Is...>
-    {
-    };
-
-    template<std::size_t... Is>
-    struct make_index_sequence<0, Is...> :
-        index_sequence<Is...>
-    {
-    };
-
-    // C++17
-
-    // See https://aherrmann.github.io/programming/2016/02/28/unpacking-tuples-in-cpp14/
-    template<typename T, class F, size_t... Is>
-    constexpr void apply_impl(T t, F f, index_sequence<Is...>)
-    {
-        f(std::get<Is>(t)...);
-    }
-
-    template <class T, class F>
-    constexpr void apply(T t, F f)
-    {
-        apply_impl(t, f, make_index_sequence<std::tuple_size<T>{}>{});
     }
 
     unsigned int min_delay_ms;

--- a/rtgui/delayedconnection.h
+++ b/rtgui/delayedconnection.h
@@ -1,0 +1,147 @@
+/*
+ *  This file is part of RawTherapee.
+ *
+ *  Copyright (C) 2020 Flössie <floessie.mail@gmail.com>
+ *
+ *  RawTherapee is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RawTherapee is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include <glibmm/main.h>
+#include <glibmm/signalproxy.h>
+
+template<typename... Ts>
+class DelayedConnection final
+{
+public:
+    DelayedConnection(unsigned int _min_delay_ms, unsigned int _max_delay_ms = 0) :
+        min_delay_ms(_min_delay_ms),
+        max_delay_ms(_max_delay_ms)
+    {
+    }
+
+    void connect(Glib::SignalProxy<void, Ts...> signal, const sigc::slot<void, Ts...>& slot, const sigc::slot<void, Ts...>& immediate_slot = {})
+    {
+        this->slot = slot;
+        this->immediate_slot = immediate_slot;
+        this->signal = signal.connect(sigc::mem_fun(*this, &DelayedConnection::onSignal));
+    }
+
+    void block(bool value = true)
+    {
+        signal.block(value);
+        min_timeout.block(value);
+        max_timeout.block(value);
+    }
+
+    void unblock()
+    {
+        signal.unblock();
+        min_timeout.unblock();
+        max_timeout.unblock();
+    }
+
+    void cancel()
+    {
+        min_timeout.disconnect();
+        max_timeout.disconnect();
+    }
+
+private:
+    void onSignal(Ts... ts)
+    {
+        if (immediate_slot) {
+            immediate_slot(ts...);
+        }
+
+        if (!min_delay_ms) {
+            slot(ts...);
+            return;
+        }
+
+        params = std::make_tuple(ts...);
+
+        min_timeout.disconnect();
+        min_timeout = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DelayedConnection::onMinTimeout), min_delay_ms);
+
+        if (max_delay_ms && !max_timeout.connected()) {
+            max_timeout = Glib::signal_timeout().connect(sigc::mem_fun(*this, &DelayedConnection::onMaxTimeout), max_delay_ms);
+        }
+    }
+
+    bool onMinTimeout()
+    {
+        max_timeout.disconnect();
+        apply(params, slot);
+        return false;
+    }
+
+    bool onMaxTimeout()
+    {
+        min_timeout.disconnect();
+        apply(params, slot);
+        return false;
+    }
+
+    // C++14
+
+    // See https://gist.github.com/ntessore/dc17769676fb3c6daa1f
+    template<std::size_t... Is>
+    struct index_sequence
+    {
+    };
+
+    template<std::size_t N, std::size_t... Is>
+    struct make_index_sequence :
+        make_index_sequence<N-1, N-1, Is...>
+    {
+    };
+
+    template<std::size_t... Is>
+    struct make_index_sequence<0, Is...> :
+        index_sequence<Is...>
+    {
+    };
+
+    // C++17
+
+    // See https://aherrmann.github.io/programming/2016/02/28/unpacking-tuples-in-cpp14/
+    template<typename T, class F, size_t... Is>
+    constexpr void apply_impl(T t, F f, index_sequence<Is...>)
+    {
+        f(std::get<Is>(t)...);
+    }
+
+    template <class T, class F>
+    constexpr void apply(T t, F f)
+    {
+        apply_impl(t, f, make_index_sequence<std::tuple_size<T>{}>{});
+    }
+
+    const unsigned int min_delay_ms;
+    const unsigned int max_delay_ms;
+
+    sigc::connection signal;
+    sigc::connection min_timeout;
+    sigc::connection max_timeout;
+
+    sigc::slot<void, Ts...> slot;
+    sigc::slot<void, Ts...> immediate_slot;
+
+    std::tuple<Ts...> params;
+};

--- a/rtgui/delayedconnection.h
+++ b/rtgui/delayedconnection.h
@@ -62,6 +62,15 @@ public:
         max_timeout.disconnect();
     }
 
+    void setDelay(unsigned int min_delay_ms, unsigned int max_delay_ms = 0)
+    {
+        this->min_delay_ms = min_delay_ms;
+        this->max_delay_ms = max_delay_ms;
+
+        min_timeout.disconnect();
+        max_timeout.disconnect();
+    }
+
 private:
     void onSignal(Ts... ts)
     {
@@ -133,8 +142,8 @@ private:
         apply_impl(t, f, make_index_sequence<std::tuple_size<T>{}>{});
     }
 
-    const unsigned int min_delay_ms;
-    const unsigned int max_delay_ms;
+    unsigned int min_delay_ms;
+    unsigned int max_delay_ms;
 
     sigc::connection signal;
     sigc::connection min_timeout;

--- a/rtgui/filmnegative.cc
+++ b/rtgui/filmnegative.cc
@@ -36,9 +36,7 @@ Adjuster* createExponentAdjuster(AdjusterListener* listener, const Glib::ustring
     adj->setAdjusterListener(listener);
     adj->setLogScale(6, 1, true);
 
-    if (adj->delay < options.adjusterMaxDelay) {
-        adj->delay = options.adjusterMaxDelay;
-    }
+    adj->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     adj->show();
     return adj;

--- a/rtgui/flatfield.cc
+++ b/rtgui/flatfield.cc
@@ -47,9 +47,7 @@ FlatField::FlatField () : FoldableToolPanel(this, "flatfield", M("TP_FLATFIELD_L
     flatFieldBlurRadius = Gtk::manage(new Adjuster (M("TP_FLATFIELD_BLURRADIUS"), 0, 200, 2, 32));
     flatFieldBlurRadius->setAdjusterListener (this);
 
-    if (flatFieldBlurRadius->delay < options.adjusterMaxDelay) {
-        flatFieldBlurRadius->delay = options.adjusterMaxDelay;
-    }
+    flatFieldBlurRadius->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     flatFieldBlurRadius->show();
 
@@ -67,9 +65,7 @@ FlatField::FlatField () : FoldableToolPanel(this, "flatfield", M("TP_FLATFIELD_L
     flatFieldClipControl->setAdjusterListener(this);
     flatFieldClipControl->addAutoButton("");
 
-    if (flatFieldClipControl->delay < options.adjusterMaxDelay) {
-        flatFieldClipControl->delay = options.adjusterMaxDelay;
-    }
+    flatFieldClipControl->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     flatFieldClipControl->show();
     flatFieldClipControl->set_tooltip_markup (M("TP_FLATFIELD_CLIPCONTROL_TOOLTIP"));

--- a/rtgui/histogrampanel.h
+++ b/rtgui/histogrampanel.h
@@ -24,6 +24,7 @@
 
 #include <cairomm/cairomm.h>
 
+#include "delayed.h"
 #include "guiutils.h"
 #include "pointermotionlistener.h"
 
@@ -180,6 +181,8 @@ private:
 
 class HistogramPanel final : public Gtk::Grid, public PointerMotionListener, public DrawModeListener, public rtengine::NonCopyable
 {
+private:
+    DelayedCall<bool, Glib::ustring, Glib::ustring, int, int, int> pointer_moved_delayed_call;
 
 protected:
 

--- a/rtgui/iccprofilecreator.cc
+++ b/rtgui/iccprofilecreator.cc
@@ -151,9 +151,7 @@ ICCProfileCreator::ICCProfileCreator(RTWindow *rtwindow)
     aGamma = Gtk::manage(new Adjuster(M("ICCPROFCREATOR_GAMMA"), 1, 3.5, 0.00001, 2.4));
     setExpandAlignProperties(aGamma, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
 
-    if (aGamma->delay < options.adjusterMaxDelay) {
-        aGamma->delay = options.adjusterMaxDelay;
-    }
+    aGamma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     aGamma->show();
     mainGrid->attach(*aGamma, 1, 3, 1, 1); //gamma
@@ -161,9 +159,7 @@ ICCProfileCreator::ICCProfileCreator(RTWindow *rtwindow)
     aSlope = Gtk::manage(new Adjuster(M("ICCPROFCREATOR_SLOPE"), 0, 15, 0.00001, 12.92310));
     setExpandAlignProperties(aSlope, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
 
-    if (aSlope->delay < options.adjusterMaxDelay) {
-        aSlope->delay = options.adjusterMaxDelay;
-    }
+    aSlope->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     aSlope->show();
     mainGrid->attach(*aSlope, 1, 4, 1, 1); //slope
@@ -328,7 +324,7 @@ ICCProfileCreator::ICCProfileCreator(RTWindow *rtwindow)
     close->signal_clicked().connect(sigc::mem_fun(*this, &ICCProfileCreator::closePressed));
     get_action_area()->pack_start(*close);
 
-    //--------------- Show childrens
+    //--------------- Show children
 
     show_all_children();
 

--- a/rtgui/icmpanel.cc
+++ b/rtgui/icmpanel.cc
@@ -214,13 +214,9 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, "icm", M("TP_ICM_LABEL")), iuncha
     wGamma->setAdjusterListener(this);
     wSlope->setAdjusterListener(this);
 
-    if (wGamma->delay < options.adjusterMaxDelay) {
-        wGamma->delay = options.adjusterMaxDelay;
-    }
+    wGamma->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
-    if (wSlope->delay < options.adjusterMaxDelay) {
-        wSlope->delay = options.adjusterMaxDelay;
-    }
+    wSlope->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     wFrame->add(*wProfVBox);
 

--- a/rtgui/navigator.h
+++ b/rtgui/navigator.h
@@ -20,6 +20,7 @@
 
 #include <gtkmm.h>
 
+#include "delayed.h"
 #include "options.h"
 #include "pointermotionlistener.h"
 
@@ -33,6 +34,8 @@ class Navigator final :
     typedef const double (*TMatrix)[3];
 
 private:
+    DelayedCall<bool, Glib::ustring, Glib::ustring, int, int, int, int, int, bool> pointer_moved_delayed_call;
+
     Options::NavigatorUnit currentRGBUnit;
     Options::NavigatorUnit currentHSVUnit;
     void cycleUnitsRGB (GdkEventButton *event);
@@ -53,7 +56,8 @@ protected:
 public:
     PreviewWindow* previewWindow;
 
-    Navigator ();
+    Navigator();
+    ~Navigator() override;
 
     // pointermotionlistener interface
     //  void pointerMoved (bool validPos, int x, int y, int r, int g, int b);

--- a/rtgui/pdsharpening.cc
+++ b/rtgui/pdsharpening.cc
@@ -81,10 +81,10 @@ PdSharpening::PdSharpening() :
     dradiusOffset->setAdjusterListener(this);
     diter->setAdjusterListener(this);
 
-    contrast->delay = std::max(contrast->delay, options.adjusterMaxDelay);
-    dradius->delay = std::max(dradius->delay, options.adjusterMaxDelay);
-    dradiusOffset->delay = std::max(dradiusOffset->delay, options.adjusterMaxDelay);
-    diter->delay = std::max(diter->delay, options.adjusterMaxDelay);
+    contrast->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    dradius->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    dradiusOffset->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+    diter->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 }
 
 PdSharpening::~PdSharpening()

--- a/rtgui/preprocess.cc
+++ b/rtgui/preprocess.cc
@@ -46,9 +46,7 @@ PreProcess::PreProcess () : FoldableToolPanel(this, "preprocess", M("TP_PREPROCE
     hdThreshold->set_tooltip_markup (M("TP_RAW_HD_TOOLTIP"));
     hdThreshold->setAdjusterListener (this);
 
-    if (hdThreshold->delay < options.adjusterMaxDelay) {
-        hdThreshold->delay = options.adjusterMaxDelay;
-    }
+    hdThreshold->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     hdThreshold->show();
     pack_start( *hdThreshold, Gtk::PACK_SHRINK, 4);

--- a/rtgui/rawcacorrection.cc
+++ b/rtgui/rawcacorrection.cc
@@ -47,24 +47,18 @@ RAWCACorr::RAWCACorr () : FoldableToolPanel(this, "rawcacorrection", M("TP_RAWCA
     caAutoiterations->setAdjusterListener (this);
     caAutoiterations->set_tooltip_markup(M("TP_RAWCACORR_AUTOIT_TOOLTIP"));
 
-    if (caAutoiterations->delay < options.adjusterMaxDelay) {
-        caAutoiterations->delay = options.adjusterMaxDelay;
-    }
+    caAutoiterations->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     caRed = Gtk::manage(new Adjuster (M("TP_RAWCACORR_CARED"), -4.0, 4.0, 0.1, 0, icaredL, icaredR));
     caRed->setAdjusterListener (this);
 
-    if (caRed->delay < options.adjusterMaxDelay) {
-        caRed->delay = options.adjusterMaxDelay;
-    }
+    caRed->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     caRed->show();
     caBlue = Gtk::manage(new Adjuster (M("TP_RAWCACORR_CABLUE"), -8.0, 8.0, 0.1, 0, icablueL, icablueR));
     caBlue->setAdjusterListener (this);
 
-    if (caBlue->delay < options.adjusterMaxDelay) {
-        caBlue->delay = options.adjusterMaxDelay;
-    }
+    caBlue->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     caBlue->show();
 

--- a/rtgui/rawexposure.cc
+++ b/rtgui/rawexposure.cc
@@ -33,9 +33,7 @@ RAWExposure::RAWExposure () : FoldableToolPanel(this, "rawexposure", M("TP_EXPOS
     PexPos = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_LINEAR"), 0.1, 16.0, 0.01, 1));
     PexPos->setAdjusterListener (this);
 
-    if (PexPos->delay < options.adjusterMaxDelay) {
-        PexPos->delay = options.adjusterMaxDelay;
-    }
+    PexPos->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexPos->show();
     pack_start( *PexPos, Gtk::PACK_SHRINK, 4);//exposi

--- a/rtgui/retinex.cc
+++ b/rtgui/retinex.cc
@@ -488,112 +488,58 @@ Retinex::Retinex () : FoldableToolPanel (this, "retinex", M ("TP_RETINEX_LABEL")
 
 
     str->setAdjusterListener (this);
-
-    if (str->delay < 200) {
-        str->delay = 200;
-    }
+    str->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     scal->setAdjusterListener (this);
-
-    if (scal->delay < 200) {
-        scal->delay = 200;
-    }
+    scal->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     iter->setAdjusterListener (this);
-
-    if (iter->delay < 200) {
-        iter->delay = 200;
-    }
+    iter->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     grad->setAdjusterListener (this);
-
-    if (grad->delay < 200) {
-        grad->delay = 200;
-    }
+    grad->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     grads->setAdjusterListener (this);
-
-    if (grads->delay < 200) {
-        grads->delay = 200;
-    }
+    grads->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     gam->setAdjusterListener (this);
-
-    if (gam->delay < 500) {
-        gam->delay = 500;
-    }
+    gam->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay) * 2.5f);
 
     slope->setAdjusterListener (this);
-
-    if (slope->delay < 500) {
-        slope->delay = 500;
-    }
+    slope->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay) * 2.5f);
 
     neigh->setAdjusterListener (this);
-
-    if (neigh->delay < 200) {
-        neigh->delay = 200;
-    }
+    neigh->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     offs->setAdjusterListener (this);
-
-    if (offs->delay < 200) {
-        offs->delay = 200;
-    }
+    offs->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     vart->setAdjusterListener (this);
-
-    if (vart->delay < 200) {
-        vart->delay = 200;
-    }
+    offs->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     limd->setAdjusterListener (this);
-
-    if (limd->delay < 200) {
-        limd->delay = 200;
-    }
+    limd->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     highl->setAdjusterListener (this);
-
-    if (highl->delay < 200) {
-        highl->delay = 200;
-    }
+    highl->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     radius->setAdjusterListener (this);
-
-    if (radius->delay < 200) {
-        radius->delay = 200;
-    }
+    radius->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     highlights->setAdjusterListener (this);
-
-    if (highlights->delay < 200) {
-        highlights->delay = 200;
-    }
+    highlights->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     h_tonalwidth->setAdjusterListener (this);
-
-    if (h_tonalwidth->delay < 200) {
-        h_tonalwidth->delay = 200;
-    }
+    h_tonalwidth->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     shadows->setAdjusterListener (this);
-
-    if (shadows->delay < 200) {
-        shadows->delay = 200;
-    }
+    shadows->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     s_tonalwidth->setAdjusterListener (this);
-
-    if (s_tonalwidth->delay < 200) {
-        s_tonalwidth->delay = 200;
-    }
+    s_tonalwidth->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     skal->setAdjusterListener (this);
-
-    if (skal->delay < 200) {
-        skal->delay = 200;
-    }
+    skal->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     disableListener();
     retinexColorSpaceChanged();

--- a/rtgui/sharpenedge.cc
+++ b/rtgui/sharpenedge.cc
@@ -36,16 +36,12 @@ SharpenEdge::SharpenEdge () : FoldableToolPanel(this, "sharpenedge", M("TP_SHARP
     passes = Gtk::manage(new Adjuster (M("TP_SHARPENEDGE_PASSES"), 1, 4, 1, 2));
     passes->setAdjusterListener (this);
 
-    if (passes->delay < options.adjusterMaxDelay) {
-        passes->delay = options.adjusterMaxDelay;
-    }
+    passes->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     amount = Gtk::manage(new Adjuster (M("TP_SHARPENEDGE_AMOUNT"), 0, 100, 1, 50));
     amount->setAdjusterListener (this);
 
-    if (amount->delay < options.adjusterMaxDelay) {
-        amount->delay = options.adjusterMaxDelay;
-    }
+    amount->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     threechannels = Gtk::manage(new Gtk::CheckButton((M("TP_SHARPENEDGE_THREE"))));// L + a + b
     threechannels->set_active (false);

--- a/rtgui/xtransprocess.cc
+++ b/rtgui/xtransprocess.cc
@@ -79,9 +79,7 @@ XTransProcess::XTransProcess () : FoldableToolPanel(this, "xtransprocess", M("TP
     dualDemosaicContrast->addAutoButton(M("TP_RAW_DUALDEMOSAICAUTOCONTRAST_TOOLTIP"));
     dualDemosaicContrast->setAutoValue(true);
 
-    if (dualDemosaicContrast->delay < options.adjusterMaxDelay) {
-        dualDemosaicContrast->delay = options.adjusterMaxDelay;
-    }
+    dualDemosaicContrast->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     dualDemosaicContrast->show();
     dualDemosaicOptions->pack_start(*dualDemosaicContrast);
@@ -91,9 +89,7 @@ XTransProcess::XTransProcess () : FoldableToolPanel(this, "xtransprocess", M("TP
     border = Gtk::manage(new Adjuster(M("TP_RAW_BORDER"), 0, 16, 1, 7));
     border->setAdjusterListener (this);
 
-    if (border->delay < options.adjusterMaxDelay) {
-        border->delay = options.adjusterMaxDelay;
-    }
+    border->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     border->show();
     borderbox->pack_start(*border);
@@ -103,9 +99,7 @@ XTransProcess::XTransProcess () : FoldableToolPanel(this, "xtransprocess", M("TP
     ccSteps = Gtk::manage (new Adjuster (M("TP_RAW_FALSECOLOR"), 0, 5, 1, 0 ));
     ccSteps->setAdjusterListener (this);
 
-    if (ccSteps->delay < options.adjusterMaxDelay) {
-        ccSteps->delay = options.adjusterMaxDelay;
-    }
+    ccSteps->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     ccSteps->show();
     pack_start( *ccSteps, Gtk::PACK_SHRINK, 4);

--- a/rtgui/xtransrawexposure.cc
+++ b/rtgui/xtransrawexposure.cc
@@ -33,25 +33,19 @@ XTransRAWExposure::XTransRAWExposure () : FoldableToolPanel(this, "xtransrawexpo
     PexBlackRed = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_RED"), -2048, 2048, 1.0, 0)); //black level
     PexBlackRed->setAdjusterListener (this);
 
-    if (PexBlackRed->delay < options.adjusterMaxDelay) {
-        PexBlackRed->delay = options.adjusterMaxDelay;
-    }
+    PexBlackRed->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlackRed->show();
     PexBlackGreen = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_GREEN"), -2048, 2048, 1.0, 0)); //black level
     PexBlackGreen->setAdjusterListener (this);
 
-    if (PexBlackGreen->delay < options.adjusterMaxDelay) {
-        PexBlackGreen->delay = options.adjusterMaxDelay;
-    }
+    PexBlackGreen->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlackGreen->show();
     PexBlackBlue = Gtk::manage(new Adjuster (M("TP_RAWEXPOS_BLACK_BLUE"), -2048, 2048, 1.0, 0)); //black level
     PexBlackBlue->setAdjusterListener (this);
 
-    if (PexBlackBlue->delay < options.adjusterMaxDelay) {
-        PexBlackBlue->delay = options.adjusterMaxDelay;
-    }
+    PexBlackBlue->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
     PexBlackBlue->show();
 


### PR DESCRIPTION
Hello fellow RawTherapists,

I've added a little facility in `rtgui/delayed.h` as a generic solution to #5813. I started with something for `adjuster.h`, that's why the branch is called `delayed_connection`.

The interesting thing was to come up with an idea on how to store and especially replay a function call. While it was relatively clear that a `std::tuple<>` was the right "container" to store the parameters, a bit of research was necessary for the replaying. I've added the references in the code. Should we ever switch to C++17, the solution is already there, namely [`std::apply()`](https://en.cppreference.com/w/cpp/utility/apply).

Hope you like it,
Flössie