### PR TITLE
Local adjustments - Log encoding - addition of ciecam processes

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1210,6 +1210,7 @@ HISTORY_MSG_961;Local - Log encoding Ciecam
 HISTORY_MSG_962;Local - Log encoding  Absolute luminance source
 HISTORY_MSG_963;Local - Log encoding  Absolute luminance target
 HISTORY_MSG_964;Local - Log encoding  Surround
+HISTORY_MSG_965;Local - Log encoding  Saturation
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2452,7 +2452,8 @@ TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. 
 TP_LOCALLAB_CHROMASK_TOOLTIP;You can use this slider to desaturated background (inverse mask - curve near 0).\nAlso to attenuate or enhance the action of a mask on the chroma
 TP_LOCALLAB_CHRRT;Chroma
 TP_LOCALLAB_CIEC;Use Ciecam environment parameters
-TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as part of the second (contrast J, saturation s) , as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
+//TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as part of the second (contrast J, saturation s) , as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
+TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nThe first Ciecam process 'Scene conditions' is carried out by Log encoding, it also uses 'Absolute luminance' at the time of the shooting.\nThe second Ciecam process  'Image adjustments' is simplified and uses only 3 variables (local contrast, contrast J, saturation s).\nThe third Ciecam process  'Viewing conditions' adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma
@@ -2675,15 +2676,23 @@ TP_LOCALLAB_LOGAUTO;Automatic
 TP_LOCALLAB_LOGAUTO_TOOLTIP;Pressing this button will calculate the dynamic range and Source Gray Point (if "Automatic Source Gray Point” enabled).\nPress the button again to adjust the automatically calculated values.
 TP_LOCALLAB_LOGBASE_TOOLTIP;Default = 2.\nValues less than 2 reduce the action of the algorithm making the shadows darker and the highlights brighter.\nWith values greater than 2, the shadows are grayer and the highlights become more washed out.
 TP_LOCALLAB_LOGBLACKWHEV_TOOLTIP;Estimated values of Dynamic Range i.e. Black Ev and White Ev
+TP_LOCALLAB_LOGCONTL_TOOLTIP;Contrast (J) in CIECAM02 takes into account the increase in perceived coloration with luminance.
+TP_LOCALLAB_LOGDETAIL_TOOLTIP;Acts mainly on high frequencies.
+TP_LOCALLAB_LOGCATAD_TOOLTIP;The chromatic adaptation allows us to interpret a color according to its spatio-temporal environment.\nUseful when the white balance is far from reference D50.\nAdapts colors to the illuminant of the output device.
 TP_LOCALLAB_LOGENCOD_TOOLTIP;Tone Mapping with Logarithmic encoding (ACES).\nUseful for underexposed images or images with high dynamic range.\n\nTwo-step process : 1) Dynamic Range calculation 2) Manual adjustment
-TP_LOCALLAB_LOGFRA;Source
-TP_LOCALLAB_LOG2FRA;Target
-TP_LOCALLAB_LOGFRAME_TOOLTIP;Allows you to calculate and adjust the Ev levels and the Source Gray Point for the spot area. The resulting values will be used by all Lab operations and most RGB operations in the pipeline.\n Takes into account exposure compensation in the main-menu Exposure tab.
+TP_LOCALLAB_LOGFRA;Scene Conditions
+TP_LOCALLAB_LOG1FRA;Image Adjustments
+TP_LOCALLAB_LOG2FRA;Viewing Conditions
+TP_LOCALLAB_LOGFRAME_TOOLTIP;Allows you to calculate and adjust the Ev levels and the Source Gray Point for the spot area. The resulting values will be used by all Lab operations and most RGB operations in the pipeline.\nTakes into account exposure compensation in the main-menu Exposure tab.\nAlso calculates the absolute luminance at the time of the shooting.
+TP_LOCALLAB_LOGIMAGE_TOOLTIP;Corresponds to the treatment of correlated Ciecam variables (here mainly Contrast 'J' and Saturation 's').
 TP_LOCALLAB_LOGLIN;Logarithm mode
 TP_LOCALLAB_LOGPFRA;Relative Exposure Levels
+TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and high light tones
+TP_LOCALLAB_LOGSCENE_TOOLTIP;Corresponds to the shooting conditions.
 TP_LOCALLAB_LOGSRCGREY_TOOLTIP;Estimated gray point value of the image.
 TP_LOCALLAB_LOGTARGGREY_TOOLTIP;You can adjust this value to suit.
 TP_LOCALLAB_LOG_TOOLNAME;Log Encoding - 0
+TP_LOCALLAB_LOGVIEWING_TOOLTIP;Corresponds to the medium on which the final image will be viewed (monitor, TV, projector, printer,..), as well as its environment.
 TP_LOCALLAB_LUM;Curves LL - CC
 TP_LOCALLAB_LUMADARKEST;Darkest
 TP_LOCALLAB_LUMASK;Background color for luminance and color masks

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2684,10 +2684,10 @@ TP_LOCALLAB_LOGFRA;Scene Conditions
 TP_LOCALLAB_LOG1FRA;Image Adjustments
 TP_LOCALLAB_LOG2FRA;Viewing Conditions
 TP_LOCALLAB_LOGFRAME_TOOLTIP;Allows you to calculate and adjust the Ev levels and the Source Gray Point for the spot area. The resulting values will be used by all Lab operations and most RGB operations in the pipeline.\nTakes into account exposure compensation in the main-menu Exposure tab.\nAlso calculates the absolute luminance at the time of the shooting.
-TP_LOCALLAB_LOGIMAGE_TOOLTIP;Corresponds to the treatment of correlated Ciecam variables (here mainly Contrast 'J' and Saturation 's').
+TP_LOCALLAB_LOGIMAGE_TOOLTIP;Takes into account corresponding Ciecam variables (mainly Contrast 'J' and Saturation 's').
 TP_LOCALLAB_LOGLIN;Logarithm mode
 TP_LOCALLAB_LOGPFRA;Relative Exposure Levels
-TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and high light tones
+TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and highlights tones
 TP_LOCALLAB_LOGSCENE_TOOLTIP;Corresponds to the shooting conditions.
 TP_LOCALLAB_LOGSRCGREY_TOOLTIP;Estimated gray point value of the image.
 TP_LOCALLAB_LOGTARGGREY_TOOLTIP;You can adjust this value to suit.

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1203,14 +1203,15 @@ HISTORY_MSG_954;Local - Show-hide tools
 HISTORY_MSG_955;Local - Enable Spot
 HISTORY_MSG_956;Local - CH Curve
 HISTORY_MSG_957;Local - Denoise mode
-HISTORY_MSG_958;Local - Show/hide settings
 HISTORY_MSG_959;Local - Inverse blur
+HISTORY_MSG_958;Local - Show/hide settings
 HISTORY_MSG_960;Local - Log encoding - cat02
 HISTORY_MSG_961;Local - Log encoding Ciecam
 HISTORY_MSG_962;Local - Log encoding  Absolute luminance source
 HISTORY_MSG_963;Local - Log encoding  Absolute luminance target
 HISTORY_MSG_964;Local - Log encoding  Surround
-HISTORY_MSG_965;Local - Log encoding  Saturation
+HISTORY_MSG_965;Local - Log encoding  Saturation s
+HISTORY_MSG_966;Local - Log encoding  Contrast J
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
@@ -2451,7 +2452,7 @@ TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. 
 TP_LOCALLAB_CHROMASK_TOOLTIP;You can use this slider to desaturated background (inverse mask - curve near 0).\nAlso to attenuate or enhance the action of a mask on the chroma
 TP_LOCALLAB_CHRRT;Chroma
 TP_LOCALLAB_CIEC;Use Ciecam environment parameters
-TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
+TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as part of the second (contrast J, saturation s) , as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma
@@ -2479,6 +2480,7 @@ TP_LOCALLAB_COMPREFRA;Wavelet level tone mapping
 TP_LOCALLAB_COMPRESS_TOOLTIP;Use if necessary the module 'Clarity & Sharp mask and Blend & Soften Images' by adjusting 'Soft radius' to reduce artifacts.
 TP_LOCALLAB_CONTCOL;Contrast threshold
 TP_LOCALLAB_CONTFRA;Contrast by level
+TP_LOCALLAB_CONTL;Contrast (J)
 TP_LOCALLAB_CONTTHMASK_TOOLTIP;Allows you to determine which parts of the image will be impacted based on the texture.
 TP_LOCALLAB_CONTRAST;Contrast
 TP_LOCALLAB_CONTRASTCURVMASK1_TOOLTIP;Allows you to freely modify the contrast of the mask (gamma & slope), instead of using a continuous & progressive curve. However it can create artifacts that have to be dealt with using the “Smooth radius” or “Laplacian threshold sliders”.
@@ -2821,6 +2823,7 @@ TP_LOCALLAB_RGBCURVE_TOOLTIP;In RGB mode you have 4 choices : Standard, Weighted
 TP_LOCALLAB_ROW_NVIS;Not visible
 TP_LOCALLAB_ROW_VIS;Visible
 TP_LOCALLAB_SATUR;Saturation
+TP_LOCALLAB_SATURV;Saturation (s)
 TP_LOCALLAB_SAVREST;Save - Restore Current Image
 TP_LOCALLAB_SCALEGR;Scale
 TP_LOCALLAB_SCALERETI;Scale

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2449,8 +2449,8 @@ TP_LOCALLAB_CHROMASKCOL;Chroma
 TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. C(C) or LC(H) is activated).
 TP_LOCALLAB_CHROMASK_TOOLTIP;You can use this slider to desaturated background (inverse mask - curve near 0).\nAlso to attenuate or enhance the action of a mask on the chroma
 TP_LOCALLAB_CHRRT;Chroma
-TP_LOCALLAB_CIEC;Uses Ciecam's environment variables (partially)
-TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as some data from the first one (Scene conditions - Source)which is realized with Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the dislay environment. 
+TP_LOCALLAB_CIEC;Use Ciecam environment parameters
+TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2449,7 +2449,8 @@ TP_LOCALLAB_CHROMASKCOL;Chroma
 TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. C(C) or LC(H) is activated).
 TP_LOCALLAB_CHROMASK_TOOLTIP;You can use this slider to desaturated background (inverse mask - curve near 0).\nAlso to attenuate or enhance the action of a mask on the chroma
 TP_LOCALLAB_CHRRT;Chroma
