### PR TITLE
Ciecam - added cam16 to cam02

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -437,38 +437,38 @@ HISTORY_MSG_171;L*a*b* - LC curve
 HISTORY_MSG_172;L*a*b* - Restrict LC
 HISTORY_MSG_173;NR - Detail recovery
 HISTORY_MSG_174;CIECAM02
-HISTORY_MSG_175;CAM02 - CAT02/16 adaptation
-HISTORY_MSG_176;CAM02 - Viewing surround
-HISTORY_MSG_177;CAM02 - Scene luminosity
-HISTORY_MSG_178;CAM02 - Viewing luminosity
-HISTORY_MSG_179;CAM02 - White-point model
-HISTORY_MSG_180;CAM02 - Lightness (J)
-HISTORY_MSG_181;CAM02 - Chroma (C)
-HISTORY_MSG_182;CAM02 - Automatic CAT02/16
-HISTORY_MSG_183;CAM02 - Contrast (J)
-HISTORY_MSG_184;CAM02 - Scene surround
-HISTORY_MSG_185;CAM02 - Gamut control
-HISTORY_MSG_186;CAM02 - Algorithm
-HISTORY_MSG_187;CAM02 - Red/skin prot.
-HISTORY_MSG_188;CAM02 - Brightness (Q)
-HISTORY_MSG_189;CAM02 - Contrast (Q)
-HISTORY_MSG_190;CAM02 - Saturation (S)
-HISTORY_MSG_191;CAM02 - Colorfulness (M)
-HISTORY_MSG_192;CAM02 - Hue (h)
-HISTORY_MSG_193;CAM02 - Tone curve 1
-HISTORY_MSG_194;CAM02 - Tone curve 2
-HISTORY_MSG_195;CAM02 - Tone curve 1
-HISTORY_MSG_196;CAM02 - Tone curve 2
-HISTORY_MSG_197;CAM02 - Color curve
-HISTORY_MSG_198;CAM02 - Color curve
-HISTORY_MSG_199;CAM02 - Output histograms
-HISTORY_MSG_200;CAM02 - Tone mapping
+HISTORY_MSG_175;CAM02/16 - CAT02/16 adaptation
+HISTORY_MSG_176;CAM02/16 - Viewing surround
+HISTORY_MSG_177;CAM02/16 - Scene luminosity
+HISTORY_MSG_178;CAM02/16 - Viewing luminosity
+HISTORY_MSG_179;CAM02/16 - White-point model
+HISTORY_MSG_180;CAM02/16 - Lightness (J)
+HISTORY_MSG_181;CAM02/16 - Chroma (C)
+HISTORY_MSG_182;CAM02/16 - Automatic CAT02/16
+HISTORY_MSG_183;CAM02/16 - Contrast (J)
+HISTORY_MSG_184;CAM02/16 - Scene surround
+HISTORY_MSG_185;CAM02/16 - Gamut control
+HISTORY_MSG_186;CAM02/16 - Algorithm
+HISTORY_MSG_187;CAM02/16 - Red/skin prot.
+HISTORY_MSG_188;CAM02/16 - Brightness (Q)
+HISTORY_MSG_189;CAM02/16 - Contrast (Q)
+HISTORY_MSG_190;CAM02/16 - Saturation (S)
+HISTORY_MSG_191;CAM02/16 - Colorfulness (M)
+HISTORY_MSG_192;CAM02/16 - Hue (h)
+HISTORY_MSG_193;CAM02/16 - Tone curve 1
+HISTORY_MSG_194;CAM02/16 - Tone curve 2
+HISTORY_MSG_195;CAM02/16 - Tone curve 1
+HISTORY_MSG_196;CAM02/16 - Tone curve 2
+HISTORY_MSG_197;CAM02/16 - Color curve
+HISTORY_MSG_198;CAM02/16 - Color curve
+HISTORY_MSG_199;CAM02/16 - Output histograms
+HISTORY_MSG_200;CAM02/16 - Tone mapping
 HISTORY_MSG_201;NR - Chrominance - R&amp;G
 HISTORY_MSG_202;NR - Chrominance - B&amp;Y
 HISTORY_MSG_203;NR - Color space
 HISTORY_MSG_204;LMMSE enhancement steps
-HISTORY_MSG_205;CAM02 - Hot/bad pixel filter
-HISTORY_MSG_206;CAT02 - Auto scene luminosity
+HISTORY_MSG_205;CAT02/16 - Hot/bad pixel filter
+HISTORY_MSG_206;CAT02/16 - Auto scene luminosity
 HISTORY_MSG_207;Defringe - Hue curve
 HISTORY_MSG_208;WB - B/R equalizer
 HISTORY_MSG_210;GF - Angle
@@ -737,15 +737,15 @@ HISTORY_MSG_472;PS Smooth transitions
 HISTORY_MSG_473;PS Use lmmse
 HISTORY_MSG_474;PS Equalize
 HISTORY_MSG_475;PS Equalize channel
-HISTORY_MSG_476;CAM02 - Temp out
-HISTORY_MSG_477;CAM02 - Green out
-HISTORY_MSG_478;CAM02 - Yb out
-HISTORY_MSG_479;CAM02 - CAT02 adaptation out
-HISTORY_MSG_480;CAM02 - Automatic CAT02 out
-HISTORY_MSG_481;CAM02 - Temp scene
-HISTORY_MSG_482;CAM02 - Green scene
-HISTORY_MSG_483;CAM02 - Yb scene
-HISTORY_MSG_484;CAM02 - Auto Yb scene
+HISTORY_MSG_476;CAM02/16 - Temp out
+HISTORY_MSG_477;CAM02/16 - Green out
+HISTORY_MSG_478;CAM02/16 - Yb out
+HISTORY_MSG_479;CAM02/16 - CAT02/16 adaptation out
+HISTORY_MSG_480;CAM02/16 - Automatic CAT02/16 out
+HISTORY_MSG_481;CAM02/16 - Temp scene
+HISTORY_MSG_482;CAM02/16 - Green scene
+HISTORY_MSG_483;CAM02/16 - Yb scene
+HISTORY_MSG_484;CAM02/16 - Auto Yb scene
 HISTORY_MSG_485;Lens Correction
 HISTORY_MSG_486;Lens Correction - Camera
 HISTORY_MSG_487;Lens Correction - Lens
@@ -2027,8 +2027,8 @@ TP_COLORAPP_LIGHT;Lightness (J)
 TP_COLORAPP_LIGHT_TOOLTIP;Lightness in CIECAM02 is the clarity of a stimulus relative to the clarity of a stimulus that appears white under similar viewing conditions, differs from L*a*b* and RGB lightness.
 TP_COLORAPP_MEANLUMINANCE;Mean luminance (Yb%)
 TP_COLORAPP_MODEL;WP Model
-TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
-TP_COLORAPP_MODELCAT;Model Cat
+TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02/16] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02/16 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
+TP_COLORAPP_MODELCAT;Model CAT
 TP_COLORAPP_MODELCAT_TOOLTIP;Allows you to choose between Ciecam02 or Ciecam16.\n Ciecam02 will generally be more accurate.\n Ciecam16 should generate fewer artifacts
 TP_COLORAPP_MOD02;Cat02
 TP_COLORAPP_MOD16;Cat16

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -437,14 +437,14 @@ HISTORY_MSG_171;L*a*b* - LC curve
 HISTORY_MSG_172;L*a*b* - Restrict LC
 HISTORY_MSG_173;NR - Detail recovery
 HISTORY_MSG_174;CIECAM02
-HISTORY_MSG_175;CAM02 - CAT02 adaptation
+HISTORY_MSG_175;CAM02 - CAT02/16 adaptation
 HISTORY_MSG_176;CAM02 - Viewing surround
 HISTORY_MSG_177;CAM02 - Scene luminosity
 HISTORY_MSG_178;CAM02 - Viewing luminosity
 HISTORY_MSG_179;CAM02 - White-point model
 HISTORY_MSG_180;CAM02 - Lightness (J)
 HISTORY_MSG_181;CAM02 - Chroma (C)
-HISTORY_MSG_182;CAM02 - Automatic CAT02
+HISTORY_MSG_182;CAM02 - Automatic CAT02/16
 HISTORY_MSG_183;CAM02 - Contrast (J)
 HISTORY_MSG_184;CAM02 - Scene surround
 HISTORY_MSG_185;CAM02 - Gamut control
@@ -1205,7 +1205,7 @@ HISTORY_MSG_956;Local - CH Curve
 HISTORY_MSG_957;Local - Denoise mode
 HISTORY_MSG_958;Local - Show/hide settings
 HISTORY_MSG_959;Local - Inverse blur
-HISTORY_MSG_960;Local - Log encoding - cat02
+HISTORY_MSG_960;Local - Log encoding - cat16
 HISTORY_MSG_961;Local - Log encoding Ciecam
 HISTORY_MSG_962;Local - Log encoding  Absolute luminance source
 HISTORY_MSG_963;Local - Log encoding  Absolute luminance target
@@ -1230,8 +1230,9 @@ HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
 HISTORY_MSG_BLUWAV;Attenuation response
-HISTORY_MSG_CAT02PRESET;Cat02 automatic preset
+HISTORY_MSG_CAT02PRESET;Cat02/16 automatic preset
 HISTORY_MSG_CATCOMPLEX;Ciecam complexity
+HISTORY_MSG_CATMODEL;Model Cat
 HISTORY_MSG_CLAMPOOG;Clip out-of-gamut colors
 HISTORY_MSG_COLORTONING_LABGRID_VALUE;CT - Color correction
 HISTORY_MSG_COLORTONING_LABREGION_AB;CT - Color correction
@@ -1986,7 +1987,7 @@ TP_COLORAPP_CHROMA_M_TOOLTIP;Colorfulness in CIECAM02 is the perceived amount of
 TP_COLORAPP_CHROMA_S;Saturation (S)
 TP_COLORAPP_CHROMA_S_TOOLTIP;Saturation in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness, differs from L*a*b* and RGB saturation.
 TP_COLORAPP_CHROMA_TOOLTIP;Chroma in CIECAM02 corresponds to the color of a stimulus relative to the clarity of a stimulus that appears white under identical conditions, differs from L*a*b* and RGB chroma.
-TP_COLORAPP_CIECAT_DEGREE;CAT02 adaptation
+TP_COLORAPP_CIECAT_DEGREE;CAT02/16 adaptation
 TP_COLORAPP_CONTRAST;Contrast (J), 
 TP_COLORAPP_CONTRAST_Q;Contrast (Q)
 TP_COLORAPP_CONTRAST_Q_TOOLTIP;Contrast (Q) based on brightness, differs from L*a*b* and RGB contrast.
@@ -1999,13 +2000,13 @@ TP_COLORAPP_CURVEEDITOR3;Color curve
 TP_COLORAPP_CURVEEDITOR3_TOOLTIP;Adjust either chroma, saturation or colorfulness.\n\nShows the histogram of chromaticity (L*a*b*) before CIECAM02.\nIf the "CIECAM02 output histograms in curves" checkbox is enabled, shows the histogram of C, S or M after CIECAM02.\n\nC, S and M are not shown in the main histogram panel.\nFor final output refer to the main histogram panel.
 TP_COLORAPP_DATACIE;CIECAM02 output histograms in curves
 TP_COLORAPP_DATACIE_TOOLTIP;When enabled, histograms in CIECAM02 curves show approximate values/ranges for J or Q, and C, s or M after the CIECAM02 adjustments.\nThis selection does not impact the main histogram panel.\n\nWhen disabled, histograms in CIECAM02 curves show L*a*b* values before CIECAM02 adjustments.
-TP_COLORAPP_DEGREE_TOOLTIP;CAT02 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D65), into new values whose white point is that of the new illuminant - see WP Model (for example D50 or D55).
-TP_COLORAPP_DEGREOUT_TOOLTIP;CAT02 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D50), into new values whose white point is that of the new illuminant - see WP model (for example D75).
-TP_COLORAPP_FREE;Free temp+green + CAT02 + [output]
+TP_COLORAPP_DEGREE_TOOLTIP;CAT02/16 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D65), into new values whose white point is that of the new illuminant - see WP Model (for example D50 or D55).
+TP_COLORAPP_DEGREOUT_TOOLTIP;CAT02/16 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D50), into new values whose white point is that of the new illuminant - see WP model (for example D75).
+TP_COLORAPP_FREE;Free temp+green + CAT02/16 + [output]
 TP_COLORAPP_GAMUT;Gamut control (L*a*b*)
 TP_COLORAPP_GAMUT_TOOLTIP;Allow gamut control in L*a*b* mode.
 TP_COLORAPP_GEN;Settings - Preset
