### PR TITLE
Local adjustments - Neutralize process after LA when when the user uses preview deltaE

### DIFF
--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1053,6 +1053,13 @@ void Crop::update(int todo)
                             params.chmixer.enabled = false;
                             params.hsvequalizer.enabled = false;
                             params.filmSimulation.enabled = false;
+                            params.toneCurve.black = 0.f;
+                            params.toneCurve.saturation = 0.f;
+                            params.colorappearance.enabled = false;
+                            params.vibrance.enabled = false;
+                            params.labCurve.enabled = false;
+                            params.wavelet.enabled = false;
+                            params.epd.enabled = false;
                         }
             } else {
                 parent->ipf.Lab_Local(1, sp, (float**)shbuffer, labnCrop, labnCrop, reservCrop.get(), lastorigCrop.get(), cropx / skip, cropy / skip, skips(parent->fw, skip), skips(parent->fh, skip), skip, locRETgainCurve, locRETtransCurve,

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1046,10 +1046,14 @@ void Crop::update(int todo)
                         huerefblu, chromarefblu, lumarefblu, huere, chromare, lumare, sobelre, lastsav, 
                         parent->previewDeltaE, parent->locallColorMask, parent->locallColorMaskinv, parent->locallExpMask, parent->locallExpMaskinv, parent->locallSHMask, parent->locallSHMaskinv, parent->locallvibMask,  parent->localllcMask, parent->locallsharMask, parent->locallcbMask, parent->locallretiMask, parent->locallsoftMask, parent->localltmMask, parent->locallblMask,
                         parent->localllogMask, parent->locall_Mask, minCD, maxCD, mini, maxi, Tmean, Tsigma, Tmin, Tmax);
-                        if(parent->previewDeltaE) {  
+                        if(parent->previewDeltaE || parent->locallColorMask == 5 || parent->locallvibMask == 4 || parent->locallExpMask == 5 || parent->locallSHMask == 4 || parent->localllcMask == 4 || parent->localltmMask == 4 || parent->localllogMask == 4 || parent->locallsoftMask == 6 || parent->localllcMask == 4) {  
                             params.blackwhite.enabled = false;
+                            params.colorToning.enabled = false;
+                            params.rgbCurves.enabled = false;
+                            params.chmixer.enabled = false;
+                            params.hsvequalizer.enabled = false;
+                            params.filmSimulation.enabled = false;
                         }
-
             } else {
                 parent->ipf.Lab_Local(1, sp, (float**)shbuffer, labnCrop, labnCrop, reservCrop.get(), lastorigCrop.get(), cropx / skip, cropy / skip, skips(parent->fw, skip), skips(parent->fh, skip), skip, locRETgainCurve, locRETtransCurve,
                         lllocalcurve2,locallutili, 

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1055,11 +1055,19 @@ void Crop::update(int todo)
                             params.filmSimulation.enabled = false;
                             params.toneCurve.black = 0.f;
                             params.toneCurve.saturation = 0.f;
+                            params.toneCurve.brightness= 0.f;
+                            params.toneCurve.contrast = 0.f;
+                            params.toneCurve.hlcompr = 0.f;
+                            //these 3 are "before" LA
+                            //params.toneCurve.expcomp = 0;
+                            //params.toneCurve.curve = { 0 };
+                            //params.toneCurve.curve2 = { 0 };
                             params.colorappearance.enabled = false;
                             params.vibrance.enabled = false;
                             params.labCurve.enabled = false;
                             params.wavelet.enabled = false;
                             params.epd.enabled = false;
+                            params.softlight.enabled = false;
                         }
             } else {
                 parent->ipf.Lab_Local(1, sp, (float**)shbuffer, labnCrop, labnCrop, reservCrop.get(), lastorigCrop.get(), cropx / skip, cropy / skip, skips(parent->fw, skip), skips(parent->fh, skip), skip, locRETgainCurve, locRETtransCurve,

--- a/rtgui/locallabtools.cc
+++ b/rtgui/locallabtools.cc
@@ -1,4 +1,5 @@
 /*
+ *
  *  This file is part of RawTherapee.
  *
  *  Copyright (c) 2004-2010 Gabor Horvath <hgabor@rawtherapee.com>frame
@@ -5838,6 +5839,7 @@ LocallabSoft::LocallabSoft():
     sensisf->setAdjusterListener(this);
 
     // Add Soft light specific widgets to GUI
+    pack_start(*sensisf);
     pack_start(*softMethod);
     Gtk::Label* const labelsoftmethod = Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_SHOWDCT") + ":"));
     ctboxsoftmethod->pack_start(*labelsoftmethod, Gtk::PACK_SHRINK, 4);
@@ -5845,7 +5847,6 @@ LocallabSoft::LocallabSoft():
     pack_start(*ctboxsoftmethod);
     pack_start(*streng);
     pack_start(*laplace);
-    pack_start(*sensisf);
 }
 
 bool LocallabSoft::isMaskViewActive()
@@ -6529,6 +6530,7 @@ LocallabBlur::LocallabBlur():
 
     // Add Blur, Noise & Denoise specific widgets to GUI
     ToolParamBlock* const blnoisebox = Gtk::manage(new ToolParamBlock());
+    blnoisebox->pack_start(*sensibn);
     blnoisebox->pack_start(*blMethod);
     blnoisebox->pack_start(*fftwbl, Gtk::PACK_SHRINK, 0);
     blnoisebox->pack_start(*radius);
@@ -6553,7 +6555,7 @@ LocallabBlur::LocallabBlur():
     wavBox2->pack_start(*invmask);
     expdenoise2->add(*wavBox2, false);
     blnoisebox->pack_start(*expdenoise2);
-    blnoisebox->pack_start(*sensibn);
+//    blnoisebox->pack_start(*sensibn);
 //    blnoisebox->pack_start(*blurMethod);
     blnoisebox->pack_start(*invbl);
     blnoisebox->pack_start(*chroMethod);
@@ -6585,6 +6587,7 @@ LocallabBlur::LocallabBlur():
     detailBox->pack_start(*usemask, Gtk::PACK_SHRINK, 0);
     detailFrame->add(*detailBox);
     wavBox->pack_start(*detailFrame);
+    denoisebox->pack_start(*sensiden);
     
     ToolParamBlock* const nlbox = Gtk::manage(new ToolParamBlock());
     nlbox->pack_start(*nlstr);
@@ -6615,7 +6618,6 @@ LocallabBlur::LocallabBlur():
     expdenoise3->add(*wavBox3, false);
     denoisebox->pack_start(*expdenoise3);
     denoisebox->pack_start(*bilateral);
-    denoisebox->pack_start(*sensiden);
     denoisebox->pack_start(*neutral);
 
     expdenoise->add(*denoisebox, false);

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -235,6 +235,7 @@ LocallabTone::LocallabTone():
 
     // Add Tone Mapping specific widgets to GUI
     // pack_start(*amount); // To use if we change transit_shapedetect parameters
+    pack_start(*sensitm);
     pack_start(*stren);
     pack_start(*equiltm);
     pack_start(*gamma);
@@ -243,7 +244,7 @@ LocallabTone::LocallabTone():
     pack_start(*scaltm);
     pack_start(*rewei);
     // pack_start(*softradiustm); // Always bad with TM ??
-    pack_start(*sensitm);
+//    pack_start(*sensitm);
     ToolParamBlock* const tmBox3 = Gtk::manage(new ToolParamBlock());
     tmBox3->pack_start(*maskusablet, Gtk::PACK_SHRINK, 0);
     tmBox3->pack_start(*maskunusablet, Gtk::PACK_SHRINK, 0);
@@ -1992,13 +1993,14 @@ LocallabSharp::LocallabSharp():
     showmasksharMethodConn = showmasksharMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabSharp::showmasksharMethodChanged));
 
     // Add Sharpening specific widgets to GUI
+    pack_start(*sensisha);
     pack_start(*sharcontrast);
     pack_start(*sharblur);
     pack_start(*sharradius);
     pack_start(*sharamount);
     pack_start(*shardamping);
     pack_start(*shariter);
-    pack_start(*sensisha);
+//    pack_start(*sensisha);
     pack_start(*inverssha);
     sharFrame->set_label_align(0.025, 0.5);
     ToolParamBlock* const sharfBox = Gtk::manage(new ToolParamBlock());
@@ -2648,6 +2650,7 @@ LocallabContrast::LocallabContrast():
     mask2lcCurveEditorG->curveListComplete();
 
     // Add Local contrast specific widgets to GUI
+    pack_start(*sensilc);
     pack_start(*localcontMethod);
     pack_start(*lcradius);
     pack_start(*lcamount);
@@ -2675,7 +2678,7 @@ LocallabContrast::LocallabContrast():
     resiBox->pack_start(*shresFrame);
     expresidpyr->add(*resiBox, false);
     pack_start(*expresidpyr);
-    pack_start(*sensilc);
+//    pack_start(*sensilc);
     Gtk::HSeparator* const separatorcontr = Gtk::manage(new  Gtk::HSeparator());
     pack_start(*separatorcontr);
     ToolParamBlock* const clariBox = Gtk::manage(new ToolParamBlock());
@@ -4401,6 +4404,7 @@ LocallabCBDL::LocallabCBDL():
     lumaneutralPressedConn = lumaneutralButton->signal_pressed().connect(sigc::mem_fun(*this, &LocallabCBDL::lumaneutralPressed));
 
     lumacontrastPlusPressedConn = lumacontrastPlusButton->signal_pressed().connect(sigc::mem_fun(*this, &LocallabCBDL::lumacontrastPlusPressed));
+    pack_start(*sensicb);
 
     // Add CBDL specific widgets to GUI
     ToolParamBlock* const levBox = Gtk::manage(new ToolParamBlock());
@@ -4428,7 +4432,7 @@ LocallabCBDL::LocallabCBDL():
     residFrame->add(*residBox);
     pack_start(*residFrame);
     pack_start(*softradiuscb);
-    pack_start(*sensicb);
+//    pack_start(*sensicb);
     ToolParamBlock* const cbBox3 = Gtk::manage(new ToolParamBlock());
     cbBox3->pack_start(*maskusablecb, Gtk::PACK_SHRINK, 0);
     cbBox3->pack_start(*maskunusablecb, Gtk::PACK_SHRINK, 0);
@@ -5255,6 +5259,7 @@ LocallabLog::LocallabLog():
     mask2CurveEditorL->curveListComplete();
 
     // Add Log encoding specific widgets to GUI
+    pack_start(*sensilog);
     pack_start(*repar);
     pack_start(*ciecam);
     logPFrame->set_label_align(0.025, 0.5);
@@ -5323,7 +5328,7 @@ LocallabLog::LocallabLog():
     pack_start(*exprecovl, false, false);
     
 //    pack_start(*baselog);
-    pack_start(*sensilog);
+//    pack_start(*sensilog);
     pack_start(*expmaskL, false, false);
     
  //   Gtk::Frame* const gradlogFrame = Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_GRADLOGFRA")));


### PR DESCRIPTION
Up to now only BW was concerned by this behavior

Now, process after "LA" are neutralize (provisory) when the user uses one of the functions "Preview deltaE".
So we can see the impact of LA without the action of downstream processes

Jacques