-TP_LOCALLAB_CIEC;Uses ciecam's environment variables (partially)
+TP_LOCALLAB_CIEC;Uses Ciecam's environment variables (partially)
+TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as some data from the first one (Scene conditions - Source)which is realized with Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the dislay environment. 
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1118,7 +1118,6 @@ HISTORY_MSG_864;Local - Wavelet dir contrast attenuation
 HISTORY_MSG_865;Local - Wavelet dir contrast delta
 HISTORY_MSG_866;Local - Wavelet dir compression
 HISTORY_MSG_869;Local - Denoise by level
-
 HISTORY_MSG_870;Local - Wavelet mask curve H
 HISTORY_MSG_871;Local - Wavelet mask curve C
 HISTORY_MSG_872;Local - Wavelet mask curve L
@@ -1207,6 +1206,10 @@ HISTORY_MSG_957;Local - Denoise mode
 HISTORY_MSG_958;Local - Show/hide settings
 HISTORY_MSG_959;Local - Inverse blur
 HISTORY_MSG_960;Local - Log encoding - cat02
+HISTORY_MSG_961;Local - Log encoding Ciecam
+HISTORY_MSG_962;Local - Log encoding  Absolute luminance source
+HISTORY_MSG_963;Local - Log encoding  Absolute luminance target
+HISTORY_MSG_964;Local - Log encoding  Surround
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
@@ -2446,6 +2449,7 @@ TP_LOCALLAB_CHROMASKCOL;Chroma
 TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. C(C) or LC(H) is activated).
 TP_LOCALLAB_CHROMASK_TOOLTIP;You can use this slider to desaturated background (inverse mask - curve near 0).\nAlso to attenuate or enhance the action of a mask on the chroma
 TP_LOCALLAB_CHRRT;Chroma
+TP_LOCALLAB_CIEC;Uses ciecam's environment variables (partially)
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma
@@ -2892,6 +2896,7 @@ TP_LOCALLAB_SOFTRADIUSCOL_TOOLTIP;Applies a guided filter to the output image to
 TP_LOCALLAB_SOFTRETI;Reduce ΔE artifacts 
 TP_LOCALLAB_SOFTRETI_TOOLTIP;Take into account deltaE to improve Transmission map
 TP_LOCALLAB_SOFT_TOOLNAME;Soft Light & Original Retinex - 6
+TP_LOCALLAB_SOURCE_ABS;Absolute luminance
 TP_LOCALLAB_SOURCE_GRAY;Mean luminance (Yb%)
 TP_LOCALLAB_SPECCASE;Specific cases
 TP_LOCALLAB_SPECIAL;Special use of RGB curves

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -745,6 +745,8 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
                 float *sourceg = nullptr;
                 sourceg = new float[sizespot];
+                float *sourceab = nullptr;
+                sourceab = new float[sizespot];
                 float *targetg = nullptr;
                 targetg = new float[sizespot];
                 bool *log = nullptr;
@@ -777,6 +779,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     blackev[sp] = params->locallab.spots.at(sp).blackEv;
                     whiteev[sp] = params->locallab.spots.at(sp).whiteEv;
                     sourceg[sp] = params->locallab.spots.at(sp).sourceGray;
+                    sourceab[sp] = params->locallab.spots.at(sp).sourceabs;
                     Autogr[sp] = params->locallab.spots.at(sp).Autogray;
                     targetg[sp] = params->locallab.spots.at(sp).targetGray;
                     locx[sp] = params->locallab.spots.at(sp).loc.at(0) / 2000.0;
@@ -806,14 +809,15 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                             xend = 1.f;
                         }
 
-                        ipf.getAutoLogloc(sp, imgsrc, sourceg, blackev, whiteev, Autogr, fw, fh, xsta, xend, ysta, yend, SCALE);
+                        ipf.getAutoLogloc(sp, imgsrc, sourceg, blackev, whiteev, Autogr, sourceab, fw, fh, xsta, xend, ysta, yend, SCALE);
 
                         params->locallab.spots.at(sp).blackEv = blackev[sp];
                         params->locallab.spots.at(sp).whiteEv = whiteev[sp];
                         params->locallab.spots.at(sp).sourceGray = sourceg[sp];
+                        params->locallab.spots.at(sp).sourceabs = sourceab[sp];
 
                         if (locallListener) {
-                            locallListener->logencodChanged(blackev[sp], whiteev[sp], sourceg[sp], targetg[sp]);
+                            locallListener->logencodChanged(blackev[sp], whiteev[sp], sourceg[sp], sourceab[sp], targetg[sp]);
                         }
                     }
                 }
@@ -829,6 +833,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 delete [] whiteev;
                 delete [] blackev;
                 delete [] targetg;
+                delete [] sourceab;
                 delete [] sourceg;
                 delete [] log;
                 delete [] autocomput;

--- a/rtengine/improcfun.h
+++ b/rtengine/improcfun.h
@@ -175,7 +175,7 @@ public:
     void moyeqt(Imagefloat* working, float &moyS, float &eqty);
 
     void luminanceCurve(LabImage* lold, LabImage* lnew, const LUTf &curve);
-    void ciecamloc_02float(int sp, LabImage* lab);
+    void ciecamloc_02float(int sp, LabImage* lab, int call);
 
     void ciecam_02float(CieImage* ncie, float adap, int pW, int pwb, LabImage* lab, const procparams::ProcParams* params,
                         const ColorAppearance & customColCurve1, const ColorAppearance & customColCurve, const ColorAppearance & customColCurve3,

--- a/rtengine/improcfun.h
+++ b/rtengine/improcfun.h
@@ -264,7 +264,7 @@ public:
     //3 functions from Alberto Griggio, adapted J.Desmis 2019
     void filmGrain(Imagefloat *rgb, int isogr, int strengr, int scalegr, int bfw, int bfh);
     void log_encode(Imagefloat *rgb, struct local_params & lp, bool multiThread, int bfw, int bfh);
-    void getAutoLogloc(int sp, ImageSource *imgsrc, float *sourceg, float *blackev, float *whiteev, bool *Autogr, int fw, int fh, float xsta, float xend, float ysta, float yend, int SCALE);
+    void getAutoLogloc(int sp, ImageSource *imgsrc, float *sourceg, float *blackev, float *whiteev, bool *Autogr, float *sourceab, int fw, int fh, float xsta, float xend, float ysta, float yend, int SCALE);
 
     void MSRLocal(int call, int sp, bool fftw, int lum, float** reducDE, LabImage * bufreti, LabImage * bufmask, LabImage * buforig, LabImage * buforigmas, float** luminance, const float* const *originalLuminance,
         const int width, const int height, int bfwr, int bfhr, const procparams::LocallabParams &loc, const int skip, const LocretigainCurve &locRETgainCcurve, const LocretitransCurve &locRETtransCcurve,

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -1837,11 +1837,13 @@ void ImProcFunctions::getAutoLogloc(int sp, ImageSource *imgsrc, float *sourceg,
                 }
             }
         }
-
         const float gray = sourceg[sp] / 100.f;
         whiteev[sp] = xlogf(maxVal / gray) / log2;
         blackev[sp] = whiteev[sp] - dynamic_range;
-        
+
+
+        //calculate La - Absolute luminance shooting
+
         const FramesMetaData* metaData = imgsrc->getMetaData();
         int imgNum = 0;
 