-TP_COLORAPP_GEN_TOOLTIP;This module is based on the CIECAM02 color appearance model, which was designed to better simulate how human vision perceives colors under different lighting conditions, e.g., against different backgrounds.\nIt takes into account the environment of each color and modifies its appearance to get as close as possible to human perception.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic appearance is preserved across the scene and display environments.
+TP_COLORAPP_GEN_TOOLTIP;This module is based on the CIECAM color appearance model, which was designed to better simulate how human vision perceives colors under different lighting conditions, e.g., against different backgrounds.\nIt takes into account the environment of each color and modifies its appearance to get as close as possible to human perception.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic appearance is preserved across the scene and display environments.
 TP_COLORAPP_HUE;Hue (h)
 TP_COLORAPP_HUE_TOOLTIP;Hue (h) is the degree to which a stimulus can be described as similar to a color described as red, green, blue and yellow.
 TP_COLORAPP_IL41;D41
@@ -2018,7 +2019,7 @@ TP_COLORAPP_ILA;Incandescent StdA 2856K
 TP_COLORAPP_ILFREE;Free
 TP_COLORAPP_ILLUM;Illuminant
 TP_COLORAPP_ILLUM_TOOLTIP;Select the illuminant closest to the shooting conditions.\nIn general D50, but it can change depending on the time and lattitude.
-TP_COLORAPP_LABEL;Color Appearance & Lighting (CIECAM02)
+TP_COLORAPP_LABEL;Color Appearance & Lighting (CIECAM02/16)
 TP_COLORAPP_LABEL_CAM02;Image Adjustments
 TP_COLORAPP_LABEL_SCENE;Scene Conditions
 TP_COLORAPP_LABEL_VIEWING;Viewing Conditions
@@ -2027,10 +2028,14 @@ TP_COLORAPP_LIGHT_TOOLTIP;Lightness in CIECAM02 is the clarity of a stimulus rel
 TP_COLORAPP_MEANLUMINANCE;Mean luminance (Yb%)
 TP_COLORAPP_MODEL;WP Model
 TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
+TP_COLORAPP_MODELCAT;Model Cat
+TP_COLORAPP_MODELCAT_TOOLTIP;Allows you to choose between Ciecam02 or Ciecam16.\n Ciecam02 will generally be more accurate.\n Ciecam16 should generate fewer artifacts
+TP_COLORAPP_MOD02;Cat02
+TP_COLORAPP_MOD16;Cat16
 TP_COLORAPP_NEUTRAL;Reset
 TP_COLORAPP_NEUTRAL_TIP;Reset all sliders checkbox and curves to their default values
-TP_COLORAPP_PRESETCAT02;Preset cat02 automatic - Symetric mode
-TP_COLORAPP_PRESETCAT02_TIP;Set combobox, sliders, temp, green so that Cat02 automatic is preset.\nYou can change illuminant shooting conditions.\nYou must change Cat02 adaptation Viewing conditions if needed.\nYou can change Temperature and Tint Viewing conditions if needed, and other settings if needed. 
+TP_COLORAPP_PRESETCAT02;Preset cat02/16 automatic - Symmetric mode
+TP_COLORAPP_PRESETCAT02_TIP;Set combobox, sliders, temp, green so that Cat02/16 automatic is preset.\nYou can change illuminant shooting conditions.\nYou must change Cat02/16 adaptation Viewing conditions if needed.\nYou can change Temperature and Tint Viewing conditions if needed, and other settings if needed. 
 TP_COLORAPP_RSTPRO;Red & skin-tones protection
 TP_COLORAPP_RSTPRO_TOOLTIP;Red &amp; skin-tones protection affects both sliders and curves.
 TP_COLORAPP_SOURCEF_TOOLTIP;Corresponds to the shooting conditions and how to bring the conditions and data back to a "normal" area. Normal" means average or standard conditions and data, i.e. without taking into account CIECAM corrections.
@@ -2057,7 +2062,7 @@ TP_COLORAPP_TONECIE;Tone mapping using CIECAM02
 TP_COLORAPP_TONECIE_TOOLTIP;If this option is disabled, tone mapping is done in L*a*b* space.\nIf this option is enabled, tone mapping is done using CIECAM02.\nThe Tone Mapping tool must be enabled for this setting to take effect.
 TP_COLORAPP_VIEWINGF_TOOLTIP;Takes into account the support on which the final image will be viewed (monitor, TV, projector, printer, ...), as well as its environment. This process will take the data coming from process "Image Adjustments" and "bring" it to the support in such a way that the viewing conditions and its environment are taken into account.
 TP_COLORAPP_VIEWING_ABSOLUTELUMINANCE_TOOLTIP;Absolute luminance of the viewing environment\n(usually 16 cd/m²).
-TP_COLORAPP_WBCAM;WB [RT+CAT02] + [output]
+TP_COLORAPP_WBCAM;WB [RT+CAT02/16] + [output]
 TP_COLORAPP_WBRT;WB [RT] + [output]
 TP_COLORAPP_YBOUT_TOOLTIP;Yb is the relative luminance of the background, expressed in % of gray. A gray at 18% corresponds to a background luminance expressed in CIE L of 50%.\nThis data must take into account the average luminance of the image
 TP_COLORAPP_YBSCEN_TOOLTIP;Yb is the relative luminance of the background, expressed in % of gray. A gray at 18% corresponds to a background luminance expressed in CIE L of 50%.\nThis data is calculated from the average luminance of the image
@@ -2457,7 +2462,7 @@ TP_LOCALLAB_BUTTON_DEL;Delete
 TP_LOCALLAB_BUTTON_DUPL;Duplicate
 TP_LOCALLAB_BUTTON_REN;Rename
 TP_LOCALLAB_BUTTON_VIS;Show/Hide
-TP_LOCALLAB_CATAD;Chromatic adaptation - Cat02
+TP_LOCALLAB_CATAD;Chromatic adaptation - Cat16
 TP_LOCALLAB_CBDL;Contrast by Detail Levels
 TP_LOCALLAB_CBDLCLARI_TOOLTIP;Enhances local contrast of the midtones.
 TP_LOCALLAB_CBDL_ADJ_TOOLTIP;Same as wavelets.\nThe first level (0) acts on 2x2 pixel details.\nThe last level (5) acts on 64x64 pixel details.
@@ -2476,7 +2481,7 @@ TP_LOCALLAB_CHROMASKCOL;Chroma
 TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. C(C) or LC(H) is activated).
 TP_LOCALLAB_CHRRT;Chroma
 TP_LOCALLAB_CIEC;Use Ciecam environment parameters
-TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nThe first Ciecam process 'Scene conditions' is carried out by Log encoding, it also uses 'Absolute luminance' at the time of shooting.\nThe second Ciecam process  'Image adjustments' is simplified and uses only 3 variables (local contrast, contrast J, saturation s).\nThe third Ciecam process  'Viewing conditions' adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
+TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nThe first Ciecam process 'Scene conditions' is carried out by Log encoding, it also uses 'Absolute luminance' at the time of shooting.\nThe second Ciecam process  'Image adjustments' is simplified and uses only 3 variables (local contrast, contrast J, saturation s).\nThe third Ciecam process  'Viewing conditions' adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
 TP_LOCALLAB_CIRCRADIUS;Spot size
 TP_LOCALLAB_CIRCRAD_TOOLTIP;Contains the references of the RT-spot, useful for shape detection (hue, luma, chroma, Sobel).\nLow values may be useful for treating foliage.\nHigh values may be useful for treating skin
 TP_LOCALLAB_CLARICRES;Merge chroma
@@ -3709,7 +3714,7 @@ ZOOMPANEL_ZOOMFITCROPSCREEN;Fit crop to screen\nShortcut: <b>f</b>
 ZOOMPANEL_ZOOMFITSCREEN;Fit whole image to screen\nShortcut: <b>Alt</b>-<b>f</b>
 ZOOMPANEL_ZOOMIN;Zoom In\nShortcut: <b>+</b>
 ZOOMPANEL_ZOOMOUT;Zoom Out\nShortcut: <b>-</b>
-//TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM02 color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as part of the second (contrast J, saturation s) , as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
+//TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nOnly the third Ciecam process (Viewing conditions - Target) is taken into account, as well as part of the second (contrast J, saturation s) , as well as some data from the first process (Scene conditions - Source) which is used for the Log encoding.\nIt also adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
 //TP_WAVELET_DENH;Low levels (1234)- Finest details
 //TP_WAVELET_DENL;High levels - Coarsest details
 //TP_WAVELET_DENLH;Guided threshold by detail levels 1-4

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1988,10 +1988,10 @@ TP_COLORAPP_CHROMA_S;Saturation (S)
 TP_COLORAPP_CHROMA_S_TOOLTIP;Saturation in CIECAM02/16 corresponds to the color of a stimulus in relation to its own brightness, differs from L*a*b* and RGB saturation.
 TP_COLORAPP_CHROMA_TOOLTIP;Chroma in CIECAM02/16 corresponds to the color of a stimulus relative to the clarity of a stimulus that appears white under identical conditions, differs from L*a*b* and RGB chroma.
 TP_COLORAPP_CIECAT_DEGREE;CAT02/16 adaptation
-TP_COLORAPP_CONTRAST;Contrast (J), 
+TP_COLORAPP_CONTRAST;Contrast (J) 
 TP_COLORAPP_CONTRAST_Q;Contrast (Q)
-TP_COLORAPP_CONTRAST_Q_TOOLTIP;Contrast (Q) based on brightness, differs from L*a*b* and RGB contrast.
-TP_COLORAPP_CONTRAST_TOOLTIP;Contrast (J) based on lightness, differs from L*a*b* and RGB contrast.
+TP_COLORAPP_CONTRAST_Q_TOOLTIP;Contrast (Q) in CIECAM02/16 is based on brightness, differs from L*a*b* and RGB contrast.
+TP_COLORAPP_CONTRAST_TOOLTIP;Contrast (J) in CIECAM02/16 is based on lightness, differs from L*a*b* and RGB contrast.
 TP_COLORAPP_CURVEEDITOR1;Tone curve 1
 TP_COLORAPP_CURVEEDITOR1_TOOLTIP;Shows the histogram of L* (L*a*b*) before CIECAM02/16.\nIf the "CIECAM02/16 output histograms in curves" checkbox is enabled, shows the histogram of J or Q after CIECAM02/16.\n\nJ and Q are not shown in the main histogram panel.\n\nFor final output refer to the main histogram panel.
 TP_COLORAPP_CURVEEDITOR2;Tone curve 2
@@ -2029,7 +2029,7 @@ TP_COLORAPP_MEANLUMINANCE;Mean luminance (Yb%)
 TP_COLORAPP_MODEL;WP Model
 TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02/16 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02/16] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02/16 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
 TP_COLORAPP_MODELCAT;CAM Model
-TP_COLORAPP_MODELCAT_TOOLTIP;Allows you to choose between Ciecam02 or Ciecam16.\n Ciecam02 will generally be more accurate.\n Ciecam16 should generate fewer artifacts
+TP_COLORAPP_MODELCAT_TOOLTIP;Allows you to choose between CIECAM02 or CIECAM16.\n CIECAM02 will sometimes be more accurate.\n CIECAM16 should generate fewer artifacts
 TP_COLORAPP_MOD02;CIECAM02
 TP_COLORAPP_MOD16;CIECAM16
 TP_COLORAPP_NEUTRAL;Reset

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -436,7 +436,7 @@ HISTORY_MSG_170;Vibrance - HH curve
 HISTORY_MSG_171;L*a*b* - LC curve
 HISTORY_MSG_172;L*a*b* - Restrict LC
 HISTORY_MSG_173;NR - Detail recovery
-HISTORY_MSG_174;CIECAM02
+HISTORY_MSG_174;CIECAM02/16
 HISTORY_MSG_175;CAM02/16 - CAT02/16 adaptation
 HISTORY_MSG_176;CAM02/16 - Viewing surround
 HISTORY_MSG_177;CAM02/16 - Scene luminosity
