### PR TITLE
A few more minor fixes geared towards lgtm.com alerts

### DIFF
--- a/rtengine/canon_cr3_decoder.cc
+++ b/rtengine/canon_cr3_decoder.cc
@@ -843,7 +843,7 @@ inline void crxFillBuffer(CrxBitstream* bitStrm)
 #endif
 
             if (bitStrm->curBufSize < 1) {  // nothing read
-                throw std::exception();
+                throw std::runtime_error("Unexpected end of file in CRX bitstream");
             }
 
             bitStrm->mdatSize -= bitStrm->curBufSize;

--- a/rtengine/iccjpeg.cc
+++ b/rtengine/iccjpeg.cc
@@ -18,7 +18,7 @@
  */
 
 #include "iccjpeg.h"
-#include <cstdlib>          /* define malloc() */
+#include <new>
 
 
 /*
@@ -155,12 +155,9 @@ marker_is_icc (jpeg_saved_marker_ptr marker)
  * If TRUE is returned, *icc_data_ptr is set to point to the
  * returned data, and *icc_data_len is set to its length.
  *
- * IMPORTANT: the data at **icc_data_ptr has been allocated with malloc()
- * and must be freed by the caller with free() when the caller no longer
- * needs it.  (Alternatively, we could write this routine to use the
- * IJG library's memory allocator, so that the data would be freed implicitly
- * at jpeg_finish_decompress() time.  But it seems likely that many apps
- * will prefer to have the data stick around after decompression finishes.)
+ * IMPORTANT: the data at **icc_data_ptr has been allocated with new
+ * and must be freed by the caller with delete[] when the caller no longer
+ * needs it.
  *
  * NOTE: if the file contains invalid ICC APP2 markers, we just silently
  * return FALSE.  You might want to issue an error message instead.
@@ -235,7 +232,7 @@ read_icc_profile (j_decompress_ptr cinfo,
     }
 
     /* Allocate space for assembled data */
-    icc_data = (JOCTET *) malloc(total_length * sizeof(JOCTET));
+    icc_data = new (std::nothrow) JOCTET[total_length];
 
     if (icc_data == nullptr) {
         return FALSE;    /* oops, out of memory */

--- a/rtengine/iimage.h
+++ b/rtengine/iimage.h
@@ -220,7 +220,7 @@ public:
 #endif
         return ptrs[row][col];
     }
-    const T   operator() (size_t row, size_t col) const
+    const T&   operator() (size_t row, size_t col) const
     {
 #if CHECK_BOUNDS
         assert (row < height_ && col < width_);
@@ -1274,7 +1274,7 @@ public:
 #endif
         return ptr[3 * (row * width + col)];
     }