@@ -2103,7 +2105,6 @@ void tone_eq(array2D<float> &R, array2D<float> &G, array2D<float> &B,  const str
 
 void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
 {
-    //be careful quasi duplicate with branch cat02wb
     //BENCHFUN
     bool ciec = false;
     if (params->locallab.spots.at(sp).ciecam && params->locallab.spots.at(sp).explog && call == 1) {
@@ -2121,6 +2122,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     double Xwsc, Zwsc;
 
     LUTu hist16J;
+    //for J light and contrast
     LUTf CAMBrightCurveJ;
     CAMBrightCurveJ(32768, LUT_CLIP_ABOVE);
     CAMBrightCurveJ.dirty = true;
@@ -2209,7 +2211,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     
     float contL = 0.f;
     if (ciec) {
-        contL = 0.6f *params->locallab.spots.at(sp).contl;
+        contL = 0.6f *params->locallab.spots.at(sp).contl;//0.6 less effect, no need 1.
    
         if (CAMBrightCurveJ.dirty) {
             Ciecam02::curveJfloat(0.f, contL, hist16J, CAMBrightCurveJ); //contrast J
@@ -2264,8 +2266,6 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
         }
     }
 
-    //with which algorithm
-    //  alg = 0;
 
 
     xwd = 100.0 * Xwout;
@@ -2290,7 +2290,6 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     const float pilotout = 2.f;
 
     //algoritm's params
-    // const float rstprotection = 100. ;//- params->colorappearance.rstprotection;
     LUTu hist16Q;
     float yb = 18.f;
     yb2 = 18;

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -2100,12 +2100,12 @@ void tone_eq(array2D<float> &R, array2D<float> &G, array2D<float> &B,  const str
 }
 
 
-void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab)
+void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
 {
     //be careful quasi duplicate with branch cat02wb
     //BENCHFUN
     bool ciec = false;
-    if (params->locallab.spots.at(sp).ciecam) {
+    if (params->locallab.spots.at(sp).ciecam && params->locallab.spots.at(sp).explog && call == 1) {
         ciec = true;
     }
     int width = lab->W, height = lab->H;
@@ -2120,11 +2120,11 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab)
     double Xwsc, Zwsc;
 
     int tempo = 5000;
-    if(!ciec) {
+    if(params->locallab.spots.at(sp).expvibrance && call == 2) {
         if (params->locallab.spots.at(sp).warm > 0) {
             tempo = 5000 - 30 * params->locallab.spots.at(sp).warm;
         } else if (params->locallab.spots.at(sp).warm < 0){
-            tempo = 5000 - 49 * params->locallab.spots.at(sp).warm;
+            tempo = 5000 - 70 * params->locallab.spots.at(sp).warm;
         }
     }
 
@@ -2132,7 +2132,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab)
         if (params->locallab.spots.at(sp).catad > 0) {
             tempo = 5000 - 30 * params->locallab.spots.at(sp).catad;
         } else if (params->locallab.spots.at(sp).catad < 0){
-            tempo = 5000 - 49 * params->locallab.spots.at(sp).catad;
+            tempo = 5000 - 70 * params->locallab.spots.at(sp).catad;
         }
     }
 
@@ -2211,7 +2211,11 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab)
     yw = 100.f * Yw;
     zw = 100.0 * Zw;
     float xw1 = xws, yw1 = yws, zw1 = zws, xw2 = xwd, yw2 = ywd, zw2 = zwd;
-
+/*    
+            xw1 = 96.46f;    //use RT WB; CAT 02 is used for output device (see prefreneces)
+            yw1 = 100.0f;
+            zw1 = 82.445f;
+*/
     float cz, wh, pfl;
     Ciecam02::initcam1float(yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c);
 //   const float chr = 0.f;
@@ -9760,7 +9764,7 @@ void ImProcFunctions::Lab_Local(
             rgb2lab(*(tmpImage.get()), *bufexpfin, params->icm.workingProfile);
             tmpImage.reset();
             if (params->locallab.spots.at(sp).ciecam) {
-                ImProcFunctions::ciecamloc_02float(sp, bufexpfin.get());
+                ImProcFunctions::ciecamloc_02float(sp, bufexpfin.get(), 1);
             }
 
             //here begin graduated filter
@@ -10885,7 +10889,7 @@ void ImProcFunctions::Lab_Local(
                     ImProcFunctions::vibrance(bufexpfin.get(), vibranceParams, params->toneCurve.hrenabled, params->icm.workingProfile);
 
                     if (params->locallab.spots.at(sp).warm != 0) {
-                        ImProcFunctions::ciecamloc_02float(sp, bufexpfin.get());
+                        ImProcFunctions::ciecamloc_02float(sp, bufexpfin.get(), 2);
                     }
 
 

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -1575,7 +1575,8 @@ void ImProcFunctions::log_encode(Imagefloat *rgb, struct local_params & lp, bool
         dynamic_range = 0.5f;
     }
     const float noise = pow_F(2.f, -16.f);
-    const float log2 = xlogf(lp.baselog);
+   // const float log2 = xlogf(lp.baselog);
+    const float log2 = xlogf(2.f);
     const float base = lp.targetgray > 1 && lp.targetgray < 100 && dynamic_range > 0 ? find_gray(std::abs(lp.blackev) / dynamic_range, lp.targetgray / 100.f) : 0.f;
     const float linbase = rtengine::max(base, 0.f);
     TMatrix ws = ICCStore::getInstance()->workingSpaceMatrix(params->icm.workingProfile);

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -987,6 +987,7 @@ enum ProcEventCode {
     Evlocallabsourceabs = 961,
     Evlocallabtargabs = 962,
     Evlocallabsurround = 963,
+    Evlocallabsaturl = 964,
 
     NUMOFEVENTS
 };

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -988,6 +988,7 @@ enum ProcEventCode {
     Evlocallabtargabs = 962,
     Evlocallabsurround = 963,
     Evlocallabsaturl = 964,
+    Evlocallabcontl = 965,
 
     NUMOFEVENTS
 };

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -983,6 +983,10 @@ enum ProcEventCode {
     Evlocallabhishow = 957,
     Evlocallabinvbl = 958,
     Evlocallabcatad = 959,
+    Evlocallabciecam = 960,
+    Evlocallabsourceabs = 961,
+    Evlocallabtargabs = 962,
+    Evlocallabsurround = 963,
 
     NUMOFEVENTS
 };

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -3841,6 +3841,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     targabs(16.),
     targetGray(18.),
     catad(0.),
+    saturl(0.),
     Autogray(true),
     fullimage(true),
     ciecam(false),
@@ -4423,6 +4424,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && targabs == other.targabs
         && targetGray == other.targetGray
         && catad == other.catad
+        && saturl == other.saturl
         && Autogray == other.Autogray
         && fullimage == other.fullimage
         && ciecam == other.ciecam
@@ -5962,6 +5964,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                     saveToKeyfile(!pedited || spot_edited->targabs, "Locallab", "Targabs_" + index_str, spot.targabs, keyFile);
                     saveToKeyfile(!pedited || spot_edited->targetGray, "Locallab", "TargetGray_" + index_str, spot.targetGray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->catad, "Locallab", "Catad_" + index_str, spot.catad, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->saturl, "Locallab", "Saturl_" + index_str, spot.saturl, keyFile);
                     saveToKeyfile(!pedited || spot_edited->Autogray, "Locallab", "Autogray_" + index_str, spot.Autogray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->fullimage, "Locallab", "Fullimage_" + index_str, spot.fullimage, keyFile);
                     saveToKeyfile(!pedited || spot_edited->ciecam, "Locallab", "Ciecam_" + index_str, spot.ciecam, keyFile);
@@ -7743,6 +7746,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "Targabs_" + index_str, pedited, spot.targabs, spotEdited.targabs);
                 assignFromKeyfile(keyFile, "Locallab", "TargetGray_" + index_str, pedited, spot.targetGray, spotEdited.targetGray);
                 assignFromKeyfile(keyFile, "Locallab", "Catad_" + index_str, pedited, spot.catad, spotEdited.catad);
+                assignFromKeyfile(keyFile, "Locallab", "Saturl_" + index_str, pedited, spot.saturl, spotEdited.saturl);
                 assignFromKeyfile(keyFile, "Locallab", "AutoGray_" + index_str, pedited, spot.Autogray, spotEdited.Autogray);
                 assignFromKeyfile(keyFile, "Locallab", "Fullimage_" + index_str, pedited, spot.fullimage, spotEdited.fullimage);
                 assignFromKeyfile(keyFile, "Locallab", "Ciecam_" + index_str, pedited, spot.ciecam, spotEdited.ciecam);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -3842,6 +3842,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     targetGray(18.),
     catad(0.),
     saturl(0.),
+    contl(0.),
     Autogray(true),
     fullimage(true),
     ciecam(false),
@@ -4425,6 +4426,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && targetGray == other.targetGray
         && catad == other.catad
         && saturl == other.saturl
+        && contl == other.contl
         && Autogray == other.Autogray
         && fullimage == other.fullimage
         && ciecam == other.ciecam
@@ -5965,6 +5967,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                     saveToKeyfile(!pedited || spot_edited->targetGray, "Locallab", "TargetGray_" + index_str, spot.targetGray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->catad, "Locallab", "Catad_" + index_str, spot.catad, keyFile);
                     saveToKeyfile(!pedited || spot_edited->saturl, "Locallab", "Saturl_" + index_str, spot.saturl, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->contl, "Locallab", "Contl_" + index_str, spot.contl, keyFile);
                     saveToKeyfile(!pedited || spot_edited->Autogray, "Locallab", "Autogray_" + index_str, spot.Autogray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->fullimage, "Locallab", "Fullimage_" + index_str, spot.fullimage, keyFile);
                     saveToKeyfile(!pedited || spot_edited->ciecam, "Locallab", "Ciecam_" + index_str, spot.ciecam, keyFile);
@@ -7747,6 +7750,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "TargetGray_" + index_str, pedited, spot.targetGray, spotEdited.targetGray);
                 assignFromKeyfile(keyFile, "Locallab", "Catad_" + index_str, pedited, spot.catad, spotEdited.catad);
                 assignFromKeyfile(keyFile, "Locallab", "Saturl_" + index_str, pedited, spot.saturl, spotEdited.saturl);
+                assignFromKeyfile(keyFile, "Locallab", "Contl_" + index_str, pedited, spot.contl, spotEdited.contl);
                 assignFromKeyfile(keyFile, "Locallab", "AutoGray_" + index_str, pedited, spot.Autogray, spotEdited.Autogray);
                 assignFromKeyfile(keyFile, "Locallab", "Fullimage_" + index_str, pedited, spot.fullimage, spotEdited.fullimage);
                 assignFromKeyfile(keyFile, "Locallab", "Ciecam_" + index_str, pedited, spot.ciecam, spotEdited.ciecam);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -3837,14 +3837,18 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     explog(false),
     autocompute(false),
     sourceGray(10.),
+    sourceabs(2000.),
+    targabs(16.),
     targetGray(18.),
     catad(0.),
     Autogray(true),
     fullimage(true),
+    ciecam(false),
     blackEv(-5.0),
     whiteEv(10.0),
     detail(0.6),
     sensilog(60),
+    surround("Average"),
     baselog(2.),
     strlog(0.0),
     anglog(0.0),
@@ -4415,15 +4419,19 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && explog == other.explog
         && autocompute == other.autocompute
         && sourceGray == other.sourceGray
+        && sourceabs == other.sourceabs
+        && targabs == other.targabs
         && targetGray == other.targetGray
         && catad == other.catad
         && Autogray == other.Autogray
         && fullimage == other.fullimage
+        && ciecam == other.ciecam
         && blackEv == other.blackEv
         && whiteEv == other.whiteEv
         && detail == other.detail
         && sensilog == other.sensilog
         && baselog == other.baselog
+        && surround == other.surround
         && strlog == other.strlog
         && anglog == other.anglog
         // mask
@@ -5950,15 +5958,19 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                     saveToKeyfile(!pedited || spot_edited->explog, "Locallab", "Explog_" + index_str, spot.explog, keyFile);
                     saveToKeyfile(!pedited || spot_edited->autocompute, "Locallab", "Autocompute_" + index_str, spot.autocompute, keyFile);
                     saveToKeyfile(!pedited || spot_edited->sourceGray, "Locallab", "SourceGray_" + index_str, spot.sourceGray, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->sourceabs, "Locallab", "Sourceabs_" + index_str, spot.sourceabs, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->targabs, "Locallab", "Targabs_" + index_str, spot.targabs, keyFile);
                     saveToKeyfile(!pedited || spot_edited->targetGray, "Locallab", "TargetGray_" + index_str, spot.targetGray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->catad, "Locallab", "Catad_" + index_str, spot.catad, keyFile);
                     saveToKeyfile(!pedited || spot_edited->Autogray, "Locallab", "Autogray_" + index_str, spot.Autogray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->fullimage, "Locallab", "Fullimage_" + index_str, spot.fullimage, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->ciecam, "Locallab", "Ciecam_" + index_str, spot.ciecam, keyFile);
                     saveToKeyfile(!pedited || spot_edited->blackEv, "Locallab", "BlackEv_" + index_str, spot.blackEv, keyFile);
                     saveToKeyfile(!pedited || spot_edited->whiteEv, "Locallab", "WhiteEv_" + index_str, spot.whiteEv, keyFile);
                     saveToKeyfile(!pedited || spot_edited->detail, "Locallab", "Detail_" + index_str, spot.detail, keyFile);
                     saveToKeyfile(!pedited || spot_edited->sensilog, "Locallab", "Sensilog_" + index_str, spot.sensilog, keyFile);
                     saveToKeyfile(!pedited || spot_edited->baselog, "Locallab", "Baselog_" + index_str, spot.baselog, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->surround, "Locallab", "Surround_" + index_str, spot.surround, keyFile);
                     saveToKeyfile(!pedited || spot_edited->strlog, "Locallab", "Strlog_" + index_str, spot.strlog, keyFile);
                     saveToKeyfile(!pedited || spot_edited->anglog, "Locallab", "Anglog_" + index_str, spot.anglog, keyFile);
                 }