@@ -1232,7 +1232,7 @@ HISTORY_MSG_BLURWAV;Blur luminance
 HISTORY_MSG_BLUWAV;Attenuation response
 HISTORY_MSG_CAT02PRESET;Cat02/16 automatic preset
 HISTORY_MSG_CATCOMPLEX;Ciecam complexity
-HISTORY_MSG_CATMODEL;Model Cat
+HISTORY_MSG_CATMODEL;CAM Model
 HISTORY_MSG_CLAMPOOG;Clip out-of-gamut colors
 HISTORY_MSG_COLORTONING_LABGRID_VALUE;CT - Color correction
 HISTORY_MSG_COLORTONING_LABREGION_AB;CT - Color correction
@@ -1542,7 +1542,7 @@ PARTIALPASTE_CACORRECTION;Chromatic aberration correction
 PARTIALPASTE_CHANNELMIXER;Channel mixer
 PARTIALPASTE_CHANNELMIXERBW;Black-and-white
 PARTIALPASTE_COARSETRANS;Coarse rotation/flipping
-PARTIALPASTE_COLORAPP;CIECAM02
+PARTIALPASTE_COLORAPP;CIECAM02/16
 PARTIALPASTE_COLORGROUP;Color Related Settings
 PARTIALPASTE_COLORTONING;Color toning
 PARTIALPASTE_COMMONTRANSFORMPARAMS;Auto-fill
@@ -1979,27 +1979,27 @@ TP_COLORAPP_ALGO_TOOLTIP;Lets you choose between parameter subsets or all parame
 TP_COLORAPP_BADPIXSL;Hot/bad pixel filter
 TP_COLORAPP_BADPIXSL_TOOLTIP;Suppression of hot/bad (brightly colored) pixels.\n0 = No effect\n1 = Median\n2 = Gaussian.\nAlternatively, adjust the image to avoid very dark shadows.\n\nThese artifacts are due to limitations of CIECAM02.
 TP_COLORAPP_BRIGHT;Brightness (Q)
-TP_COLORAPP_BRIGHT_TOOLTIP;Brightness in CIECAM02 is the amount of perceived light emanating from a stimulus and differs from L*a*b* and RGB brightness.
+TP_COLORAPP_BRIGHT_TOOLTIP;Brightness in CIECAM02/16 is the amount of perceived light emanating from a stimulus and differs from L*a*b* and RGB brightness.
 TP_COLORAPP_CAT02ADAPTATION_TOOLTIP;When setting manually, values above 65 are recommended.
 TP_COLORAPP_CHROMA;Chroma (C)
 TP_COLORAPP_CHROMA_M;Colorfulness (M)
-TP_COLORAPP_CHROMA_M_TOOLTIP;Colorfulness in CIECAM02 is the perceived amount of hue in relation to gray, an indicator that a stimulus appears to be more or less colored.
+TP_COLORAPP_CHROMA_M_TOOLTIP;Colorfulness in CIECAM02/16 is the perceived amount of hue in relation to gray, an indicator that a stimulus appears to be more or less colored.
 TP_COLORAPP_CHROMA_S;Saturation (S)
-TP_COLORAPP_CHROMA_S_TOOLTIP;Saturation in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness, differs from L*a*b* and RGB saturation.
-TP_COLORAPP_CHROMA_TOOLTIP;Chroma in CIECAM02 corresponds to the color of a stimulus relative to the clarity of a stimulus that appears white under identical conditions, differs from L*a*b* and RGB chroma.
+TP_COLORAPP_CHROMA_S_TOOLTIP;Saturation in CIECAM02/16 corresponds to the color of a stimulus in relation to its own brightness, differs from L*a*b* and RGB saturation.
+TP_COLORAPP_CHROMA_TOOLTIP;Chroma in CIECAM02/16 corresponds to the color of a stimulus relative to the clarity of a stimulus that appears white under identical conditions, differs from L*a*b* and RGB chroma.
 TP_COLORAPP_CIECAT_DEGREE;CAT02/16 adaptation
 TP_COLORAPP_CONTRAST;Contrast (J), 
 TP_COLORAPP_CONTRAST_Q;Contrast (Q)
 TP_COLORAPP_CONTRAST_Q_TOOLTIP;Contrast (Q) based on brightness, differs from L*a*b* and RGB contrast.
 TP_COLORAPP_CONTRAST_TOOLTIP;Contrast (J) based on lightness, differs from L*a*b* and RGB contrast.
 TP_COLORAPP_CURVEEDITOR1;Tone curve 1
-TP_COLORAPP_CURVEEDITOR1_TOOLTIP;Shows the histogram of L* (L*a*b*) before CIECAM02.\nIf the "CIECAM02 output histograms in curves" checkbox is enabled, shows the histogram of J or Q after CIECAM02.\n\nJ and Q are not shown in the main histogram panel.\n\nFor final output refer to the main histogram panel.
+TP_COLORAPP_CURVEEDITOR1_TOOLTIP;Shows the histogram of L* (L*a*b*) before CIECAM02/16.\nIf the "CIECAM02/16 output histograms in curves" checkbox is enabled, shows the histogram of J or Q after CIECAM02/16.\n\nJ and Q are not shown in the main histogram panel.\n\nFor final output refer to the main histogram panel.
 TP_COLORAPP_CURVEEDITOR2;Tone curve 2
 TP_COLORAPP_CURVEEDITOR2_TOOLTIP;Same usage as with the second exposure tone curve.
 TP_COLORAPP_CURVEEDITOR3;Color curve
-TP_COLORAPP_CURVEEDITOR3_TOOLTIP;Adjust either chroma, saturation or colorfulness.\n\nShows the histogram of chromaticity (L*a*b*) before CIECAM02.\nIf the "CIECAM02 output histograms in curves" checkbox is enabled, shows the histogram of C, S or M after CIECAM02.\n\nC, S and M are not shown in the main histogram panel.\nFor final output refer to the main histogram panel.
-TP_COLORAPP_DATACIE;CIECAM02 output histograms in curves
-TP_COLORAPP_DATACIE_TOOLTIP;When enabled, histograms in CIECAM02 curves show approximate values/ranges for J or Q, and C, s or M after the CIECAM02 adjustments.\nThis selection does not impact the main histogram panel.\n\nWhen disabled, histograms in CIECAM02 curves show L*a*b* values before CIECAM02 adjustments.
+TP_COLORAPP_CURVEEDITOR3_TOOLTIP;Adjust either chroma, saturation or colorfulness.\n\nShows the histogram of chromaticity (L*a*b*) before CIECAM02/16.\nIf the "CIECAM02/16 output histograms in curves" checkbox is enabled, shows the histogram of C, S or M after CIECAM02/16.\n\nC, S and M are not shown in the main histogram panel.\nFor final output refer to the main histogram panel.
+TP_COLORAPP_DATACIE;CIECAM02/16 output histograms in curves
+TP_COLORAPP_DATACIE_TOOLTIP;When enabled, histograms in CIECAM02/16 curves show approximate values/ranges for J or Q, and C, s or M after the CIECAM02/16 adjustments.\nThis selection does not impact the main histogram panel.\n\nWhen disabled, histograms in CIECAM02/16 curves show L*a*b* values before CIECAM02/16 adjustments.
 TP_COLORAPP_DEGREE_TOOLTIP;CAT02/16 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D65), into new values whose white point is that of the new illuminant - see WP Model (for example D50 or D55).
 TP_COLORAPP_DEGREOUT_TOOLTIP;CAT02/16 is a chromatic adaptation, it converts the values of an image whose white point is that of a given illuminant (for example D50), into new values whose white point is that of the new illuminant - see WP model (for example D75).
 TP_COLORAPP_FREE;Free temp+green + CAT02/16 + [output]
@@ -2024,14 +2024,14 @@ TP_COLORAPP_LABEL_CAM02;Image Adjustments
 TP_COLORAPP_LABEL_SCENE;Scene Conditions
 TP_COLORAPP_LABEL_VIEWING;Viewing Conditions
 TP_COLORAPP_LIGHT;Lightness (J)
-TP_COLORAPP_LIGHT_TOOLTIP;Lightness in CIECAM02 is the clarity of a stimulus relative to the clarity of a stimulus that appears white under similar viewing conditions, differs from L*a*b* and RGB lightness.
+TP_COLORAPP_LIGHT_TOOLTIP;Lightness in CIECAM02/16 is the clarity of a stimulus relative to the clarity of a stimulus that appears white under similar viewing conditions, differs from L*a*b* and RGB lightness.
 TP_COLORAPP_MEANLUMINANCE;Mean luminance (Yb%)
 TP_COLORAPP_MODEL;WP Model
-TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02/16] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02/16 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
-TP_COLORAPP_MODELCAT;Model CAT
+TP_COLORAPP_MODEL_TOOLTIP;White-Point Model.\n\n<b>WB [RT] + [output]</b>: RT's white balance is used for the scene, CIECAM02/16 is set to D50, and the output device's white balance is set in Viewing Conditions.\n\n<b>WB [RT+CAT02/16] + [output]</b>: RT's white balance settings are used by CAT02 and the output device's white balance is set in Viewing Conditions.\n\n<b>Free temp+green + CAT02/16 + [output]:</b> temp and green are selected by the user, the output device's white balance is set in Viewing Conditions.
+TP_COLORAPP_MODELCAT;CAM Model
 TP_COLORAPP_MODELCAT_TOOLTIP;Allows you to choose between Ciecam02 or Ciecam16.\n Ciecam02 will generally be more accurate.\n Ciecam16 should generate fewer artifacts
-TP_COLORAPP_MOD02;Cat02
-TP_COLORAPP_MOD16;Cat16
+TP_COLORAPP_MOD02;CIECAM02
+TP_COLORAPP_MOD16;CIECAM16
 TP_COLORAPP_NEUTRAL;Reset
 TP_COLORAPP_NEUTRAL_TIP;Reset all sliders checkbox and curves to their default values
 TP_COLORAPP_PRESETCAT02;Preset cat02/16 automatic - Symmetric mode
@@ -2058,7 +2058,7 @@ TP_COLORAPP_TCMODE_SATUR;Saturation
 TP_COLORAPP_TEMP2_TOOLTIP;Either symmetrical mode temp = White balance.\nEither select illuminant always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
 TP_COLORAPP_TEMPOUT_TOOLTIP;Disable to change temperature and tint
 TP_COLORAPP_TEMP_TOOLTIP;To select an illuminant, always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
-TP_COLORAPP_TONECIE;Tone mapping using CIECAM02
+TP_COLORAPP_TONECIE;Tone mapping using CIECAM02/16
 TP_COLORAPP_TONECIE_TOOLTIP;If this option is disabled, tone mapping is done in L*a*b* space.\nIf this option is enabled, tone mapping is done using CIECAM02.\nThe Tone Mapping tool must be enabled for this setting to take effect.
 TP_COLORAPP_VIEWINGF_TOOLTIP;Takes into account the support on which the final image will be viewed (monitor, TV, projector, printer, ...), as well as its environment. This process will take the data coming from process "Image Adjustments" and "bring" it to the support in such a way that the viewing conditions and its environment are taken into account.
 TP_COLORAPP_VIEWING_ABSOLUTELUMINANCE_TOOLTIP;Absolute luminance of the viewing environment\n(usually 16 cd/m²).
@@ -2714,8 +2714,8 @@ TP_LOCALLAB_LOGCOLORFL;Colorfulness (M)
 TP_LOCALLAB_LOGCOLORF_TOOLTIP;Perceived amount of hue in relation to gray.\nIndicator that a stimulus appears more or less colored.
 TP_LOCALLAB_LOGCONQL;Contrast (Q)
 TP_LOCALLAB_LOGCONTL;Contrast (J)
-TP_LOCALLAB_LOGCONTL_TOOLTIP;Contrast (J) in CIECAM02 takes into account the increase in perceived coloration with luminance.
-TP_LOCALLAB_LOGCONTQ_TOOLTIP;Contrast (Q) in CIECAM02 takes into account the increase in perceived coloration with brightness.
+TP_LOCALLAB_LOGCONTL_TOOLTIP;Contrast (J) in CIECAM16 takes into account the increase in perceived coloration with luminance.
+TP_LOCALLAB_LOGCONTQ_TOOLTIP;Contrast (Q) in CIECAM16 takes into account the increase in perceived coloration with brightness.
 TP_LOCALLAB_LOGDETAIL_TOOLTIP;Acts mainly on high frequencies.
 TP_LOCALLAB_LOGENCOD_TOOLTIP;Tone Mapping with Logarithmic encoding (ACES).\nUseful for underexposed images or images with high dynamic range.\n\nTwo-step process : 1) Dynamic Range calculation 2) Manual adjustment
 TP_LOCALLAB_LOGEXP;All tools
