### PR TITLE
Fix wrong minimum calculation in ImProcFunctions::Aver()

### DIFF
--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -2271,7 +2271,7 @@ void ImProcFunctions::Aver(const float* RESTRICT DataList, int datalen, float &a
     #pragma omp parallel num_threads(numThreads) if (numThreads>1)
 #endif
     {
-        float lmax = 0.f, lmin = 0.f;
+        float lmax = 0.f, lmin = RT_INFINITY_F;
 #ifdef _OPENMP
         #pragma omp for reduction(+:averaP,averaN,countP,countN) nowait
 #endif


### PR DESCRIPTION
This fixes a wrong minimum calculation (probably introduced by me long time ago) in the function `ImProcFunctions::Aver()`
The old code never gave a min > 0
@Desmis Jacques, please confirm