@@ -7727,15 +7739,19 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
 
                 assignFromKeyfile(keyFile, "Locallab", "Autocompute_" + index_str, pedited, spot.autocompute, spotEdited.autocompute);
                 assignFromKeyfile(keyFile, "Locallab", "SourceGray_" + index_str, pedited, spot.sourceGray, spotEdited.sourceGray);
+                assignFromKeyfile(keyFile, "Locallab", "Sourceabs_" + index_str, pedited, spot.sourceabs, spotEdited.sourceabs);
+                assignFromKeyfile(keyFile, "Locallab", "Targabs_" + index_str, pedited, spot.targabs, spotEdited.targabs);
                 assignFromKeyfile(keyFile, "Locallab", "TargetGray_" + index_str, pedited, spot.targetGray, spotEdited.targetGray);
                 assignFromKeyfile(keyFile, "Locallab", "Catad_" + index_str, pedited, spot.catad, spotEdited.catad);
                 assignFromKeyfile(keyFile, "Locallab", "AutoGray_" + index_str, pedited, spot.Autogray, spotEdited.Autogray);
                 assignFromKeyfile(keyFile, "Locallab", "Fullimage_" + index_str, pedited, spot.fullimage, spotEdited.fullimage);
+                assignFromKeyfile(keyFile, "Locallab", "Ciecam_" + index_str, pedited, spot.ciecam, spotEdited.ciecam);
                 assignFromKeyfile(keyFile, "Locallab", "BlackEv_" + index_str, pedited, spot.blackEv, spotEdited.blackEv);
                 assignFromKeyfile(keyFile, "Locallab", "WhiteEv_" + index_str, pedited, spot.whiteEv, spotEdited.whiteEv);
                 assignFromKeyfile(keyFile, "Locallab", "Detail_" + index_str, pedited, spot.detail, spotEdited.detail);
                 assignFromKeyfile(keyFile, "Locallab", "Sensilog_" + index_str, pedited, spot.sensilog, spotEdited.sensilog);
                 assignFromKeyfile(keyFile, "Locallab", "Baselog_" + index_str, pedited, spot.baselog, spotEdited.baselog);
+                assignFromKeyfile(keyFile, "Locallab", "Surround_" + index_str, pedited, spot.surround, spotEdited.surround);
                 assignFromKeyfile(keyFile, "Locallab", "Strlog_" + index_str, pedited, spot.strlog, spotEdited.strlog);
                 assignFromKeyfile(keyFile, "Locallab", "Anglog_" + index_str, pedited, spot.anglog, spotEdited.anglog);
                 // mask

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1429,6 +1429,7 @@ struct LocallabParams {
         double targetGray;
         double catad;
         double saturl;
+        double contl;
         bool Autogray;
         bool fullimage;
         bool ciecam;

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1428,6 +1428,7 @@ struct LocallabParams {
         double targabs;
         double targetGray;
         double catad;
+        double saturl;
         bool Autogray;
         bool fullimage;
         bool ciecam;

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1424,14 +1424,18 @@ struct LocallabParams {
         bool explog;
         bool autocompute;
         double sourceGray;
+        double sourceabs;
+        double targabs;
         double targetGray;
         double catad;
         bool Autogray;
         bool fullimage;
+        bool ciecam;
         double blackEv;
         double whiteEv;
         double detail;
         int sensilog;
+        Glib::ustring surround;
         double baselog;
         double strlog;
         double anglog;

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -990,7 +990,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     LUMINANCECURVE,   // Evlocallabciecam
     LUMINANCECURVE,   // Evlocallabsourceabs
     LUMINANCECURVE,   // Evlocallabtargabs
-    LUMINANCECURVE   // Evlocallabsurround
+    LUMINANCECURVE,   // Evlocallabsurround
+    LUMINANCECURVE   // Evlocallabsaturl
 
 };
 

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -991,7 +991,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     LUMINANCECURVE,   // Evlocallabsourceabs
     LUMINANCECURVE,   // Evlocallabtargabs
     LUMINANCECURVE,   // Evlocallabsurround
-    LUMINANCECURVE   // Evlocallabsaturl
+    LUMINANCECURVE,   // Evlocallabsaturl
+    LUMINANCECURVE   // Evlocallabcontl
 
 };
 

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -986,7 +986,11 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     LUMINANCECURVE,   //EvlocallabquaMethod
     LUMINANCECURVE,   //Evlocallabhishow
     LUMINANCECURVE,   // Evlocallabinvbl
-    LUMINANCECURVE   // Evlocallabcatad
+    LUMINANCECURVE,   // Evlocallabcatad
+    LUMINANCECURVE,   // Evlocallabciecam
+    LUMINANCECURVE,   // Evlocallabsourceabs
+    LUMINANCECURVE,   // Evlocallabtargabs
+    LUMINANCECURVE   // Evlocallabsurround
 
 };
 

--- a/rtengine/rtengine.h
+++ b/rtengine/rtengine.h
@@ -439,7 +439,7 @@ public:
     virtual ~LocallabListener() = default;
     virtual void refChanged(const std::vector<locallabRef> &ref, int selspot) = 0;
     virtual void minmaxChanged(const std::vector<locallabRetiMinMax> &minmax, int selspot) = 0;
-    virtual void logencodChanged(const float blackev, const float whiteev, const float sourceg, const float targetg) = 0;
+    virtual void logencodChanged(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg) = 0;
 };
 
 class AutoColorTonListener

--- a/rtgui/locallab.cc
+++ b/rtgui/locallab.cc
@@ -1017,10 +1017,10 @@ void Locallab::minmaxChanged(const std::vector<locallabRetiMinMax> &minmax, int 
     }
 }
 
-void Locallab::logencodChanged(const float blackev, const float whiteev, const float sourceg, const float targetg)
+void Locallab::logencodChanged(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg)
 {
     // Update Locallab Log Encoding accordingly
-    explog->updateAutocompute(blackev, whiteev, sourceg, targetg);
+    explog->updateAutocompute(blackev, whiteev, sourceg, sourceab, targetg);
 }
 
 void Locallab::refChanged(const std::vector<locallabRef> &ref, int selspot)

--- a/rtgui/locallab.h
+++ b/rtgui/locallab.h
@@ -141,7 +141,7 @@ public:
     void minmaxChanged(const std::vector<locallabRetiMinMax> &minmax, int selspot) override;
 
     // Locallab Log Encoding autocompute function
-    void logencodChanged(const float blackev, const float whiteev, const float sourceg, const float targetg) override;
+    void logencodChanged(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg) override;
 
     // Locallab tools mask background management function
     void refChanged(const std::vector<locallabRef> &ref, int selspot) override;

--- a/rtgui/locallabtools.h
+++ b/rtgui/locallabtools.h
@@ -1196,9 +1196,11 @@ private:
     Adjuster* const blackEv;
     Adjuster* const whiteEv;
     Gtk::CheckButton* const fullimage;
+    Gtk::Frame* const logFrame;
     Gtk::CheckButton* const Autogray;
     Adjuster* const sourceGray;
     Adjuster* const sourceabs;
+    Gtk::Frame* const log1Frame;
     Gtk::Frame* const log2Frame;
     Adjuster* const targetGray;
     Adjuster* const detail;

--- a/rtgui/locallabtools.h
+++ b/rtgui/locallabtools.h
@@ -1203,6 +1203,7 @@ private:
     Adjuster* const targetGray;
     Adjuster* const detail;
     Adjuster* const catad;
+    Adjuster* const saturl;
     Adjuster* const targabs;
     MyComboBoxText*  const surround;
     Gtk::HBox* const surrHBox;

--- a/rtgui/locallabtools.h
+++ b/rtgui/locallabtools.h
@@ -1203,6 +1203,7 @@ private:
     Adjuster* const targetGray;
     Adjuster* const detail;
     Adjuster* const catad;
+    Adjuster* const contl;
     Adjuster* const saturl;
     Adjuster* const targabs;
     MyComboBoxText*  const surround;