@@ -2730,7 +2730,7 @@ TP_LOCALLAB_LOGLIN;Logarithm mode
 TP_LOCALLAB_LOGPFRA;Relative Exposure Levels
 TP_LOCALLAB_LOGREPART;Strength
 TP_LOCALLAB_LOGREPART_TOOLTIP;Allows you to adjust the relative strength of the log-encoded image with respect to the original image.\nDoes not affect the Ciecam component.
-TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM02 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and highlights tones
+TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM16 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and highlights tones
 TP_LOCALLAB_LOGSCENE_TOOLTIP;Corresponds to the shooting conditions.
 TP_LOCALLAB_LOGSRCGREY_TOOLTIP;Estimated gray point value of the image.
 TP_LOCALLAB_LOGSURSOUR_TOOLTIP;Changes tones and colors to take into account the Scene conditions.\n\n<b>Average</b>: Average light environment (standard). The image will not change.\n\n<b>Dim</b>: Dim environment. The image will become slightly bright.

--- a/rtengine/ciecam02.cc
+++ b/rtengine/ciecam02.cc
@@ -182,7 +182,7 @@ float Ciecam02::calculate_fl_from_la_ciecam02float ( float la )
     return (0.2f * k * la5) + (0.1f * (1.0f - k) * (1.0f - k) * std::cbrt (la5));
 }
 
-float Ciecam02::achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb, float c16)
+float Ciecam02::achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb, int c16)
 {
     float r, g, b;
     float rc, gc, bc;
@@ -195,13 +195,17 @@ float Ciecam02::achromatic_response_to_whitefloat ( float x, float y, float z, f
     gc = g * (((y * d) / g) + (1.0f - d));
     bc = b * (((y * d) / b) + (1.0f - d));
 
-    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc);
+    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
 
-//    if (gamu == 1) { //gamut correction M.H.Brill S.Susstrunk
-    rp = MAXR (rp, 0.0f);
-    gp = MAXR (gp, 0.0f);
-    bp = MAXR (bp, 0.0f);
-//    }
+    if(c16 ==1) {
+        rp = MAXR (rp, 0.0f);
+        gp = MAXR (gp, 0.0f);
+        bp = MAXR (bp, 0.0f);
+    } else {
+        rp = MAXR (rc, 0.0f);
+        gp = MAXR (gc, 0.0f);
+        bp = MAXR (bc, 0.0f);
+    }
 
     rpa = nonlinear_adaptationfloat ( rp, fl );
     gpa = nonlinear_adaptationfloat ( gp, fl );
@@ -210,23 +214,17 @@ float Ciecam02::achromatic_response_to_whitefloat ( float x, float y, float z, f
     return ((2.0f * rpa) + gpa + ((1.0f / 20.0f) * bpa) - 0.305f) * nbb;
 }
 
-void Ciecam02::xyz_to_cat02float ( float &r, float &g, float &b, float x, float y, float z, float c16)
+void Ciecam02::xyz_to_cat02float ( float &r, float &g, float &b, float x, float y, float z, int c16)
 {
-//    gamu = 1;
-//
-//    if (gamu == 0) {
-//        r = ( 0.7328f * x) + (0.4296f * y) - (0.1624f * z);
-//        g = (-0.7036f * x) + (1.6975f * y) + (0.0061f * z);
-//        b = ( 0.0030f * x) + (0.0136f * y) + (0.9834f * z);
-//    } else if (gamu == 1) { //gamut correction M.H.Brill S.Susstrunk
+    //original cat02
     //r = ( 0.7328 * x) + (0.4296 * y) - (0.1624 * z);
     //g = (-0.7036 * x) + (1.6975 * y) + (0.0061 * z);
     //b = ( 0.0000 * x) + (0.0000 * y) + (1.0000 * z);
-    if(c16 == 1.f) {
+    if(c16 == 1) {//cat02
         r = ( 1.007245f * x) + (0.011136f * y) - (0.018381f * z); //Changjun Li
         g = (-0.318061f * x) + (1.314589f * y) + (0.003471f * z);
         b = ( 0.0000f * x) + (0.0000f * y) + (1.0000f * z);
-    } else {
+    } else {//cat16
         r = ( 0.401288f * x) + (0.650173f * y) - (0.051461f * z); //cat16
         g = (-0.250268f * x) + (1.204414f * y) + (0.045854f * z);
         b = ( -0.002079f * x) + (0.048952f * y) + (0.953127f * z);
@@ -235,104 +233,108 @@ void Ciecam02::xyz_to_cat02float ( float &r, float &g, float &b, float x, float 
 //    }
 }
 #ifdef __SSE2__
-void Ciecam02::xyz_to_cat02float ( vfloat &r, vfloat &g, vfloat &b, vfloat x, vfloat y, vfloat z, float c16)
+void Ciecam02::xyz_to_cat02float ( vfloat &r, vfloat &g, vfloat &b, vfloat x, vfloat y, vfloat z, int c16)
 {
     //gamut correction M.H.Brill S.Susstrunk
-    if(c16 == 1.f) {
+    if(c16 == 1) {
         r = ( F2V (1.007245f) * x) + (F2V (0.011136f) * y) - (F2V (0.018381f) * z); //Changjun Li
         g = (F2V (-0.318061f) * x) + (F2V (1.314589f) * y) + (F2V (0.003471f) * z);
         b = z;
     } else {
-
     //cat16
-    r = ( F2V (0.401288f) * x) + (F2V (0.650173f) * y) - (F2V (0.051461f) * z); //Changjun Li
-    g = -(F2V (0.250268f) * x) + (F2V (1.204414f) * y) + (F2V (0.045854f) * z);
-    b = -(F2V(0.002079f) * x) + (F2V(0.048952f) * y) + (F2V(0.953127f) * z);
+        r = ( F2V (0.401288f) * x) + (F2V (0.650173f) * y) - (F2V (0.051461f) * z); //Changjun Li
+        g = -(F2V (0.250268f) * x) + (F2V (1.204414f) * y) + (F2V (0.045854f) * z);
+        b = -(F2V(0.002079f) * x) + (F2V(0.048952f) * y) + (F2V(0.953127f) * z);
     }
 }
 #endif
 
-void Ciecam02::cat02_to_xyzfloat ( float &x, float &y, float &z, float r, float g, float b, float c16)
+void Ciecam02::cat02_to_xyzfloat ( float &x, float &y, float &z, float r, float g, float b, int c16)
 {
-//    gamu = 1;
-//
-//    if (gamu == 0) {
-//        x = ( 1.096124f * r) - (0.278869f * g) + (0.182745f * b);
-//        y = ( 0.454369f * r) + (0.473533f * g) + (0.072098f * b);
-//        z = (-0.009628f * r) - (0.005698f * g) + (1.015326f * b);
-//    } else if (gamu == 1) { //gamut correction M.H.Brill S.Susstrunk
+    //original cat02
     //x = ( 1.0978566 * r) - (0.277843 * g) + (0.179987 * b);
     //y = ( 0.455053 * r) + (0.473938 * g) + (0.0710096* b);
     //z = ( 0.000000 * r) - (0.000000 * g) + (1.000000 * b);
-    if(c16 == 1.f) {
+    if(c16 == 1) {
         x = ( 0.99015849f * r) - (0.00838772f * g) + (0.018229217f * b); //Changjun Li
         y = ( 0.239565979f * r) + (0.758664642f * g) + (0.001770137f * b);
         z = ( 0.000000f * r) - (0.000000f * g) + (1.000000f * b);
-    } else {
-
-        x = ( 1.862068f * r) - (1.011255f * g) + (0.149187f * b); //Cat16
-        y = ( 0.38752f * r) + (0.621447f * g) + (-0.008974f * b);
-        z = ( -0.015841f * r) - (0.034123f * g) + (1.049964f * b);
+    } else {//cat16
+        x = ( 1.86206786f * r) - (1.01125463f * g) + (0.14918677f * b); //Cat16
+        y = ( 0.38752654f * r) + (0.62144744f * g) + (-0.00897398f * b);
+        z = ( -0.0158415f * r) - (0.03412294f * g) + (1.04996444f * b);
     }
 
 //    }
 }
 #ifdef __SSE2__
-void Ciecam02::cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, float c16 )
+void Ciecam02::cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, int c16 )
 {
     //gamut correction M.H.Brill S.Susstrunk
-    if(c16 == 1.f) {
+    if(c16 == 1) {//cat02
         x = ( F2V (0.99015849f) * r) - (F2V (0.00838772f) * g) + (F2V (0.018229217f) * b); //Changjun Li
         y = ( F2V (0.239565979f) * r) + (F2V (0.758664642f) * g) + (F2V (0.001770137f) * b);
-    z = b;} else {
-  //cat16  
-        x = ( F2V (1.862068f) * r) - (F2V (1.011255f) * g) + (F2V (0.149187f) * b);
-        y = ( F2V (0.38752f) * r) + (F2V (0.621447f) * g) - (F2V (0.008974f) * b);
-        z = -(F2V(0.015841f) * r) - (F2V(0.034123f) * g) + (F2V(1.049964f) * b);
+        z = b;
+        } else {
+        //cat16  
+        x = ( F2V (1.86206786f) * r) - (F2V (1.01125463f) * g) + (F2V (0.14918677f) * b);
+        y = ( F2V (0.38752654f) * r) + (F2V (0.621447744f) * g) - (F2V (0.00897398f) * b);
+        z = -(F2V(0.0158415f) * r) - (F2V(0.03412294f) * g) + (F2V(1.04996444f) * b);
     }
     
 }
 #endif
 
-void Ciecam02::hpe_to_xyzfloat ( float &x, float &y, float &z, float r, float g, float b )
+void Ciecam02::hpe_to_xyzfloat ( float &x, float &y, float &z, float r, float g, float b, int c16)
 {
-    x = (1.910197f * r) - (1.112124f * g) + (0.201908f * b);
-    y = (0.370950f * r) + (0.629054f * g) - (0.000008f * b);
-    z = b;
-    
-    
+        x = (1.910197f * r) - (1.112124f * g) + (0.201908f * b);
+        y = (0.370950f * r) + (0.629054f * g) - (0.000008f * b);
+        z = b;
 }
 #ifdef __SSE2__
-void Ciecam02::hpe_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b )
+void Ciecam02::hpe_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, int c16)
 {
-    x = (F2V (1.910197f) * r) - (F2V (1.112124f) * g) + (F2V (0.201908f) * b);
-    y = (F2V (0.370950f) * r) + (F2V (0.629054f) * g) - (F2V (0.000008f) * b);
-    z = b;
+        x = (F2V (1.910197f) * r) - (F2V (1.112124f) * g) + (F2V (0.201908f) * b);
+        y = (F2V (0.370950f) * r) + (F2V (0.629054f) * g) - (F2V (0.000008f) * b);
+        z = b;
 }
 #endif
 
-void Ciecam02::cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, float g, float b)
+void Ciecam02::cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, float g, float b, int c16)
 {
-//    gamu = 1;
-//
-//    if (gamu == 0) {
+// original cat02
 //        rh = ( 0.7409792f * r) + (0.2180250f * g) + (0.0410058f * b);
 //        gh = ( 0.2853532f * r) + (0.6242014f * g) + (0.0904454f * b);
 //        bh = (-0.0096280f * r) - (0.0056980f * g) + (1.0153260f * b);
 //    } else if (gamu == 1) { //Changjun Li
-    rh = ( 0.550930835f * r) + (0.519435987f * g) - ( 0.070356303f * b);
-    gh = ( 0.055954056f * r) + (0.89973132f * g) + (0.044315524f * b);
-    bh = (0.0f * r) - (0.0f * g) + (1.0f * b);
+    if(c16 == 1) {//cat02
+        rh = ( 0.550930835f * r) + (0.519435987f * g) - ( 0.070356303f * b);
+        gh = ( 0.055954056f * r) + (0.89973132f * g) + (0.044315524f * b);
+        bh = (0.0f * r) - (0.0f * g) + (1.0f * b);
+    } else {//cat16
+        rh = ( 1.f * r) + (0.f * g) + ( 0.f * b);
+        gh = ( 0.f * r) + (1.f * g) + (0.f * b);
+        bh = (0.0f * r) + (0.0f * g) + (1.0f * b);
+   
+    }
+
 //    }
 }
 
 #ifdef __SSE2__
-void Ciecam02::cat02_to_hpefloat ( vfloat &rh, vfloat &gh, vfloat &bh, vfloat r, vfloat g, vfloat b)
+void Ciecam02::cat02_to_hpefloat ( vfloat &rh, vfloat &gh, vfloat &bh, vfloat r, vfloat g, vfloat b, int c16)
 {
+    if(c16 == 1) {
     //Changjun Li
-    rh = ( F2V (0.550930835f) * r) + (F2V (0.519435987f) * g) - ( F2V (0.070356303f) * b);
-    gh = ( F2V (0.055954056f) * r) + (F2V (0.89973132f) * g) + (F2V (0.044315524f) * b);
-    bh = b;
+        rh = ( F2V (0.550930835f) * r) + (F2V (0.519435987f) * g) - ( F2V (0.070356303f) * b);
+        gh = ( F2V (0.055954056f) * r) + (F2V (0.89973132f) * g) + (F2V (0.044315524f) * b);
+        bh = b;
+    } else {//cat16
+        rh = ( F2V (1.f) * r) + (F2V (0.f) * g) + ( F2V (0.f) * b);
+        gh = ( F2V (0.f) * r) + (F2V (1.f) * g) + (F2V (0.f) * b);
+        bh = b;
+        
+    }
 }
 #endif
 
@@ -431,7 +433,7 @@ void Ciecam02::calculate_abfloat ( vfloat &aa, vfloat &bb, vfloat h, vfloat e, v
 #endif
 
 void Ciecam02::initcam1float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                              float &cz, float &aw, float &wh, float &pfl, float &fl, float c, float c16)
+                              float &cz, float &aw, float &wh, float &pfl, float &fl, float c, int c16)
 {
     n = yb / yw;
 
@@ -450,7 +452,7 @@ void Ciecam02::initcam1float (float yb, float pilotd, float f, float la, float x
 }
 
 void Ciecam02::initcam2float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                              float &cz, float &aw, float &fl, float c16)
