### PR TITLE
Fix GCC warning about comparing signed and unsigned integers.

### DIFF
--- a/rtengine/array2D.h
+++ b/rtengine/array2D.h
@@ -184,13 +184,13 @@ public:
     // use with indices
     T * operator[](int index)
     {
-        assert((index >= 0) && (index < rows.size()));
+        assert((index >= 0) && (std::size_t(index) < rows.size()));
         return rows[index];
     }
 
     const T * operator[](int index) const
     {
-        assert((index >= 0) && (index < rows.size()));
+        assert((index >= 0) && (std::size_t(index) < rows.size()));
         return rows[index];
     }
 


### PR DESCRIPTION
GCC 10.2 seems somewhat unhappy about
```
../rtengine/array2D.h:187:39: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<float*, std::allocator<float*> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  187 |         assert((index >= 0) && (index < rows.size()));
      |                                ~~~~~~~^~~~~~~~~~~~~~
```
which triggers a lot of warnings as `array2D.h` is transitively included in many translation units.

Casting `index` to a wider unsigned type should work as a fix since we check for non-negativity first.