--- a/rtgui/locallabtools.h
+++ b/rtgui/locallabtools.h
@@ -1190,6 +1190,7 @@ class LocallabLog:
     public LocallabTool
 {
 private:
+    Gtk::CheckButton* const ciecam;
     Gtk::ToggleButton* const autocompute;
     Gtk::Frame* const logPFrame;
     Adjuster* const blackEv;
@@ -1197,20 +1198,27 @@ private:
     Gtk::CheckButton* const fullimage;
     Gtk::CheckButton* const Autogray;
     Adjuster* const sourceGray;
+    Adjuster* const sourceabs;
     Gtk::Frame* const log2Frame;
     Adjuster* const targetGray;
     Adjuster* const detail;
     Adjuster* const catad;
+    Adjuster* const targabs;
+    MyComboBoxText*  const surround;
+    Gtk::HBox* const surrHBox;
+    
     Adjuster* const baselog;
     Adjuster* const sensilog;
     Adjuster* const strlog;
     Adjuster* const anglog;
 
-    sigc::connection autoconn, fullimageConn, AutograyConn;
+    sigc::connection autoconn, ciecamconn, fullimageConn, AutograyConn;
+    sigc::connection  surroundconn;
 
 public:
     LocallabLog();
     void updateAdviceTooltips(const bool showTooltips) override;
+    void surroundChanged();
 
     void disableListener() override;
     void enableListener() override;
@@ -1219,7 +1227,7 @@ public:
     void setDefaults(const rtengine::procparams::ProcParams* defParams, const ParamsEdited* pedited = nullptr) override;
     void adjusterChanged(Adjuster* a, double newval) override;
 
-    void updateAutocompute(const float blackev, const float whiteev, const float sourceg, const float targetg);
+    void updateAutocompute(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg);
 
 private:
     void enabledChanged() override;
@@ -1227,8 +1235,10 @@ private:
     void autocomputeToggled();
     void fullimageChanged();
     void AutograyChanged();
+    void ciecamChanged();
 
     void updateLogGUI();
+    void updateLogGUI2();
 };
 
 

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -5117,15 +5117,20 @@ void LocallabLog::autocomputeToggled()
 void LocallabLog::ciecamChanged()
 {
     if(ciecam->get_active()){
-        sourceabs->set_sensitive(true);
+    /*    sourceabs->set_sensitive(true);
         targabs->set_sensitive(true);
         catad->set_sensitive(true);
         surrHBox->set_sensitive(true);
+        */
+        sourceabs->show();
+        targabs->show();
+        catad->show();
+        surrHBox->show();
     } else {
-        sourceabs->set_sensitive(false);
-        targabs->set_sensitive(false);
-        catad->set_sensitive(false);
-        surrHBox->set_sensitive(false);
+        sourceabs->hide();
+        targabs->hide();
+        catad->hide();
+        surrHBox->hide();
     }
 
     if (isLocActivated && exp->getEnabled()) {
@@ -5175,15 +5180,15 @@ void LocallabLog::AutograyChanged()
 void LocallabLog::updateLogGUI2()
 {
     if(ciecam->get_active()){
-        sourceabs->set_sensitive(true);
-        targabs->set_sensitive(true);
-        catad->set_sensitive(true);
-        surrHBox->set_sensitive(true);
+        sourceabs->show();
+        targabs->show();
+        catad->show();
+        surrHBox->show();
     } else {
-        sourceabs->set_sensitive(false);
-        targabs->set_sensitive(false);
-        catad->set_sensitive(false);
-        surrHBox->set_sensitive(false);
+        sourceabs->hide();
+        targabs->hide();
+        catad->hide();
+        surrHBox->hide();
     }
 }
 

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4665,7 +4665,8 @@ LocallabLog::LocallabLog():
     targetGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_TARGET_GRAY"), 5.0, 80.0, 0.1, 18.0))),
     detail(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DETAIL"), 0., 1., 0.01, 0.6))),
     catad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CATAD"), -100., 100., 0.5, 0.))),
-    saturl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATUR"), -100., 100., 0.5, 0.))),
+    contl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTL"), -100., 100., 0.5, 0.))),
+    saturl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATURV"), -100., 100., 0.5, 0.))),
     targabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 16.0))),
     surround(Gtk::manage (new MyComboBoxText ())),
     surrHBox(Gtk::manage(new Gtk::HBox())),
@@ -4702,6 +4703,8 @@ LocallabLog::LocallabLog():
     catad->setAdjusterListener(this);
 
     saturl->setAdjusterListener(this);
+
+    contl->setAdjusterListener(this);
 
     targabs->setLogScale(500, 0);
 
@@ -4752,6 +4755,7 @@ LocallabLog::LocallabLog():
     logP2Box->pack_start(*targetGray);
     logP2Box->pack_start(*targabs);
     logP2Box->pack_start(*detail);
+    logP2Box->pack_start(*contl);
     logP2Box->pack_start(*saturl);
     logP2Box->pack_start(*catad);
     logP2Box->pack_start (*surrHBox);
@@ -4879,6 +4883,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         sourceabs->setValue(spot.sourceabs);
         catad->setValue(spot.catad);
         saturl->setValue(spot.saturl);
+        contl->setValue(spot.contl);
         targabs->setValue(spot.targabs);
         targetGray->setValue(spot.targetGray);
         detail->setValue(spot.detail);
@@ -4920,6 +4925,7 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.targetGray = targetGray->getValue();
         spot.catad = catad->getValue();
         spot.saturl = saturl->getValue();
+        spot.contl = contl->getValue();
         spot.detail = detail->getValue();
         spot.baselog = baselog->getValue();
         spot.sensilog = sensilog->getIntValue();
@@ -4958,6 +4964,7 @@ void LocallabLog::setDefaults(const rtengine::procparams::ProcParams* defParams,
         targetGray->setDefault(defSpot.targetGray);
         catad->setDefault(defSpot.catad);
         saturl->setDefault(defSpot.saturl);
+        contl->setDefault(defSpot.contl);
         detail->setDefault(defSpot.detail);
         baselog->setDefault(defSpot.baselog);
         sensilog->setDefault((double)defSpot.sensilog);
@@ -5024,6 +5031,13 @@ void LocallabLog::adjusterChanged(Adjuster* a, double newval)
             if (listener) {
                 listener->panelChanged(Evlocallabsaturl,
                                        saturl->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+
+        if (a == contl) {
+            if (listener) {
+                listener->panelChanged(Evlocallabcontl,
+                                       contl->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
             }
         }
 
@@ -5141,11 +5155,13 @@ void LocallabLog::ciecamChanged()
         targabs->show();
         catad->show();
         saturl->show();
+        contl->show();
         surrHBox->show();
     } else {
         sourceabs->hide();
         targabs->hide();
         saturl->hide();
+        contl->hide();
         catad->hide();
         surrHBox->hide();
     }
@@ -5201,12 +5217,14 @@ void LocallabLog::updateLogGUI2()
         targabs->show();
         catad->show();
         saturl->show();
+        contl->show();
         surrHBox->show();
     } else {
         sourceabs->hide();
         targabs->hide();
         catad->hide();
         saturl->hide();
+        contl->hide();
         surrHBox->hide();
     }
 }

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4665,6 +4665,7 @@ LocallabLog::LocallabLog():
     targetGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_TARGET_GRAY"), 5.0, 80.0, 0.1, 18.0))),
     detail(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DETAIL"), 0., 1., 0.01, 0.6))),
     catad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CATAD"), -100., 100., 0.5, 0.))),
+    saturl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATUR"), -100., 100., 0.5, 0.))),
     targabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 16.0))),
     surround(Gtk::manage (new MyComboBoxText ())),
     surrHBox(Gtk::manage(new Gtk::HBox())),
@@ -4699,6 +4700,8 @@ LocallabLog::LocallabLog():
     detail->setAdjusterListener(this);
 
     catad->setAdjusterListener(this);
+
+    saturl->setAdjusterListener(this);
 
     targabs->setLogScale(500, 0);
 
@@ -4749,6 +4752,7 @@ LocallabLog::LocallabLog():
     logP2Box->pack_start(*targetGray);
     logP2Box->pack_start(*targabs);
     logP2Box->pack_start(*detail);
+    logP2Box->pack_start(*saturl);
     logP2Box->pack_start(*catad);
     logP2Box->pack_start (*surrHBox);
     log2Frame->add(*logP2Box);
@@ -4874,6 +4878,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         sourceGray->setValue(spot.sourceGray);
         sourceabs->setValue(spot.sourceabs);
         catad->setValue(spot.catad);
+        saturl->setValue(spot.saturl);
         targabs->setValue(spot.targabs);
         targetGray->setValue(spot.targetGray);
         detail->setValue(spot.detail);
@@ -4914,6 +4919,7 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.targabs = targabs->getValue();
         spot.targetGray = targetGray->getValue();
         spot.catad = catad->getValue();
+        spot.saturl = saturl->getValue();
         spot.detail = detail->getValue();
         spot.baselog = baselog->getValue();
         spot.sensilog = sensilog->getIntValue();
@@ -4951,6 +4957,7 @@ void LocallabLog::setDefaults(const rtengine::procparams::ProcParams* defParams,
         targabs->setDefault(defSpot.targabs);
         targetGray->setDefault(defSpot.targetGray);
         catad->setDefault(defSpot.catad);
+        saturl->setDefault(defSpot.saturl);
         detail->setDefault(defSpot.detail);
         baselog->setDefault(defSpot.baselog);
         sensilog->setDefault((double)defSpot.sensilog);
@@ -5010,6 +5017,13 @@ void LocallabLog::adjusterChanged(Adjuster* a, double newval)
             if (listener) {
                 listener->panelChanged(Evlocallabcatad,
                                        catad->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+
+        if (a == saturl) {
+            if (listener) {
+                listener->panelChanged(Evlocallabsaturl,
+                                       saturl->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
             }
         }
 
@@ -5126,10 +5140,12 @@ void LocallabLog::ciecamChanged()
         sourceabs->show();
         targabs->show();
         catad->show();
+        saturl->show();
         surrHBox->show();
     } else {
         sourceabs->hide();
         targabs->hide();
+        saturl->hide();
         catad->hide();
         surrHBox->hide();
     }
@@ -5184,11 +5200,13 @@ void LocallabLog::updateLogGUI2()
         sourceabs->show();
         targabs->show();
         catad->show();
+        saturl->show();
         surrHBox->show();
     } else {
         sourceabs->hide();
         targabs->hide();
         catad->hide();
+        saturl->hide();
         surrHBox->hide();
     }
 }

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4669,7 +4669,7 @@ LocallabLog::LocallabLog():
     surround(Gtk::manage (new MyComboBoxText ())),
     surrHBox(Gtk::manage(new Gtk::HBox())),
 
-    baselog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BASELOG"), 1.3, 8., 0.05, 2., Gtk::manage(new RTImage("circle-black-small.png")), Gtk::manage(new RTImage("circle-white-small.png"))))),
+    baselog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BASELOG"), 1.3, 3., 0.05, 2., Gtk::manage(new RTImage("circle-black-small.png")), Gtk::manage(new RTImage("circle-white-small.png"))))),
     sensilog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 60))),
     strlog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTR"), -2.0, 2.0, 0.05, 0.))),
     anglog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADANG"), -180, 180, 0.1, 0.)))

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4658,13 +4658,15 @@ LocallabLog::LocallabLog():
     blackEv(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLACK_EV"), -16.0, 0.0, 0.1, -5.0))),
     whiteEv(Gtk::manage(new Adjuster(M("TP_LOCALLAB_WHITE_EV"), 0., 32.0, 0.1, 10.0))),
     fullimage(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FULLIMAGE")))),
+    logFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGFRA")))),
     Autogray(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AUTOGRAY")))),
     sourceGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_GRAY"), 1.0, 100.0, 0.1, 10.0))),
     sourceabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 2000.0))),