+                              float &cz, float &aw, float &fl, int c16)
 {
     n = yb / yw;
 
@@ -469,7 +471,7 @@ void Ciecam02::initcam2float (float yb, float pilotd, float f, float la, float x
 
 void Ciecam02::xyz2jchqms_ciecam02float ( float &J, float &C, float &h, float &Q, float &M, float &s, float aw, float fl, float wh,
         float x, float y, float z, float xw, float yw, float zw,
-        float c, float nc, float pow1, float nbb, float ncb, float pfl, float cz, float d, float c16)
+        float c, float nc, float pow1, float nbb, float ncb, float pfl, float cz, float d, int c16)
 
 {
     float r, g, b;
@@ -480,20 +482,23 @@ void Ciecam02::xyz2jchqms_ciecam02float ( float &J, float &C, float &h, float &Q
     float a, ca, cb;
     float e, t;
     float myh;
-//    gamu = 1;
     xyz_to_cat02float ( r, g, b, x, y, z, c16);
     xyz_to_cat02float ( rw, gw, bw, xw, yw, zw, c16);
     rc = r * (((yw * d) / rw) + (1.f - d));
     gc = g * (((yw * d) / gw) + (1.f - d));
     bc = b * (((yw * d) / bw) + (1.f - d));
 
-    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc);
+    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
 
-//    if (gamu == 1) { //gamut correction M.H.Brill S.Susstrunk
-    rp = MAXR (rp, 0.0f);
-    gp = MAXR (gp, 0.0f);
-    bp = MAXR (bp, 0.0f);
-//    }
+    if(c16 == 1) {//cat02
+        rp = MAXR (rp, 0.0f);
+        gp = MAXR (gp, 0.0f);
+        bp = MAXR (bp, 0.0f);
+    } else {//cat16
+        rp = MAXR (rc, 0.0f);
+        gp = MAXR (gc, 0.0f);
+        bp = MAXR (bc, 0.0f);
+    }
 
     rpa = nonlinear_adaptationfloat ( rp, fl );
     gpa = nonlinear_adaptationfloat ( gp, fl );
@@ -510,9 +515,7 @@ void Ciecam02::xyz2jchqms_ciecam02float ( float &J, float &C, float &h, float &Q
 
     a = ((2.0f * rpa) + gpa + (0.05f * bpa) - 0.305f) * nbb;
 
-//    if (gamu == 1) {
     a = MAXR (a, 0.0f); //gamut correction M.H.Brill S.Susstrunk
-//    }
 
     J = pow_F ( a / aw, c * cz * 0.5f);
 
@@ -531,7 +534,7 @@ void Ciecam02::xyz2jchqms_ciecam02float ( float &J, float &C, float &h, float &Q
 #ifdef __SSE2__
 void Ciecam02::xyz2jchqms_ciecam02float ( vfloat &J, vfloat &C, vfloat &h, vfloat &Q, vfloat &M, vfloat &s, vfloat aw, vfloat fl, vfloat wh,
         vfloat x, vfloat y, vfloat z, vfloat xw, vfloat yw, vfloat zw,
-        vfloat c, vfloat nc, vfloat pow1, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d, float c16)
+        vfloat c, vfloat nc, vfloat pow1, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d, int c16)
 
 {
     vfloat r, g, b;
@@ -549,11 +552,19 @@ void Ciecam02::xyz2jchqms_ciecam02float ( vfloat &J, vfloat &C, vfloat &h, vfloa
     gc = g * (((yw * d) / gw) + (onev - d));
     bc = b * (((yw * d) / bw) + (onev - d));
 
-    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc);
+    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
+
     //gamut correction M.H.Brill S.Susstrunk
-    rp = vmaxf (rp, ZEROV);
-    gp = vmaxf (gp, ZEROV);
-    bp = vmaxf (bp, ZEROV);
+    if(c16 == 1) {//cat02
+        rp = vmaxf (rp, ZEROV);
+        gp = vmaxf (gp, ZEROV);
+        bp = vmaxf (bp, ZEROV);
+    } else {//cat16
+        rp = vmaxf (rc, ZEROV);
+        gp = vmaxf (gc, ZEROV);
+        bp = vmaxf (bc, ZEROV);
+    }
+
     rpa = nonlinear_adaptationfloat ( rp, fl );
     gpa = nonlinear_adaptationfloat ( gp, fl );
     bpa = nonlinear_adaptationfloat ( bp, fl );
@@ -588,7 +599,7 @@ void Ciecam02::xyz2jchqms_ciecam02float ( vfloat &J, vfloat &C, vfloat &h, vfloa
 
 void Ciecam02::xyz2jch_ciecam02float ( float &J, float &C, float &h, float aw, float fl,
                                        float x, float y, float z, float xw, float yw, float zw,
-                                       float c, float nc, float pow1, float nbb, float ncb, float cz, float d, float c16)
+                                       float c, float nc, float pow1, float nbb, float ncb, float cz, float d, int c16)
 
 {
     float r, g, b;
@@ -606,13 +617,18 @@ void Ciecam02::xyz2jch_ciecam02float ( float &J, float &C, float &h, float aw, f
     gc = g * (((yw * d) / gw) + (1.f - d));
     bc = b * (((yw * d) / bw) + (1.f - d));
 
-    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc);
+    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
 
-//    if (gamu == 1) { //gamut correction M.H.Brill S.Susstrunk
-    rp = MAXR (rp, 0.0f);
-    gp = MAXR (gp, 0.0f);
-    bp = MAXR (bp, 0.0f);
-//    }
+    if(c16 == 1) {//cat02
+        rp = MAXR (rp, 0.0f);
+        gp = MAXR (gp, 0.0f);
+        bp = MAXR (bp, 0.0f);
+    } else {//cat16
+        rp = MAXR (rc, 0.0f);
+        gp = MAXR (gc, 0.0f);
+        bp = MAXR (bc, 0.0f);
+    }
+
 
 #ifdef __SSE2__
     vfloat pv = _mm_setr_ps(rp, gp, bp, 1.f);
@@ -638,9 +654,7 @@ void Ciecam02::xyz2jch_ciecam02float ( float &J, float &C, float &h, float aw, f
 
     a = ((2.0f * rpa) + gpa + (0.05f * bpa) - 0.305f) * nbb;
 
-//    if (gamu == 1) {
     a = MAXR (a, 0.0f); //gamut correction M.H.Brill S.Susstrunk
-//    }
 
     J = pow_F ( a / aw, c * cz * 0.5f);
 
@@ -655,7 +669,7 @@ void Ciecam02::xyz2jch_ciecam02float ( float &J, float &C, float &h, float aw, f
 
 void Ciecam02::jch2xyz_ciecam02float ( float &x, float &y, float &z, float J, float C, float h,
                                        float xw, float yw, float zw,
-                                       float c, float nc, float pow1, float nbb, float ncb, float fl, float cz, float d, float aw, float c16)
+                                       float c, float nc, float pow1, float nbb, float ncb, float fl, float cz, float d, float aw, int c16)
 {
     float r, g, b;
     float rc, gc, bc;
@@ -664,7 +678,6 @@ void Ciecam02::jch2xyz_ciecam02float ( float &x, float &y, float &z, float J, fl
     float rw, gw, bw;
     float a, ca, cb;
     float e, t;
-//    gamu = 1;
     xyz_to_cat02float(rw, gw, bw, xw, yw, zw, c16);
     e = ((961.53846f) * nc * ncb) * (xcosf(h * rtengine::RT_PI_F_180 + 2.0f) + 3.8f);
 
@@ -694,12 +707,19 @@ void Ciecam02::jch2xyz_ciecam02float ( float &x, float &y, float &z, float J, fl
     gp = inverse_nonlinear_adaptationfloat(gpa, fl);
     bp = inverse_nonlinear_adaptationfloat(bpa, fl);
 #endif
-    hpe_to_xyzfloat(x, y, z, rp, gp, bp);
-    xyz_to_cat02float(rc, gc, bc, x, y, z, c16);
 
-    r = rc / (((yw * d) / rw) + (1.0f - d));
-    g = gc / (((yw * d) / gw) + (1.0f - d));
-    b = bc / (((yw * d) / bw) + (1.0f - d));
+    if(c16 == 1) {//cat02
+        hpe_to_xyzfloat(x, y, z, rp, gp, bp, c16);
+        xyz_to_cat02float(rc, gc, bc, x, y, z, c16);
+
+        r = rc / (((yw * d) / rw) + (1.0f - d));
+        g = gc / (((yw * d) / gw) + (1.0f - d));
+        b = bc / (((yw * d) / bw) + (1.0f - d));
+    } else {//cat16
+        r = rp / (((yw * d) / rw) + (1.0f - d));
+        g = gp / (((yw * d) / gw) + (1.0f - d));
+        b = bp / (((yw * d) / bw) + (1.0f - d));
+    }
 
     cat02_to_xyzfloat(x, y, z, r, g, b, c16);
 }
@@ -707,7 +727,7 @@ void Ciecam02::jch2xyz_ciecam02float ( float &x, float &y, float &z, float J, fl
 #ifdef __SSE2__
 void Ciecam02::jch2xyz_ciecam02float ( vfloat &x, vfloat &y, vfloat &z, vfloat J, vfloat C, vfloat h,
                                        vfloat xw, vfloat yw, vfloat zw,
-                                       vfloat nc, vfloat pow1, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz, float c16)
+                                       vfloat nc, vfloat pow1, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz, int c16)
 {
     vfloat r, g, b;
     vfloat rc, gc, bc;
@@ -728,12 +748,18 @@ void Ciecam02::jch2xyz_ciecam02float ( vfloat &x, vfloat &y, vfloat &z, vfloat J
     gp = inverse_nonlinear_adaptationfloat ( gpa, fl );
     bp = inverse_nonlinear_adaptationfloat ( bpa, fl );
 
-    hpe_to_xyzfloat ( x, y, z, rp, gp, bp );
-    xyz_to_cat02float ( rc, gc, bc, x, y, z, c16 );
+    if(c16 == 1) {//cat02
+        hpe_to_xyzfloat ( x, y, z, rp, gp, bp, c16);
+        xyz_to_cat02float ( rc, gc, bc, x, y, z, c16 );
 
-    r = rc / (((yw * d) / rw) + (F2V (1.0f) - d));
-    g = gc / (((yw * d) / gw) + (F2V (1.0f) - d));
-    b = bc / (((yw * d) / bw) + (F2V (1.0f) - d));
+        r = rc / (((yw * d) / rw) + (F2V (1.0f) - d));
+        g = gc / (((yw * d) / gw) + (F2V (1.0f) - d));
+        b = bc / (((yw * d) / bw) + (F2V (1.0f) - d));
+    } else {//cat16
+        r = rp / (((yw * d) / rw) + (F2V (1.0f) - d));
+        g = gp / (((yw * d) / gw) + (F2V (1.0f) - d));
+        b = bp / (((yw * d) / bw) + (F2V (1.0f) - d));
+    }
 
     cat02_to_xyzfloat ( x, y, z, r, g, b, c16 );
 }

--- a/rtengine/ciecam02.cc
+++ b/rtengine/ciecam02.cc
@@ -2,7 +2,7 @@
  *  This file is part of RawTherapee.
  *
  *  Copyright (c) 2004-2010 Gabor Horvath <hgabor@rawtherapee.com>
- *
+ *  Changes in Ciecam02 with Ciecam16 Jacques Desmis jdesmis@gmail.com   12/2020 
  *  RawTherapee is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
@@ -230,7 +230,6 @@ void Ciecam02::xyz_to_cat02float ( float &r, float &g, float &b, float x, float 
         b = ( -0.002079f * x) + (0.048952f * y) + (0.953127f * z);
     }
 
-//    }
 }
 #ifdef __SSE2__
 void Ciecam02::xyz_to_cat02float ( vfloat &r, vfloat &g, vfloat &b, vfloat x, vfloat y, vfloat z, int c16)
@@ -265,7 +264,6 @@ void Ciecam02::cat02_to_xyzfloat ( float &x, float &y, float &z, float r, float 
         z = ( -0.0158415f * r) - (0.03412294f * g) + (1.04996444f * b);
     }
 
-//    }
 }
 #ifdef __SSE2__
 void Ciecam02::cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, int c16 )
@@ -281,7 +279,6 @@ void Ciecam02::cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vf
         y = ( F2V (0.38752654f) * r) + (F2V (0.621447744f) * g) - (F2V (0.00897398f) * b);
         z = -(F2V(0.0158415f) * r) - (F2V(0.03412294f) * g) + (F2V(1.04996444f) * b);
     }
-    
 }
 #endif
 
@@ -306,7 +303,6 @@ void Ciecam02::cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, flo
 //        rh = ( 0.7409792f * r) + (0.2180250f * g) + (0.0410058f * b);
 //        gh = ( 0.2853532f * r) + (0.6242014f * g) + (0.0904454f * b);
 //        bh = (-0.0096280f * r) - (0.0056980f * g) + (1.0153260f * b);
-//    } else if (gamu == 1) { //Changjun Li
     if(c16 == 1) {//cat02
         rh = ( 0.550930835f * r) + (0.519435987f * g) - ( 0.070356303f * b);
         gh = ( 0.055954056f * r) + (0.89973132f * g) + (0.044315524f * b);
@@ -315,10 +311,8 @@ void Ciecam02::cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, flo
         rh = ( 1.f * r) + (0.f * g) + ( 0.f * b);
         gh = ( 0.f * r) + (1.f * g) + (0.f * b);
         bh = (0.0f * r) + (0.0f * g) + (1.0f * b);
-   
     }
 
-//    }
 }
 
 #ifdef __SSE2__
@@ -610,7 +604,6 @@ void Ciecam02::xyz2jch_ciecam02float ( float &J, float &C, float &h, float aw, f
     float a, ca, cb;
     float e, t;
     float myh;
-//    int gamu = 1;
     xyz_to_cat02float ( r, g, b, x, y, z, c16);
     xyz_to_cat02float ( rw, gw, bw, xw, yw, zw, c16);
     rc = r * (((yw * d) / rw) + (1.f - d));
@@ -819,6 +812,4 @@ vfloat Ciecam02::inverse_nonlinear_adaptationfloat ( vfloat c, vfloat fl )
     return (F2V (100.0f) / fl) * pow_F ( (F2V (27.13f) * c) / (F2V (400.0f) - c), F2V (2.38095238f) );
 }
 #endif
-//end CIECAM Billy Bigg
-
 }

--- a/rtengine/ciecam02.cc
+++ b/rtengine/ciecam02.cc
@@ -195,9 +195,9 @@ float Ciecam02::achromatic_response_to_whitefloat ( float x, float y, float z, f
     gc = g * (((y * d) / g) + (1.0f - d));
     bc = b * (((y * d) / b) + (1.0f - d));
 
-    cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
 
-    if(c16 ==1) {
+    if(c16 == 1) {
+        cat02_to_hpefloat ( rp, gp, bp, rc, gc, bc, c16);
         rp = MAXR (rp, 0.0f);
         gp = MAXR (gp, 0.0f);
         bp = MAXR (bp, 0.0f);

--- a/rtengine/ciecam02.h
+++ b/rtengine/ciecam02.h
@@ -37,12 +37,12 @@ class Ciecam02
 private:
     static float d_factorfloat ( float f, float la );
     static float calculate_fl_from_la_ciecam02float ( float la );
-    static float achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb);
-    static void xyz_to_cat02float ( float &r,  float &g,  float &b,  float x, float y, float z);
+    static float achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb, float c16);
+    static void xyz_to_cat02float ( float &r,  float &g,  float &b,  float x, float y, float z, float c16);
     static void cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, float g, float b);
 
 #ifdef __SSE2__
-    static void xyz_to_cat02float ( vfloat &r,  vfloat &g,  vfloat &b,  vfloat x, vfloat y, vfloat z );
+    static void xyz_to_cat02float ( vfloat &r,  vfloat &g,  vfloat &b,  vfloat x, vfloat y, vfloat z, float c16);
     static void cat02_to_hpefloat ( vfloat &rh, vfloat &gh, vfloat &bh, vfloat r, vfloat g, vfloat b );
     static vfloat nonlinear_adaptationfloat ( vfloat c, vfloat fl );
 #endif
@@ -53,13 +53,13 @@ private:
     static void calculate_abfloat ( float &aa, float &bb, float h, float e, float t, float nbb, float a );
     static void Aab_to_rgbfloat ( float &r, float &g, float &b, float A, float aa, float bb, float nbb );
     static void hpe_to_xyzfloat   ( float &x,  float &y,  float &z,  float r, float g, float b );
-    static void cat02_to_xyzfloat ( float &x,  float &y,  float &z,  float r, float g, float b);
+    static void cat02_to_xyzfloat ( float &x,  float &y,  float &z,  float r, float g, float b, float c16);
 #ifdef __SSE2__
     static vfloat inverse_nonlinear_adaptationfloat ( vfloat c, vfloat fl );
     static void calculate_abfloat ( vfloat &aa, vfloat &bb, vfloat h, vfloat e, vfloat t, vfloat nbb, vfloat a );
     static void Aab_to_rgbfloat ( vfloat &r, vfloat &g, vfloat &b, vfloat A, vfloat aa, vfloat bb, vfloat nbb );
     static void hpe_to_xyzfloat   ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b );
-    static void cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b );
+    static void cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, float c16 );
 #endif
 
 public:
@@ -73,40 +73,40 @@ public:
     static void jch2xyz_ciecam02float ( float &x, float &y, float &z,
                                         float J, float C, float h,
                                         float xw, float yw, float zw,
-                                        float c, float nc, float n, float nbb, float ncb, float fl, float cz, float d, float aw );
+                                        float c, float nc, float n, float nbb, float ncb, float fl, float cz, float d, float aw, float c16);
 #ifdef __SSE2__
     static void jch2xyz_ciecam02float ( vfloat &x, vfloat &y, vfloat &z,
                                         vfloat J, vfloat C, vfloat h,
                                         vfloat xw, vfloat yw, vfloat zw,
-                                        vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz );
+                                        vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz, float c16 );
 #endif
     /**
      * Forward transform from XYZ to CIECAM02 JCh.
      */
     static void initcam1float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                               float &cz, float &aw, float &wh, float &pfl, float &fl, float c);
+                               float &cz, float &aw, float &wh, float &pfl, float &fl, float c, float c16);
 
     static void initcam2float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                               float &cz, float &aw, float &fl);
+                               float &cz, float &aw, float &fl, float c16);
 
     static void xyz2jch_ciecam02float ( float &J, float &C, float &h,
                                         float aw, float fl,
                                         float x, float y, float z,
                                         float xw, float yw, float zw,
-                                        float c, float nc, float n, float nbb, float ncb, float cz, float d  );
+                                        float c, float nc, float n, float nbb, float ncb, float cz, float d, float c16);
 
     static void xyz2jchqms_ciecam02float ( float &J, float &C, float &h,
                                            float &Q, float &M, float &s, float aw, float fl, float wh,
                                            float x, float y, float z,
                                            float xw, float yw, float zw,
-                                           float c, float nc, float n, float nbb, float ncb, float pfl, float cz, float d  );
+                                           float c, float nc, float n, float nbb, float ncb, float pfl, float cz, float d, float c16);
 
 #ifdef __SSE2__
     static void xyz2jchqms_ciecam02float ( vfloat &J, vfloat &C, vfloat &h,
                                            vfloat &Q, vfloat &M, vfloat &s, vfloat aw, vfloat fl, vfloat wh,
                                            vfloat x, vfloat y, vfloat z,
                                            vfloat xw, vfloat yw, vfloat zw,
-                                           vfloat c, vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d  );
+                                           vfloat c, vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d, float c16);
 
 
 #endif

--- a/rtengine/ciecam02.h
+++ b/rtengine/ciecam02.h
@@ -37,13 +37,13 @@ class Ciecam02
 private:
     static float d_factorfloat ( float f, float la );
     static float calculate_fl_from_la_ciecam02float ( float la );
-    static float achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb, float c16);
-    static void xyz_to_cat02float ( float &r,  float &g,  float &b,  float x, float y, float z, float c16);
-    static void cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, float g, float b);
+    static float achromatic_response_to_whitefloat ( float x, float y, float z, float d, float fl, float nbb, int c16);
+    static void xyz_to_cat02float ( float &r,  float &g,  float &b,  float x, float y, float z, int c16);
+    static void cat02_to_hpefloat ( float &rh, float &gh, float &bh, float r, float g, float b, int c16);
 
 #ifdef __SSE2__
-    static void xyz_to_cat02float ( vfloat &r,  vfloat &g,  vfloat &b,  vfloat x, vfloat y, vfloat z, float c16);
-    static void cat02_to_hpefloat ( vfloat &rh, vfloat &gh, vfloat &bh, vfloat r, vfloat g, vfloat b );
+    static void xyz_to_cat02float ( vfloat &r,  vfloat &g,  vfloat &b,  vfloat x, vfloat y, vfloat z, int c16);
+    static void cat02_to_hpefloat ( vfloat &rh, vfloat &gh, vfloat &bh, vfloat r, vfloat g, vfloat b, int c16);
     static vfloat nonlinear_adaptationfloat ( vfloat c, vfloat fl );
 #endif
 
@@ -52,14 +52,14 @@ private:
     static float inverse_nonlinear_adaptationfloat ( float c, float fl );
     static void calculate_abfloat ( float &aa, float &bb, float h, float e, float t, float nbb, float a );
     static void Aab_to_rgbfloat ( float &r, float &g, float &b, float A, float aa, float bb, float nbb );
-    static void hpe_to_xyzfloat   ( float &x,  float &y,  float &z,  float r, float g, float b );
-    static void cat02_to_xyzfloat ( float &x,  float &y,  float &z,  float r, float g, float b, float c16);
+    static void hpe_to_xyzfloat   ( float &x,  float &y,  float &z,  float r, float g, float b, int c16);
+    static void cat02_to_xyzfloat ( float &x,  float &y,  float &z,  float r, float g, float b, int c16);
 #ifdef __SSE2__
     static vfloat inverse_nonlinear_adaptationfloat ( vfloat c, vfloat fl );
     static void calculate_abfloat ( vfloat &aa, vfloat &bb, vfloat h, vfloat e, vfloat t, vfloat nbb, vfloat a );
     static void Aab_to_rgbfloat ( vfloat &r, vfloat &g, vfloat &b, vfloat A, vfloat aa, vfloat bb, vfloat nbb );