-    const T  operator() (size_t row, size_t col) const
+    const T&  operator() (size_t row, size_t col) const
     {
 #if CHECK_BOUNDS
         assert (row < height_ && col < width_);

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -195,7 +195,6 @@ ImageIO::ImageIO() :
     profileData(nullptr),
     profileLength(0),
     loadedProfileData(nullptr),
-    loadedProfileDataJpg(false),
     loadedProfileLength(0),
     exifChange(new procparams::ExifPairs),
     iptc(nullptr),
@@ -517,7 +516,6 @@ int ImageIO::loadJPEGFromMemory (const char* buffer, int bufsize)
     jpeg_read_header(&cinfo, TRUE);
 
     deleteLoadedProfileData();
-    loadedProfileDataJpg = true;
     bool hasprofile = read_icc_profile (&cinfo, (JOCTET**)&loadedProfileData, (unsigned int*)&loadedProfileLength);
 
     if (hasprofile) {
@@ -602,7 +600,6 @@ int ImageIO::loadJPEG (const Glib::ustring &fname)
         cinfo.out_color_space = JCS_RGB;
 
         deleteLoadedProfileData();
-        loadedProfileDataJpg = true;
         bool hasprofile = read_icc_profile (&cinfo, (JOCTET**)&loadedProfileData, (unsigned int*)&loadedProfileLength);
 
         if (hasprofile) {
@@ -855,7 +852,6 @@ int ImageIO::loadTIFF (const Glib::ustring &fname)
 
     char* profdata;
     deleteLoadedProfileData();
-    loadedProfileDataJpg = false;
 
     if (TIFFGetField(in, TIFFTAG_ICCPROFILE, &loadedProfileLength, &profdata)) {
         embProfile = cmsOpenProfileFromMem (profdata, loadedProfileLength);
@@ -1710,11 +1706,7 @@ MyMutex& ImageIO::mutex ()
 void ImageIO::deleteLoadedProfileData( )
 {
     if(loadedProfileData) {
-        if(loadedProfileDataJpg) {
-            free(loadedProfileData);
-        } else {
-            delete[] loadedProfileData;
-        }
+        delete[] loadedProfileData;
     }
 
     loadedProfileData = nullptr;

--- a/rtengine/imageio.h
+++ b/rtengine/imageio.h
@@ -70,7 +70,6 @@ protected:
     char* profileData;
     int profileLength;
     char* loadedProfileData;
-    bool loadedProfileDataJpg;
     int loadedProfileLength;
     const std::unique_ptr<procparams::ExifPairs> exifChange;
     IptcData* iptc;

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1646,8 +1646,10 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
                 // Computing the internal image for analysis, i.e. conversion from WCS->Output profile
                 delete workimg;
+                workimg = nullptr;
+
                 workimg = ipf.lab2rgb(nprevl, 0, 0, pW, pH, params->icm);
-            } catch (char * str) {
+            } catch (std::exception&) {
                 return;
             }
         }
@@ -1722,6 +1724,7 @@ void ImProcCoordinator::freeAll()
         }
 
         delete workimg;
+        workimg = nullptr;
 
     }
 

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -5667,14 +5667,8 @@ double ImProcFunctions::getAutoDistor(const Glib::ustring &fname, int thumb_size
         rawGray = raw->getGrayscaleHistEQ(width);
 
         if (!thumbGray || !rawGray) {
-            if (thumbGray) {
-                delete thumbGray;
-            }
-
-            if (rawGray) {
-                delete rawGray;
-            }
-
+            delete[] thumbGray;
+            delete[] rawGray;
             delete thumb;
             delete raw;
             return 0.0;
@@ -5687,8 +5681,8 @@ double ImProcFunctions::getAutoDistor(const Glib::ustring &fname, int thumb_size
             calcDistortion(thumbGray, rawGray, width, h_thumb, 4, dist_amount);
         }
 
-        delete thumbGray;
-        delete rawGray;
+        delete[] thumbGray;
+        delete[] rawGray;
         delete thumb;
         delete raw;
         return dist_amount;

--- a/rtengine/klt/writeFeatures.cc
+++ b/rtengine/klt/writeFeatures.cc
@@ -559,19 +559,19 @@ static structureType _readHeader(
   if (id == FEATURE_TABLE)  {
     fscanf(fp, "%s", line);
     if (strcmp(line, ",") != 0) {
-      KLTError("(_readFeatures) File '%s' is corrupted -- "
+      KLTError("(_readFeatures) File is corrupted -- "
                "(Expected 'comma', found '%s' instead)", line);
       exit(1);
     }
     fscanf(fp, "%s", line);
     if (strcmp(line, "nFeatures") != 0) {
-      KLTError("(_readFeatures) File '%s' is corrupted -- "
+      KLTError("(_readFeatures) File is corrupted -- "
                "(2 Expected 'nFeatures ', found '%s' instead)", line);
       exit(1);
     }
     fscanf(fp, "%s", line);
     if (strcmp(line, "=") != 0) {
-      KLTError("(_readFeatures) File '%s' is corrupted -- "
+      KLTError("(_readFeatures) File is corrupted -- "
                "(2 Expected '= ', found '%s' instead)", line);
       exit(1);
     }

--- a/rtengine/lcp.cc
+++ b/rtengine/lcp.cc
@@ -196,7 +196,7 @@ rtengine::LCPProfile::LCPProfile(const Glib::ustring& fname) :
     XML_Parser parser = XML_ParserCreate(nullptr);
 
     if (!parser) {
-        throw "Couldn't allocate memory for XML parser";
+        throw std::runtime_error("Couldn't allocate memory for XML parser");
     }
 
     XML_SetElementHandler(parser, XmlStartHandler, XmlEndHandler);
@@ -216,7 +216,7 @@ rtengine::LCPProfile::LCPProfile(const Glib::ustring& fname) :
 
             if (XML_Parse(parser, buf, bytesRead, done) == XML_STATUS_ERROR) {
                 XML_ParserFree(parser);
-                throw "Invalid XML in LCP file";
+                throw std::runtime_error("Invalid XML in LCP file");
             }
         } while (!done);
 


### PR DESCRIPTION
The lgtm.com alert on `loadedProfileData` is actually a false positive AFAIU as the allocation function is indirectly tracked via `loadedProfileDataJpg`, but code that is easier analyse statically should also be easier to understand and maintain for human readers. (Using `operator new` in `read_icc_profile` might be considered controversial and there should be no issue with resolving it the other way around, i.e. allocate `loadedProfileData` using `malloc` in the other two cases.)

Concerning the leaky catch, I am not really sure it is catching anything at all at this point as the only two instances of `throw "some-error-message-as-a-string-literal";` left in the code base are in the constructor `LCPProfile::LCPProfile` but I am not completely certain that `ImProcFunctions::lab2*` does not call that constructor indirectly somehow.