+    log1Frame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOG1FRA")))),
     log2Frame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOG2FRA")))),
     targetGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_TARGET_GRAY"), 5.0, 80.0, 0.1, 18.0))),
     detail(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DETAIL"), 0., 1., 0.01, 0.6))),
-    catad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CATAD"), -100., 100., 0.5, 0.))),
+    catad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CATAD"), -100., 100., 0.5, 0., Gtk::manage(new RTImage("circle-blue-small.png")), Gtk::manage(new RTImage("circle-orange-small.png"))))),
     contl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTL"), -100., 100., 0.5, 0.))),
     saturl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATURV"), -100., 100., 0.5, 0.))),
     targabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 16.0))),
@@ -4741,22 +4743,26 @@ LocallabLog::LocallabLog():
     logPBox->pack_start(*fullimage);
     logPFrame->add(*logPBox);
     pack_start(*logPFrame);
-    Gtk::Frame* const logFrame = Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGFRA")));
+//    Gtk::Frame* const logFrame = Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGFRA")));
     logFrame->set_label_align(0.025, 0.5);
     ToolParamBlock* const logFBox = Gtk::manage(new ToolParamBlock());
     logFBox->pack_start(*Autogray);
     logFBox->pack_start(*sourceGray);
     logFBox->pack_start(*sourceabs);
-    logFBox->pack_start(*baselog);
+//    logFBox->pack_start(*baselog);
     logFrame->add(*logFBox);
     pack_start(*logFrame);
-    log2Frame->set_label_align(0.025, 0.5);
+    log1Frame->set_label_align(0.025, 0.5);
+    ToolParamBlock* const logP1Box = Gtk::manage(new ToolParamBlock());
+    logP1Box->pack_start(*detail);
+    logP1Box->pack_start(*contl);
+    logP1Box->pack_start(*saturl);
+    log1Frame->add(*logP1Box);
+    pack_start(*log1Frame);
+    log2Frame->set_label_align(0.025, 0.5);    
     ToolParamBlock* const logP2Box = Gtk::manage(new ToolParamBlock());
     logP2Box->pack_start(*targetGray);
     logP2Box->pack_start(*targabs);
-    logP2Box->pack_start(*detail);
-    logP2Box->pack_start(*contl);
-    logP2Box->pack_start(*saturl);
     logP2Box->pack_start(*catad);
     logP2Box->pack_start (*surrHBox);
     log2Frame->add(*logP2Box);
@@ -4777,6 +4783,9 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
     if (showTooltips) {
         exp->set_tooltip_text(M("TP_LOCALLAB_LOGENCOD_TOOLTIP"));
         logPFrame->set_tooltip_text(M("TP_LOCALLAB_LOGFRAME_TOOLTIP"));
+        logFrame->set_tooltip_text(M("TP_LOCALLAB_LOGSCENE_TOOLTIP"));
+        log1Frame->set_tooltip_text(M("TP_LOCALLAB_LOGIMAGE_TOOLTIP"));
+        log2Frame->set_tooltip_text(M("TP_LOCALLAB_LOGVIEWING_TOOLTIP"));
         autocompute->set_tooltip_text(M("TP_LOCALLAB_LOGAUTO_TOOLTIP"));
     //    blackEv->set_tooltip_text(M("TP_LOCALLAB_LOGBLACKWHEV_TOOLTIP"));
     //    whiteEv->set_tooltip_text(M("TP_LOCALLAB_LOGBLACKWHEV_TOOLTIP"));
@@ -4789,11 +4798,13 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         baselog->set_tooltip_text(M("TP_LOCALLAB_LOGBASE_TOOLTIP"));
         strlog->set_tooltip_text(M("TP_LOCALLAB_GRADGEN_TOOLTIP"));
         anglog->set_tooltip_text(M("TP_LOCALLAB_GRADANG_TOOLTIP"));
-
+        contl->set_tooltip_text(M("TP_LOCALLAB_LOGCONTL_TOOLTIP"));
+        saturl->set_tooltip_text(M("TP_LOCALLAB_LOGSATURL_TOOLTIP"));
+        detail->set_tooltip_text(M("TP_LOCALLAB_LOGDETAIL_TOOLTIP"));
+        catad->set_tooltip_text(M("TP_LOCALLAB_LOGCATAD_TOOLTIP"));
      //   detail->set_tooltip_text(M("TP_LOCALLAB_NUL_TOOLTIP"));
      //   Autogray->set_tooltip_text(M("TP_LOCALLAB_NUL_TOOLTIP"));
      //   sensilog->set_tooltip_text(M("TP_LOCALLAB_NUL_TOOLTIP"));
-        detail->set_tooltip_text("");
         Autogray->set_tooltip_text("");
         sensilog->set_tooltip_text(M("TP_LOCALLAB_SENSI_TOOLTIP"));
         fullimage->set_tooltip_text(M("TP_LOCALLAB_FULLIMAGELOG_TOOLTIP"));
@@ -4801,6 +4812,9 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
     } else {
         exp->set_tooltip_text("");
         logPFrame->set_tooltip_text("");
+        logFrame->set_tooltip_text("");
+        log1Frame->set_tooltip_text("");
+        log2Frame->set_tooltip_text("");
         autocompute->set_tooltip_text("");
         blackEv->set_tooltip_text("");
         whiteEv->set_tooltip_text("");
@@ -4816,7 +4830,9 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         sensilog->set_tooltip_text("");
         fullimage->set_tooltip_text("");
         ciecam->set_tooltip_text("");
-
+        contl->set_tooltip_text("");
+        saturl->set_tooltip_text("");
+        catad->set_tooltip_text("");
     }
 }
 

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4873,6 +4873,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         Autogray->set_active(spot.Autogray);
         sourceGray->setValue(spot.sourceGray);
         sourceabs->setValue(spot.sourceabs);
+        catad->setValue(spot.catad);
         targabs->setValue(spot.targabs);
         targetGray->setValue(spot.targetGray);
         detail->setValue(spot.detail);

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -4652,6 +4652,7 @@ LocallabLog::LocallabLog():
     LocallabTool(this, M("TP_LOCALLAB_LOG_TOOLNAME"), M("TP_LOCALLAB_LOG"), false, false),
 
     // Log encoding specific widgets
+    ciecam(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_CIEC")))),
     autocompute(Gtk::manage(new Gtk::ToggleButton(M("TP_LOCALLAB_LOGAUTO")))),
     logPFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGPFRA")))),
     blackEv(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLACK_EV"), -16.0, 0.0, 0.1, -5.0))),
@@ -4659,10 +4660,15 @@ LocallabLog::LocallabLog():
     fullimage(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FULLIMAGE")))),
     Autogray(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AUTOGRAY")))),
     sourceGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_GRAY"), 1.0, 100.0, 0.1, 10.0))),
+    sourceabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 2000.0))),
     log2Frame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOG2FRA")))),
     targetGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_TARGET_GRAY"), 5.0, 80.0, 0.1, 18.0))),
     detail(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DETAIL"), 0., 1., 0.01, 0.6))),
     catad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CATAD"), -100., 100., 0.5, 0.))),
+    targabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 16.0))),
+    surround(Gtk::manage (new MyComboBoxText ())),
+    surrHBox(Gtk::manage(new Gtk::HBox())),
+
     baselog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BASELOG"), 1.3, 8., 0.05, 2., Gtk::manage(new RTImage("circle-black-small.png")), Gtk::manage(new RTImage("circle-white-small.png"))))),
     sensilog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 60))),
     strlog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTR"), -2.0, 2.0, 0.05, 0.))),
@@ -4676,6 +4682,7 @@ LocallabLog::LocallabLog():
 
     whiteEv->setLogScale(16, 0);
     whiteEv->setAdjusterListener(this);
+    ciecamconn = ciecam->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::ciecamChanged));
 
     fullimageConn = fullimage->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::fullimageChanged));
 
@@ -4683,11 +4690,19 @@ LocallabLog::LocallabLog():
 
     sourceGray->setAdjusterListener(this);
 
+    sourceabs->setLogScale(500, 0);
+
+    sourceabs->setAdjusterListener(this);
+
     targetGray->setAdjusterListener(this);
 
     detail->setAdjusterListener(this);
 
     catad->setAdjusterListener(this);
+
+    targabs->setLogScale(500, 0);
+
+    targabs->setAdjusterListener(this);
 
     baselog->setAdjusterListener(this);
 
@@ -4697,7 +4712,21 @@ LocallabLog::LocallabLog():
 
     anglog->setAdjusterListener(this);
 
+//    Gtk::HBox* surrHBox = Gtk::manage (new Gtk::HBox ());
+    surrHBox->set_spacing (2);
+    surrHBox->set_tooltip_markup (M ("TP_COLORAPP_SURROUND_TOOLTIP"));
+    Gtk::Label* surrLabel = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_SURROUND") + ":"));
+    surrHBox->pack_start (*surrLabel, Gtk::PACK_SHRINK);
+    surround->append (M ("TP_COLORAPP_SURROUND_AVER"));
+    surround->append (M ("TP_COLORAPP_SURROUND_DIM"));
+    surround->append (M ("TP_COLORAPP_SURROUND_DARK"));
+    surround->append (M ("TP_COLORAPP_SURROUND_EXDARK"));
+    surround->set_active (0);
+    surrHBox->pack_start (*surround);
+    surroundconn = surround->signal_changed().connect ( sigc::mem_fun (*this, &LocallabLog::surroundChanged) );
+
     // Add Log encoding specific widgets to GUI