-    static void hpe_to_xyzfloat   ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b );
-    static void cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, float c16 );
+    static void hpe_to_xyzfloat   ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, int c16);
+    static void cat02_to_xyzfloat ( vfloat &x, vfloat &y, vfloat &z, vfloat r, vfloat g, vfloat b, int c16);
 #endif
 
 public:
@@ -73,40 +73,40 @@ public:
     static void jch2xyz_ciecam02float ( float &x, float &y, float &z,
                                         float J, float C, float h,
                                         float xw, float yw, float zw,
-                                        float c, float nc, float n, float nbb, float ncb, float fl, float cz, float d, float aw, float c16);
+                                        float c, float nc, float n, float nbb, float ncb, float fl, float cz, float d, float aw, int c16);
 #ifdef __SSE2__
     static void jch2xyz_ciecam02float ( vfloat &x, vfloat &y, vfloat &z,
                                         vfloat J, vfloat C, vfloat h,
                                         vfloat xw, vfloat yw, vfloat zw,
-                                        vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz, float c16 );
+                                        vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat fl, vfloat d, vfloat aw, vfloat reccmcz, int c16 );
 #endif
     /**
      * Forward transform from XYZ to CIECAM02 JCh.
      */
     static void initcam1float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                               float &cz, float &aw, float &wh, float &pfl, float &fl, float c, float c16);
+                               float &cz, float &aw, float &wh, float &pfl, float &fl, float c, int c16);
 
     static void initcam2float (float yb, float pilotd, float f, float la, float xw, float yw, float zw, float &n, float &d, float &nbb, float &ncb,
-                               float &cz, float &aw, float &fl, float c16);
+                               float &cz, float &aw, float &fl, int c16);
 
     static void xyz2jch_ciecam02float ( float &J, float &C, float &h,
                                         float aw, float fl,
                                         float x, float y, float z,
                                         float xw, float yw, float zw,
-                                        float c, float nc, float n, float nbb, float ncb, float cz, float d, float c16);
+                                        float c, float nc, float n, float nbb, float ncb, float cz, float d, int c16);
 
     static void xyz2jchqms_ciecam02float ( float &J, float &C, float &h,
                                            float &Q, float &M, float &s, float aw, float fl, float wh,
                                            float x, float y, float z,
                                            float xw, float yw, float zw,
-                                           float c, float nc, float n, float nbb, float ncb, float pfl, float cz, float d, float c16);
+                                           float c, float nc, float n, float nbb, float ncb, float pfl, float cz, float d, int c16);
 
 #ifdef __SSE2__
     static void xyz2jchqms_ciecam02float ( vfloat &J, vfloat &C, vfloat &h,
                                            vfloat &Q, vfloat &M, vfloat &s, vfloat aw, vfloat fl, vfloat wh,
                                            vfloat x, vfloat y, vfloat z,
                                            vfloat xw, vfloat yw, vfloat zw,
-                                           vfloat c, vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d, float c16);
+                                           vfloat c, vfloat nc, vfloat n, vfloat nbb, vfloat ncb, vfloat pfl, vfloat cz, vfloat d, int c16);
 
 
 #endif

--- a/rtengine/ciecam02.h
+++ b/rtengine/ciecam02.h
@@ -33,7 +33,7 @@ namespace rtengine
 {
 
 class Ciecam02
-{
+{//also used with Ciecam16
 private:
     static float d_factorfloat ( float f, float la );
     static float calculate_fl_from_la_ciecam02float ( float la );

--- a/rtengine/curves.cc
+++ b/rtengine/curves.cc
@@ -3460,7 +3460,7 @@ void PerceptualToneCurve::BatchApply(const size_t start, const size_t end, float
         Color::Prophotoxyz(r, g, b, x, y, z);
 
         float J, C, h;
-        float c16 = 1.f;
+        int c16 = 1;
         Ciecam02::xyz2jch_ciecam02float(J, C, h,
                                         aw, fl,
                                         x * 0.0015259022f,  y * 0.0015259022f,  z * 0.0015259022f,
@@ -3698,7 +3698,7 @@ void PerceptualToneCurve::init()
     f  = 1.00f;
     c  = 0.69f;
     nc = 1.00f;
-    float c16 = 1.f;
+    int c16 = 1;//with cat02 for compatibility
     Ciecam02::initcam1float(yb, 1.f, f, la, xw, yw, zw, n, d, nbb, ncb,
                             cz, aw, wh, pfl, fl, c, c16);
     pow1 = pow_F(1.64f - pow_F(0.29f, n), 0.73f);

--- a/rtengine/curves.cc
+++ b/rtengine/curves.cc
@@ -3460,11 +3460,12 @@ void PerceptualToneCurve::BatchApply(const size_t start, const size_t end, float
         Color::Prophotoxyz(r, g, b, x, y, z);
 
         float J, C, h;
+        float c16 = 1.f;
         Ciecam02::xyz2jch_ciecam02float(J, C, h,
                                         aw, fl,
                                         x * 0.0015259022f,  y * 0.0015259022f,  z * 0.0015259022f,
                                         xw, yw,  zw,
-                                        c,  nc, pow1, nbb, ncb, cz, d);
+                                        c,  nc, pow1, nbb, ncb, cz, d, c16);
 
 
         if (!isfinite(J) || !isfinite(C) || !isfinite(h)) {
@@ -3579,11 +3580,10 @@ void PerceptualToneCurve::BatchApply(const size_t start, const size_t end, float
         }
 
         C *= cmul;
-
         Ciecam02::jch2xyz_ciecam02float(x, y, z,
                                         J, C, h,
                                         xw, yw,  zw,
-                                        c, nc, pow1, nbb, ncb, fl, cz, d, aw);
+                                        c, nc, pow1, nbb, ncb, fl, cz, d, aw, c16);
 
         if (!isfinite(x) || !isfinite(y) || !isfinite(z)) {
             // can happen for colours on the rim of being outside gamut, that worked without chroma scaling but not with. Then we return only the curve's result.
@@ -3698,9 +3698,9 @@ void PerceptualToneCurve::init()
     f  = 1.00f;
     c  = 0.69f;
     nc = 1.00f;
-
+    float c16 = 1.f;
     Ciecam02::initcam1float(yb, 1.f, f, la, xw, yw, zw, n, d, nbb, ncb,
-                            cz, aw, wh, pfl, fl, c);
+                            cz, aw, wh, pfl, fl, c, c16);
     pow1 = pow_F(1.64f - pow_F(0.29f, n), 0.73f);
 
     {

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -952,7 +952,13 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
 
 
         float cz, wh, pfl;
-        float c16 = 1.f;
+        int c16 = 1;
+        if (params->colorappearance.modelmethod == "02") {
+            c16 = 1;
+        }else if (params->colorappearance.modelmethod == "16") {
+            c16 = 16;
+        }
+
         Ciecam02::initcam1float (yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c, c16);
         //printf ("wh=%f \n", wh);
 

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -952,12 +952,13 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
 
 
         float cz, wh, pfl;
-        Ciecam02::initcam1float (yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c);
+        float c16 = 1.f;
+        Ciecam02::initcam1float (yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c, c16);
         //printf ("wh=%f \n", wh);
 
         const float pow1 = pow_F(1.64f - pow_F(0.29f, n), 0.73f);
         float nj, nbbj, ncbj, czj, awj, flj;
-        Ciecam02::initcam2float (yb2, pilotout, f2,  la2,  xw2,  yw2,  zw2, nj, dj, nbbj, ncbj, czj, awj, flj);
+        Ciecam02::initcam2float (yb2, pilotout, f2,  la2,  xw2,  yw2,  zw2, nj, dj, nbbj, ncbj, czj, awj, flj, c16);
 #ifdef __SSE2__
         const float reccmcz = 1.f / (c2 * czj);
 #endif
@@ -1048,7 +1049,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                                                        Q,  M,  s, F2V(aw), F2V(fl), F2V(wh),
                                                        x,  y,  z,
                                                        F2V(xw1), F2V(yw1),  F2V(zw1),
-                                                       F2V(c),  F2V(nc), F2V(pow1), F2V(nbb), F2V(ncb), F2V(pfl), F2V(cz), F2V(d));
+                                                       F2V(c),  F2V(nc), F2V(pow1), F2V(nbb), F2V(ncb), F2V(pfl), F2V(cz), F2V(d), c16);
                     STVF(Jbuffer[k], J);
                     STVF(Cbuffer[k], C);
                     STVF(hbuffer[k], h);
@@ -1072,7 +1073,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                                                        Q,  M,  s, aw, fl, wh,
                                                        x,  y,  z,
                                                        xw1, yw1,  zw1,
-                                                         c,  nc, pow1, nbb, ncb, pfl, cz, d);
+                                                         c,  nc, pow1, nbb, ncb, pfl, cz, d, c16);
                     Jbuffer[k] = J;
                     Cbuffer[k] = C;
                     hbuffer[k] = h;
@@ -1110,7 +1111,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                                                        Q,  M,  s, aw, fl, wh,
                                                        x,  y,  z,
                                                        xw1, yw1,  zw1,
-                                                         c,  nc, pow1, nbb, ncb, pfl, cz, d);
+                                                         c,  nc, pow1, nbb, ncb, pfl, cz, d, c16);
 #endif
                     float Jpro, Cpro, hpro, Qpro, Mpro, spro;
                     Jpro = J;
@@ -1521,7 +1522,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                             Ciecam02::jch2xyz_ciecam02float(xx, yy, zz,
                                                             J,  C, h,
                                                             xw2, yw2,  zw2,
-                                                              c2, nc2, pow1n, nbbj, ncbj, flj, czj, dj, awj);
+                                                              c2, nc2, pow1n, nbbj, ncbj, flj, czj, dj, awj, c16);
                             float x, y, z;
                             x = xx * 655.35f;
                             y = yy * 655.35f;
@@ -1573,7 +1574,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                     Ciecam02::jch2xyz_ciecam02float(x, y, z,
                                                     LVF(Jbuffer[k]), LVF(Cbuffer[k]), LVF(hbuffer[k]),
                                                     F2V(xw2), F2V(yw2), F2V(zw2),
-                                                    F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz));
+                                                    F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz), c16);
                     STVF(xbuffer[k], x * c655d35);
                     STVF(ybuffer[k], y * c655d35);
                     STVF(zbuffer[k], z * c655d35);
@@ -1830,7 +1831,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                         Ciecam02::jch2xyz_ciecam02float(xx, yy, zz,
                                                         ncie->J_p[i][j],  ncie_C_p, ncie->h_p[i][j],
                                                         xw2, yw2,  zw2,
-                                                          c2, nc2, pow1n, nbbj, ncbj, flj, czj, dj, awj);
+                                                          c2, nc2, pow1n, nbbj, ncbj, flj, czj, dj, awj, c16);
                         float x = (float)xx * 655.35f;
                         float y = (float)yy * 655.35f;
                         float z = (float)zz * 655.35f;
@@ -1878,7 +1879,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                         Ciecam02::jch2xyz_ciecam02float(x, y, z,
                                                         LVF(Jbuffer[k]), LVF(Cbuffer[k]), LVF(hbuffer[k]),
                                                         F2V(xw2), F2V(yw2), F2V(zw2),
-                                                        F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz));
+                                                        F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz), c16);
                         x *= c655d35;
                         y *= c655d35;
                         z *= c655d35;

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -2378,7 +2378,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     zw = 100.0 * Zw;
     float xw1 = xws, yw1 = yws, zw1 = zws, xw2 = xwd, yw2 = ywd, zw2 = zwd;
     float cz, wh, pfl;
-    float c16 = 1.f;
+    int c16 = 16;//always cat16
     Ciecam02::initcam1float(yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c, c16);
     const float pow1 = pow_F(1.64f - pow_F(0.29f, n), 0.73f);
     float nj, nbbj, ncbj, czj, awj, flj;

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -2378,10 +2378,11 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     zw = 100.0 * Zw;
     float xw1 = xws, yw1 = yws, zw1 = zws, xw2 = xwd, yw2 = ywd, zw2 = zwd;
     float cz, wh, pfl;