+    pack_start(*ciecam);
     logPFrame->set_label_align(0.025, 0.5);
     ToolParamBlock* const logPBox = Gtk::manage(new ToolParamBlock());
     logPBox->pack_start(*autocompute);
@@ -4711,14 +4740,17 @@ LocallabLog::LocallabLog():
     ToolParamBlock* const logFBox = Gtk::manage(new ToolParamBlock());
     logFBox->pack_start(*Autogray);
     logFBox->pack_start(*sourceGray);
+    logFBox->pack_start(*sourceabs);
     logFBox->pack_start(*baselog);
     logFrame->add(*logFBox);
     pack_start(*logFrame);
     log2Frame->set_label_align(0.025, 0.5);
     ToolParamBlock* const logP2Box = Gtk::manage(new ToolParamBlock());
     logP2Box->pack_start(*targetGray);
+    logP2Box->pack_start(*targabs);
     logP2Box->pack_start(*detail);
     logP2Box->pack_start(*catad);
+    logP2Box->pack_start (*surrHBox);
     log2Frame->add(*logP2Box);
     pack_start(*log2Frame);
 //    pack_start(*baselog);
@@ -4743,7 +4775,9 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         blackEv->set_tooltip_text("");
         whiteEv->set_tooltip_text("");
         sourceGray->set_tooltip_text("");
-        targetGray->set_tooltip_text(M("TP_LOCALLAB_LOGTARGGREY_TOOLTIP"));
+        sourceabs->set_tooltip_text(M("TP_COLORAPP_ADAPSCEN_TOOLTIP"));
+        targabs->set_tooltip_text(M("TP_COLORAPP_VIEWING_ABSOLUTELUMINANCE_TOOLTIP"));
+        targetGray->set_tooltip_text(M("TP_COLORAPP_YBOUT_TOOLTIP"));
         baselog->set_tooltip_text(M("TP_LOCALLAB_LOGBASE_TOOLTIP"));
         strlog->set_tooltip_text(M("TP_LOCALLAB_GRADGEN_TOOLTIP"));
         anglog->set_tooltip_text(M("TP_LOCALLAB_GRADANG_TOOLTIP"));
@@ -4755,6 +4789,7 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         Autogray->set_tooltip_text("");
         sensilog->set_tooltip_text(M("TP_LOCALLAB_SENSI_TOOLTIP"));
         fullimage->set_tooltip_text(M("TP_LOCALLAB_FULLIMAGELOG_TOOLTIP"));
+        ciecam->set_tooltip_text(M("TP_LOCALLAB_CIECAMLOG_TOOLTIP"));
     } else {
         exp->set_tooltip_text("");
         logPFrame->set_tooltip_text("");
@@ -4762,6 +4797,8 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         blackEv->set_tooltip_text("");
         whiteEv->set_tooltip_text("");
         sourceGray->set_tooltip_text("");
+        sourceabs->set_tooltip_text("");
+        targabs->set_tooltip_text("");
         targetGray->set_tooltip_text("");
         baselog->set_tooltip_text("");
         strlog->set_tooltip_text("");
@@ -4770,6 +4807,7 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         Autogray->set_tooltip_text("");
         sensilog->set_tooltip_text("");
         fullimage->set_tooltip_text("");
+        ciecam->set_tooltip_text("");
 
     }
 }
@@ -4780,6 +4818,8 @@ void LocallabLog::disableListener()
 
     autoconn.block(true);
     fullimageConn.block(true);
+    ciecamconn.block(true);
+    surroundconn.block (true);
     AutograyConn.block(true);
 }
 
@@ -4789,6 +4829,8 @@ void LocallabLog::enableListener()
 
     autoconn.block(false);
     fullimageConn.block(false);
+    ciecamconn.block(false);
+    surroundconn.block (false);
     AutograyConn.block(false);
 }
 
@@ -4816,9 +4858,22 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
             whiteEv->setValue(1.5);
         }
 */
+        if (spot.surround == "Average") {
+            surround->set_active (0);
+        } else if (spot.surround == "Dim") {
+            surround->set_active (1);
+        } else if (spot.surround == "Dark") {
+            surround->set_active (2);
+        } else if (spot.surround == "ExtremelyDark") {
+            surround->set_active (3);
+        }
+
+        ciecam->set_active(spot.ciecam);
         fullimage->set_active(spot.fullimage);
         Autogray->set_active(spot.Autogray);
         sourceGray->setValue(spot.sourceGray);
+        sourceabs->setValue(spot.sourceabs);
+        targabs->setValue(spot.targabs);
         targetGray->setValue(spot.targetGray);
         detail->setValue(spot.detail);
         baselog->setValue(spot.baselog);
@@ -4832,6 +4887,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
 
     // Update Log Encoding GUI according to autocompute button state
     updateLogGUI();
+    updateLogGUI2();
 
     // Note: No need to manage pedited as batch mode is deactivated for Locallab
 }
@@ -4850,8 +4906,11 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.blackEv = blackEv->getValue();
         spot.whiteEv = whiteEv->getValue();
         spot.fullimage = fullimage->get_active();
+        spot.ciecam = ciecam->get_active();
         spot.Autogray = Autogray->get_active();
         spot.sourceGray = sourceGray->getValue();
+        spot.sourceabs = sourceabs->getValue();
+        spot.targabs = targabs->getValue();
         spot.targetGray = targetGray->getValue();
         spot.catad = catad->getValue();
         spot.detail = detail->getValue();
@@ -4859,6 +4918,18 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.sensilog = sensilog->getIntValue();
         spot.strlog = strlog->getValue();
         spot.anglog = anglog->getValue();
+        
+
+        if (surround->get_active_row_number() == 0) {
+            spot.surround = "Average";
+        } else if (surround->get_active_row_number() == 1) {
+            spot.surround = "Dim";
+        } else if (surround->get_active_row_number() == 2) {
+            spot.surround = "Dark";
+        } else if (surround->get_active_row_number() == 3) {
+            spot.surround = "ExtremelyDark";
+        }
+        
     }
 
     // Note: No need to manage pedited as batch mode is deactivated for Locallab
@@ -4875,6 +4946,8 @@ void LocallabLog::setDefaults(const rtengine::procparams::ProcParams* defParams,
         blackEv->setDefault(defSpot.blackEv);
         whiteEv->setDefault(defSpot.whiteEv);
         sourceGray->setDefault(defSpot.sourceGray);
+        sourceabs->setDefault(defSpot.sourceabs);
+        targabs->setDefault(defSpot.targabs);
         targetGray->setDefault(defSpot.targetGray);
         catad->setDefault(defSpot.catad);
         detail->setDefault(defSpot.detail);
@@ -4908,6 +4981,20 @@ void LocallabLog::adjusterChanged(Adjuster* a, double newval)
             if (listener) {
                 listener->panelChanged(EvlocallabsourceGray,
                                        sourceGray->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+
+        if (a == sourceabs) {
+            if (listener) {
+                listener->panelChanged(Evlocallabsourceabs,
+                                       sourceabs->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+
+        if (a == targabs) {
+            if (listener) {
+                listener->panelChanged(Evlocallabtargabs,
+                                       targabs->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
             }
         }
 
@@ -4962,10 +5049,10 @@ void LocallabLog::adjusterChanged(Adjuster* a, double newval)
     }
 }
 
-void LocallabLog::updateAutocompute(const float blackev, const float whiteev, const float sourceg, const float targetg)
+void LocallabLog::updateAutocompute(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg)
 {
     idle_register.add(
-    [this, blackev, whiteev, sourceg, targetg]() -> bool {
+    [this, blackev, whiteev, sourceg, sourceab, targetg]() -> bool {
         GThreadLock lock; // All GUI access from idle_add callbacks or separate thread HAVE to be protected
 
         // Update adjuster values according to autocomputed ones
@@ -4974,6 +5061,7 @@ void LocallabLog::updateAutocompute(const float blackev, const float whiteev, co
         blackEv->setValue(blackev);
         whiteEv->setValue(whiteev);
         sourceGray->setValue(sourceg);
+        sourceabs->setValue(sourceab);
         targetGray->setValue(targetg);
 
         enableListener();
@@ -4998,6 +5086,16 @@ void LocallabLog::enabledChanged()
     }
 }
 
+void LocallabLog::surroundChanged()
+{
+    if (isLocActivated && exp->getEnabled()) {
+        if (listener) {
+            listener->panelChanged(Evlocallabsurround,
+                                   surround->get_active_text() + " (" + escapeHtmlChars(spotName) + ")");
+        }
+    }
+}
+
 void LocallabLog::autocomputeToggled()
 {
     // Update Log Encoding GUI according to autocompute button state
@@ -5015,6 +5113,34 @@ void LocallabLog::autocomputeToggled()
         }
     }
 }
+
+void LocallabLog::ciecamChanged()
+{
+    if(ciecam->get_active()){
+        sourceabs->set_sensitive(true);
+        targabs->set_sensitive(true);
+        catad->set_sensitive(true);
+        surrHBox->set_sensitive(true);
+    } else {
+        sourceabs->set_sensitive(false);
+        targabs->set_sensitive(false);
+        catad->set_sensitive(false);
+        surrHBox->set_sensitive(false);
+    }
+
+    if (isLocActivated && exp->getEnabled()) {
+        if (listener) {
+            if (ciecam->get_active()) {
+                listener->panelChanged(Evlocallabciecam,
+                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(spotName) + ")");
+            } else {
+                listener->panelChanged(Evlocallabciecam,
+                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+    }
+}
+
 
 void LocallabLog::fullimageChanged()
 {
@@ -5046,16 +5172,38 @@ void LocallabLog::AutograyChanged()
     }
 }
 
+void LocallabLog::updateLogGUI2()
+{
+    if(ciecam->get_active()){
+        sourceabs->set_sensitive(true);
+        targabs->set_sensitive(true);
+        catad->set_sensitive(true);
+        surrHBox->set_sensitive(true);
+    } else {
+        sourceabs->set_sensitive(false);
+        targabs->set_sensitive(false);
+        catad->set_sensitive(false);
+        surrHBox->set_sensitive(false);
+    }
+}
+
+
 void LocallabLog::updateLogGUI()
 {
     if (autocompute->get_active()) {
         blackEv->set_sensitive(false);
         whiteEv->set_sensitive(false);
         sourceGray->set_sensitive(false);
+        sourceabs->set_sensitive(false);
     } else {
         blackEv->set_sensitive(true);
         whiteEv->set_sensitive(true);
         sourceGray->set_sensitive(true);
+        if(ciecam->get_active()){
+            sourceabs->set_sensitive(true);
+        } else {
+            sourceabs->set_sensitive(false);
+        }
     }
 }
 

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1501,6 +1501,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).targetGray = locallab.spots.at(j).targetGray && pSpot.targetGray == otherSpot.targetGray;
                 locallab.spots.at(j).catad = locallab.spots.at(j).catad && pSpot.catad == otherSpot.catad;
                 locallab.spots.at(j).saturl = locallab.spots.at(j).saturl && pSpot.saturl == otherSpot.saturl;
+                locallab.spots.at(j).contl = locallab.spots.at(j).contl && pSpot.contl == otherSpot.contl;
                 locallab.spots.at(j).Autogray = locallab.spots.at(j).Autogray && pSpot.Autogray == otherSpot.Autogray;
                 locallab.spots.at(j).fullimage = locallab.spots.at(j).fullimage && pSpot.fullimage == otherSpot.fullimage;
                 locallab.spots.at(j).ciecam = locallab.spots.at(j).ciecam && pSpot.ciecam == otherSpot.ciecam;
@@ -4877,6 +4878,9 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
             toEdit.locallab.spots.at(i).saturl = mods.locallab.spots.at(i).saturl;
         }
 
+        if (locallab.spots.at(i).contl) {
+            toEdit.locallab.spots.at(i).contl = mods.locallab.spots.at(i).contl;
+        }
 
         if (locallab.spots.at(i).Autogray) {
             toEdit.locallab.spots.at(i).Autogray = mods.locallab.spots.at(i).Autogray;
@@ -6676,6 +6680,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     targetGray(v),
     catad(v),
     saturl(v),
+    contl(v),
     Autogray(v),
     fullimage(v),
     ciecam(v),
@@ -7177,6 +7182,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     targetGray = v;
     catad = v;
     saturl = v;
+    contl = v;
     Autogray = v;
     fullimage = v;
     ciecam = v;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1500,6 +1500,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).targabs = locallab.spots.at(j).targabs && pSpot.targabs == otherSpot.targabs;
                 locallab.spots.at(j).targetGray = locallab.spots.at(j).targetGray && pSpot.targetGray == otherSpot.targetGray;
                 locallab.spots.at(j).catad = locallab.spots.at(j).catad && pSpot.catad == otherSpot.catad;
+                locallab.spots.at(j).saturl = locallab.spots.at(j).saturl && pSpot.saturl == otherSpot.saturl;
                 locallab.spots.at(j).Autogray = locallab.spots.at(j).Autogray && pSpot.Autogray == otherSpot.Autogray;
                 locallab.spots.at(j).fullimage = locallab.spots.at(j).fullimage && pSpot.fullimage == otherSpot.fullimage;
                 locallab.spots.at(j).ciecam = locallab.spots.at(j).ciecam && pSpot.ciecam == otherSpot.ciecam;
@@ -4872,6 +4873,11 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
             toEdit.locallab.spots.at(i).catad = mods.locallab.spots.at(i).catad;
         }
 
+        if (locallab.spots.at(i).saturl) {
+            toEdit.locallab.spots.at(i).saturl = mods.locallab.spots.at(i).saturl;
+        }
+
+
         if (locallab.spots.at(i).Autogray) {
             toEdit.locallab.spots.at(i).Autogray = mods.locallab.spots.at(i).Autogray;
         }
@@ -6669,6 +6675,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     targabs(v),
     targetGray(v),
     catad(v),
+    saturl(v),
     Autogray(v),
     fullimage(v),
     ciecam(v),
@@ -7169,6 +7176,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     targabs = v;
     targetGray = v;
     catad = v;
+    saturl = v;
     Autogray = v;
     fullimage = v;
     ciecam = v;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1496,13 +1496,17 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).explog = locallab.spots.at(j).explog && pSpot.explog == otherSpot.explog;
                 locallab.spots.at(j).autocompute = locallab.spots.at(j).autocompute && pSpot.autocompute == otherSpot.autocompute;
                 locallab.spots.at(j).sourceGray = locallab.spots.at(j).sourceGray && pSpot.sourceGray == otherSpot.sourceGray;
+                locallab.spots.at(j).sourceabs = locallab.spots.at(j).sourceabs && pSpot.sourceabs == otherSpot.sourceabs;
+                locallab.spots.at(j).targabs = locallab.spots.at(j).targabs && pSpot.targabs == otherSpot.targabs;
                 locallab.spots.at(j).targetGray = locallab.spots.at(j).targetGray && pSpot.targetGray == otherSpot.targetGray;
                 locallab.spots.at(j).catad = locallab.spots.at(j).catad && pSpot.catad == otherSpot.catad;
                 locallab.spots.at(j).Autogray = locallab.spots.at(j).Autogray && pSpot.Autogray == otherSpot.Autogray;
                 locallab.spots.at(j).fullimage = locallab.spots.at(j).fullimage && pSpot.fullimage == otherSpot.fullimage;
+                locallab.spots.at(j).ciecam = locallab.spots.at(j).ciecam && pSpot.ciecam == otherSpot.ciecam;
                 locallab.spots.at(j).blackEv = locallab.spots.at(j).blackEv && pSpot.blackEv == otherSpot.blackEv;
                 locallab.spots.at(j).whiteEv = locallab.spots.at(j).whiteEv && pSpot.whiteEv == otherSpot.whiteEv;
                 locallab.spots.at(j).detail = locallab.spots.at(j).detail && pSpot.detail == otherSpot.detail;
+                locallab.spots.at(j).surround = locallab.spots.at(j).surround && pSpot.surround == otherSpot.surround;
                 locallab.spots.at(j).sensilog = locallab.spots.at(j).sensilog && pSpot.sensilog == otherSpot.sensilog;
                 locallab.spots.at(j).baselog = locallab.spots.at(j).baselog && pSpot.baselog == otherSpot.baselog;
                 locallab.spots.at(j).strlog = locallab.spots.at(j).strlog && pSpot.strlog == otherSpot.strlog;
@@ -4852,6 +4856,14 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
             toEdit.locallab.spots.at(i).sourceGray = mods.locallab.spots.at(i).sourceGray;
         }
 
+        if (locallab.spots.at(i).sourceabs) {
+            toEdit.locallab.spots.at(i).sourceabs = mods.locallab.spots.at(i).sourceabs;
+        }
+
+        if (locallab.spots.at(i).targabs) {
+            toEdit.locallab.spots.at(i).targabs = mods.locallab.spots.at(i).targabs;
+        }
+
         if (locallab.spots.at(i).targetGray) {
             toEdit.locallab.spots.at(i).targetGray = mods.locallab.spots.at(i).targetGray;
         }
@@ -4866,6 +4878,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
         if (locallab.spots.at(i).fullimage) {
             toEdit.locallab.spots.at(i).fullimage = mods.locallab.spots.at(i).fullimage;
+        }
+
+        if (locallab.spots.at(i).ciecam) {
+            toEdit.locallab.spots.at(i).ciecam = mods.locallab.spots.at(i).ciecam;
         }
 
         if (locallab.spots.at(i).blackEv) {
@@ -4886,6 +4902,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
         if (locallab.spots.at(i).baselog) {
             toEdit.locallab.spots.at(i).baselog = mods.locallab.spots.at(i).baselog;
+        }
+
+        if (locallab.spots.at(i).surround) {
+            toEdit.locallab.spots.at(i).surround = mods.locallab.spots.at(i).surround;
         }
 
         if (locallab.spots.at(i).strlog) {
@@ -6645,13 +6665,17 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     explog(v),
     autocompute(v),
     sourceGray(v),
+    sourceabs(v),
+    targabs(v),
     targetGray(v),
     catad(v),
     Autogray(v),
     fullimage(v),
+    ciecam(v),
     blackEv(v),
     whiteEv(v),
     detail(v),
+    surround(v),
     sensilog(v),
     baselog(v),
     strlog(v),
@@ -7141,13 +7165,17 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     explog = v;
     autocompute = v;
     sourceGray = v;
+    sourceabs = v;
+    targabs = v;
     targetGray = v;
     catad = v;
     Autogray = v;
     fullimage = v;
+    ciecam = v;
     blackEv = v;
     whiteEv = v;
     detail = v;
+    surround = v;
     sensilog = v;
     baselog = v;
     strlog = v;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -836,6 +836,7 @@ public:
         bool targabs;
         bool targetGray;
         bool catad;
+        bool saturl;
         bool Autogray;
         bool fullimage;
         bool ciecam;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -837,6 +837,7 @@ public:
         bool targetGray;
         bool catad;
         bool saturl;
+        bool contl;
         bool Autogray;
         bool fullimage;
         bool ciecam;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -832,13 +832,17 @@ public:
         bool explog;
         bool autocompute;
         bool sourceGray;
+        bool sourceabs;
+        bool targabs;
         bool targetGray;
         bool catad;
         bool Autogray;
         bool fullimage;
+        bool ciecam;
         bool blackEv;
         bool whiteEv;
         bool detail;
+        bool surround;
         bool sensilog;
         bool baselog;
         bool strlog;


### PR DESCRIPTION
This PR allows Log encoding to use some functions of Ciecam in particular the possibility to use ciecam process 3

This "addition" is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.
Only the third Ciecam process (Viewing conditions - Target) is taken into account, as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.
It also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.)  and Cat02 adaptation so that the chromatic and contrast appearance is preserved across the display environment. 

As a result, the reservations about limited gamut possibilities (HDR) of Ciecam, are considerably limited.