-    Ciecam02::initcam1float(yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c);
+    float c16 = 1.f;
+    Ciecam02::initcam1float(yb, pilot, f, la, xw, yw, zw, n, d, nbb, ncb, cz, aw, wh, pfl, fl, c, c16);
     const float pow1 = pow_F(1.64f - pow_F(0.29f, n), 0.73f);
     float nj, nbbj, ncbj, czj, awj, flj;
-    Ciecam02::initcam2float(yb2, pilotout, f2,  la2,  xw2,  yw2,  zw2, nj, dj, nbbj, ncbj, czj, awj, flj);
+    Ciecam02::initcam2float(yb2, pilotout, f2,  la2,  xw2,  yw2,  zw2, nj, dj, nbbj, ncbj, czj, awj, flj, c16);
 #ifdef __SSE2__
     const float reccmcz = 1.f / (c2 * czj);
 #endif
@@ -2428,7 +2429,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                                                    Q,  M,  s, F2V(aw), F2V(fl), F2V(wh),
                                                    x,  y,  z,
                                                    F2V(xw1), F2V(yw1),  F2V(zw1),
-                                                   F2V(c),  F2V(nc), F2V(pow1), F2V(nbb), F2V(ncb), F2V(pfl), F2V(cz), F2V(d));
+                                                   F2V(c),  F2V(nc), F2V(pow1), F2V(nbb), F2V(ncb), F2V(pfl), F2V(cz), F2V(d), c16);
                 STVF(Jbuffer[k], J);
                 STVF(Cbuffer[k], C);
                 STVF(hbuffer[k], h);
@@ -2452,7 +2453,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                                                    Q,  M,  s, aw, fl, wh,
                                                    x,  y,  z,
                                                    xw1, yw1,  zw1,
-                                                   c,  nc, pow1, nbb, ncb, pfl, cz, d);
+                                                   c,  nc, pow1, nbb, ncb, pfl, cz, d, c16);
                 Jbuffer[k] = J;
                 Cbuffer[k] = C;
                 hbuffer[k] = h;
@@ -2490,7 +2491,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                                                    Q,  M,  s, aw, fl, wh,
                                                    x,  y,  z,
                                                    xw1, yw1,  zw1,
-                                                   c,  nc, pow1, nbb, ncb, pfl, cz, d);
+                                                   c,  nc, pow1, nbb, ncb, pfl, cz, d, c16);
 #endif
                 float Jpro, Cpro, hpro, Qpro, Mpro, spro;
                 Jpro = J;
@@ -2557,7 +2558,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                 Ciecam02::jch2xyz_ciecam02float(xx, yy, zz,
                                                 J,  C, h,
                                                 xw2, yw2,  zw2,
-                                                c2, nc2,  pow1n, nbbj, ncbj, flj, czj, dj, awj);
+                                                c2, nc2,  pow1n, nbbj, ncbj, flj, czj, dj, awj, c16);
                 x = xx * 655.35f;
                 y = yy * 655.35f;
                 z = zz * 655.35f;
@@ -2580,7 +2581,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                 Ciecam02::jch2xyz_ciecam02float(x, y, z,
                                                 LVF(Jbuffer[k]), LVF(Cbuffer[k]), LVF(hbuffer[k]),
                                                 F2V(xw2), F2V(yw2), F2V(zw2),
-                                                F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz));
+                                                F2V(nc2), F2V(pow1n), F2V(nbbj), F2V(ncbj), F2V(flj), F2V(dj), F2V(awj), F2V(reccmcz), c16);
                 STVF(xbuffer[k], x * c655d35);
                 STVF(ybuffer[k], y * c655d35);
                 STVF(zbuffer[k], z * c655d35);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -1423,6 +1423,7 @@ ColorAppearanceParams::ColorAppearanceParams() :
     curveMode2(TcMode::LIGHT),
     curveMode3(CtcMode::CHROMA),
     complexmethod("normal"),
+    modelmethod("02"),
     surround("Average"),
     surrsrc("Average"),
     adapscen(2000.0),
@@ -1472,6 +1473,7 @@ bool ColorAppearanceParams::operator ==(const ColorAppearanceParams& other) cons
         && curveMode2 == other.curveMode2
         && curveMode3 == other.curveMode3
         && complexmethod == other.complexmethod
+        && modelmethod == other.modelmethod
         && surround == other.surround
         && surrsrc == other.surrsrc
         && adapscen == other.adapscen
@@ -5456,6 +5458,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
         saveToKeyfile(!pedited || pedited->colorappearance.autodegreeout, "Color appearance", "AutoDegreeout",    colorappearance.autodegreeout, keyFile);
         saveToKeyfile(!pedited || pedited->colorappearance.surround, "Color appearance", "Surround", colorappearance.surround, keyFile);
         saveToKeyfile(!pedited || pedited->colorappearance.complexmethod, "Color appearance", "complex", colorappearance.complexmethod, keyFile);
+        saveToKeyfile(!pedited || pedited->colorappearance.modelmethod, "Color appearance", "ModelCat", colorappearance.modelmethod, keyFile);
         saveToKeyfile(!pedited || pedited->colorappearance.surrsrc, "Color appearance", "Surrsrc", colorappearance.surrsrc, keyFile);
         saveToKeyfile(!pedited || pedited->colorappearance.adaplum, "Color appearance", "AdaptLum", colorappearance.adaplum, keyFile);
         saveToKeyfile(!pedited || pedited->colorappearance.badpixsl, "Color appearance", "Badpixsl", colorappearance.badpixsl, keyFile);
@@ -7087,6 +7090,16 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                     pedited->colorappearance.complexmethod = true;
                 }
             }
+            
+            if (keyFile.has_key("Color appearance", "ModelCat")) {
+                assignFromKeyfile(keyFile, "Color appearance", "ModelCat", pedited, colorappearance.modelmethod, pedited->colorappearance.modelmethod);
+            } else if (colorappearance.enabled) {
+                colorappearance.modelmethod = "02";
+                if (pedited) {
+                    pedited->colorappearance.modelmethod = true;
+                }
+            }
+            
             assignFromKeyfile(keyFile, "Color appearance", "Surround", pedited, colorappearance.surround, pedited->colorappearance.surround);
             assignFromKeyfile(keyFile, "Color appearance", "Surrsrc", pedited, colorappearance.surrsrc, pedited->colorappearance.surrsrc);
             assignFromKeyfile(keyFile, "Color appearance", "AdaptLum", pedited, colorappearance.adaplum, pedited->colorappearance.adaplum);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -1423,7 +1423,7 @@ ColorAppearanceParams::ColorAppearanceParams() :
     curveMode2(TcMode::LIGHT),
     curveMode3(CtcMode::CHROMA),
     complexmethod("normal"),
-    modelmethod("16"),
+    modelmethod("02"),
     surround("Average"),
     surrsrc("Average"),
     adapscen(2000.0),

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -1423,7 +1423,7 @@ ColorAppearanceParams::ColorAppearanceParams() :
     curveMode2(TcMode::LIGHT),
     curveMode3(CtcMode::CHROMA),
     complexmethod("normal"),
-    modelmethod("02"),
+    modelmethod("16"),
     surround("Average"),
     surrsrc("Average"),
     adapscen(2000.0),

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -673,6 +673,7 @@ struct ColorAppearanceParams {
     TcMode     curveMode2;
     CtcMode    curveMode3;
     Glib::ustring complexmethod;
+    Glib::ustring modelmethod;
 
     Glib::ustring surround;
     Glib::ustring surrsrc;

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -939,7 +939,7 @@ void ColorAppearance::read (const ProcParams* pp, const ParamsEdited* pedited)
         complexmethod->set_active(1);
     }
     
-    modelmethod->set_active(1);
+    modelmethod->set_active(0);
 
     if (pp->colorappearance.modelmethod == "02") {
         modelmethod->set_active(0);

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -939,7 +939,7 @@ void ColorAppearance::read (const ProcParams* pp, const ParamsEdited* pedited)
         complexmethod->set_active(1);
     }
     
-    modelmethod->set_active(0);
+    modelmethod->set_active(1);
 
     if (pp->colorappearance.modelmethod == "02") {
         modelmethod->set_active(0);

--- a/rtgui/colorappearance.h
+++ b/rtgui/colorappearance.h
@@ -78,6 +78,7 @@ public:
     bool curveMode3Changed_  ();
     void neutral_pressed       ();
     void complexmethodChanged();
+    void modelmethodChanged();
     void convertParamToNormal();
     void updateGUIToMode(int mode);
 
@@ -108,6 +109,7 @@ private:
     rtengine::ProcEvent EvCATAutotempout;
     rtengine::ProcEvent EvCATillum;
     rtengine::ProcEvent EvCATcomplex;
+    rtengine::ProcEvent EvCATmodel;
     bool bgTTipQuery (int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
     bool srTTipQuery (int x, int y, bool keyboard_tooltip, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
     void foldAllButMe (GdkEventButton* event, MyExpander *expander);
@@ -144,6 +146,7 @@ private:
     MyComboBoxText* toneCurveMode2;
     MyComboBoxText* toneCurveMode3;
     MyComboBoxText* complexmethod;
+    MyComboBoxText* modelmethod;
 
     //Adjuster* edge;
     Gtk::CheckButton* surrsource;
@@ -170,7 +173,7 @@ private:
     sigc::connection  surrconn;
     sigc::connection  gamutconn, datacieconn, tonecieconn /*,badpixconn , sharpcieconn*/;
     sigc::connection  tcmodeconn, tcmode2conn, tcmode3conn, neutralconn;
-    sigc::connection  complexmethodconn;
+    sigc::connection  complexmethodconn, modelmethodconn;
     Gtk::HBox* alHBox;
     Gtk::HBox* wbmHBox;
     Gtk::HBox* illumHBox;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -245,6 +245,7 @@ void ParamsEdited::set(bool v)
     colorappearance.curveMode2 = v;
     colorappearance.curveMode3 = v;
     colorappearance.complexmethod = v;
+    colorappearance.modelmethod = v;
     colorappearance.tempout     = v;
     colorappearance.autotempout = v;
     colorappearance.greenout     = v;
@@ -916,6 +917,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
         colorappearance.curveMode2 = colorappearance.curveMode2 && p.colorappearance.curveMode2 == other.colorappearance.curveMode2;
         colorappearance.curveMode3 = colorappearance.curveMode3 && p.colorappearance.curveMode3 == other.colorappearance.curveMode3;
         colorappearance.complexmethod = colorappearance.complexmethod && p.colorappearance.complexmethod == other.colorappearance.complexmethod;
+        colorappearance.modelmethod = colorappearance.modelmethod && p.colorappearance.modelmethod == other.colorappearance.modelmethod;
         colorappearance.tempout = colorappearance.tempout && p.colorappearance.tempout == other.colorappearance.tempout;
         colorappearance.autotempout = colorappearance.autotempout && p.colorappearance.autotempout == other.colorappearance.autotempout;
         colorappearance.greenout = colorappearance.greenout && p.colorappearance.greenout == other.colorappearance.greenout;
@@ -2636,6 +2638,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
     if (colorappearance.complexmethod) {
         toEdit.colorappearance.complexmethod = mods.colorappearance.complexmethod;
+    }
+
+    if (colorappearance.modelmethod) {
+        toEdit.colorappearance.modelmethod = mods.colorappearance.modelmethod;
     }
 
     if (colorappearance.enabled) {

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -267,6 +267,7 @@ struct ColorAppearanceParamsEdited {
     bool curveMode2;
     bool curveMode3;
     bool complexmethod;
+    bool modelmethod;
     bool enabled;
     bool degree;
     bool autodegree;


### PR DESCRIPTION
I added Ciecam16 to Ciecam02 - I hope no error in the code....Because the 2 options are now usable

* I think Ciecam02 is (slightly) better for colorimetry...but despite the corrections made by M.H.Brill S.Susstrunk and the RT team (Ingo), there are still in some rare cases possible artifacts
* Ciecam16 should in theory generate less artifacts, the code is "simpler".... Which is not the case here, because it was necessary to make compatible both Ciecam02 and Ciecam16, and ensure compatability with 5.8

Jacques