### PR TITLE
Local contrast  - Try to solve bug issue #6132

### DIFF
--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1191,6 +1191,10 @@ void Crop::update(int todo)
         parent->ipf.chromiLuminanceCurve(this, 1, labnCrop, labnCrop, parent->chroma_acurve, parent->chroma_bcurve, parent->satcurve, parent->lhskcurve,  parent->clcurve, parent->lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
         parent->ipf.vibrance(labnCrop, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
         parent->ipf.labColorCorrectionRegions(labnCrop);
+        if (params.localContrast.enabled) {
+        // Alberto's local contrast
+            parent->ipf.localContrast(labnCrop, labnCrop->L, params.localContrast, false, skip);
+        }
 
         if ((params.colorappearance.enabled && !params.colorappearance.tonecie) || (!params.colorappearance.enabled)) {
             parent->ipf.EPDToneMap(labnCrop, 0, skip);

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1171,13 +1171,13 @@ void Crop::update(int todo)
         bool cclutili = parent->cclutili;
 
         LUTu dummy;
-        parent->ipf.chromiLuminanceCurve(this, 1, labnCrop, labnCrop, parent->chroma_acurve, parent->chroma_bcurve, parent->satcurve, parent->lhskcurve,  parent->clcurve, parent->lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
-        parent->ipf.vibrance(labnCrop, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
-        parent->ipf.labColorCorrectionRegions(labnCrop);
         if (params.localContrast.enabled) {
         // Alberto's local contrast
             parent->ipf.localContrast(labnCrop, labnCrop->L, params.localContrast, false, skip);
         }
+        parent->ipf.chromiLuminanceCurve(this, 1, labnCrop, labnCrop, parent->chroma_acurve, parent->chroma_bcurve, parent->satcurve, parent->lhskcurve,  parent->clcurve, parent->lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
+        parent->ipf.vibrance(labnCrop, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
+        parent->ipf.labColorCorrectionRegions(labnCrop);
 
         if ((params.colorappearance.enabled && !params.colorappearance.tonecie) || (!params.colorappearance.enabled)) {
             parent->ipf.EPDToneMap(labnCrop, 0, skip);

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1290,6 +1290,10 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
             ipf.chromiLuminanceCurve(nullptr, pW, nprevl, nprevl, chroma_acurve, chroma_bcurve, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, histCCurve, histLCurve);
             ipf.vibrance(nprevl, params->vibrance, params->toneCurve.hrenabled, params->icm.workingProfile);
             ipf.labColorCorrectionRegions(nprevl);
+            if (params->localContrast.enabled) {
+            // Alberto's local contrast
+                ipf.localContrast(nprevl, nprevl->L, params->localContrast, false, scale);
+            }
 
             if ((params->colorappearance.enabled && !params->colorappearance.tonecie) || (!params->colorappearance.enabled)) {
                 ipf.EPDToneMap(nprevl, 0, scale);

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1287,13 +1287,13 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
             histCCurve.clear();
             histLCurve.clear();
-            ipf.chromiLuminanceCurve(nullptr, pW, nprevl, nprevl, chroma_acurve, chroma_bcurve, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, histCCurve, histLCurve);
-            ipf.vibrance(nprevl, params->vibrance, params->toneCurve.hrenabled, params->icm.workingProfile);
-            ipf.labColorCorrectionRegions(nprevl);
             if (params->localContrast.enabled) {
             // Alberto's local contrast
                 ipf.localContrast(nprevl, nprevl->L, params->localContrast, false, scale);
             }
+            ipf.chromiLuminanceCurve(nullptr, pW, nprevl, nprevl, chroma_acurve, chroma_bcurve, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, histCCurve, histLCurve);
+            ipf.vibrance(nprevl, params->vibrance, params->toneCurve.hrenabled, params->icm.workingProfile);
+            ipf.labColorCorrectionRegions(nprevl);
 
             if ((params->colorappearance.enabled && !params->colorappearance.tonecie) || (!params->colorappearance.enabled)) {
                 ipf.EPDToneMap(nprevl, 0, scale);

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -3591,11 +3591,12 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
 
   //  shadowsHighlights(lab);
     shadowsHighlights(lab, params->sh.enabled, params->sh.lab,params->sh.highlights ,params->sh.shadows, params->sh.radius, scale, params->sh.htonalwidth, params->sh.stonalwidth);
-
+/*
     if (params->localContrast.enabled) {
         // Alberto's local contrast
         localContrast(lab, lab->L, params->localContrast, false, scale);
     }
+    */
 }
 
 /**

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -435,6 +435,7 @@ struct local_params {
     float balanceh;
     int colorde;
     int cir;
+    bool recur;
     float thr;
     float stru;
     int chro, cont, sens, sensh, senscb, sensbn, senstm, sensex, sensexclu, sensden, senslc, senssf, senshs, senscolor;
@@ -772,6 +773,7 @@ static void calcLocalParams(int sp, int oW, int oH, const LocallabParams& locall
     int w = oW;
     int h = oH;
     int circr = locallab.spots.at(sp).circrad;
+    bool recur = locallab.spots.at(sp).recurs;
     float streng = ((float)locallab.spots.at(sp).stren);
     float gam = ((float)locallab.spots.at(sp).gamma);
     float est = ((float)locallab.spots.at(sp).estop);
@@ -1355,6 +1357,7 @@ static void calcLocalParams(int sp, int oW, int oH, const LocallabParams& locall
     lp.deltaem = locallab.spots.at(sp).deltae;
     lp.scalereti = scaleret;
     lp.cir = circr;
+    lp.recur = recur;
     lp.actsp = acti;
     lp.xc = w * local_center_x;
     lp.yc = h * local_center_y;
@@ -11385,7 +11388,7 @@ void ImProcFunctions::Lab_Local(
                 transit_shapedetect2(call, 11, bufexporig.get(), bufexpfin.get(), originalmasklog.get(), hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
             }
             
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12068,7 +12071,7 @@ void ImProcFunctions::Lab_Local(
                             BlurNoise_Local(tmp1.get(), original, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
                         }
 
-                        if (params->locallab.spots.at(sp).recurs) {
+                        if (lp.recur) {
                             original->CopyFrom(transformed, multiThread);
                             float avge;
                             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12081,7 +12084,7 @@ void ImProcFunctions::Lab_Local(
                             InverseBlurNoise_Local(original, lp, hueref, chromaref, lumaref, original, transformed, tmp1.get(), cx, cy, sk);
                         }
 
-                        if (params->locallab.spots.at(sp).recurs) {
+                        if (lp.recur) {
                             original->CopyFrom(transformed, multiThread);
                             float avge;
                             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12133,7 +12136,7 @@ void ImProcFunctions::Lab_Local(
 
         DeNoise_Local(call, lp,  originalmaskbl.get(), levred, huerefblur, lumarefblur, chromarefblur, original, transformed, *(bufwv.get()), cx, cy, sk);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12148,7 +12151,7 @@ void ImProcFunctions::Lab_Local(
         constexpr int aut = 0;
         DeNoise(call, slidL, slida, slidb, aut, noiscfactiv, lp, originalmaskbl.get(), bufmaskblurbl.get(), levred, huerefblur, lumarefblur, chromarefblur, original, transformed, cx, cy, sk, locwavCurvehue, locwavhueutili);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12363,7 +12366,7 @@ void ImProcFunctions::Lab_Local(
                     transit_shapedetect(7, loctemp.get(), nullptr, bufchrom, false, hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
                     bufsh.free();
 
-                    if (params->locallab.spots.at(sp).recurs) {
+                    if (lp.recur) {
                         original->CopyFrom(transformed, multiThread);
                         float avge;
                         calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12589,7 +12592,7 @@ void ImProcFunctions::Lab_Local(
                 }
 
 
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -12814,7 +12817,7 @@ void ImProcFunctions::Lab_Local(
                     //  transit_shapedetect(8, tmp1.get(), originalmasktm.get(), bufchro, false, hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
                     bufgb.reset();
 
-                    if (params->locallab.spots.at(sp).recurs) {
+                    if (lp.recur) {
                         original->CopyFrom(transformed, multiThread);
                         float avge;
                         calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13017,7 +13020,7 @@ void ImProcFunctions::Lab_Local(
 
             transit_shapedetect2(call, 9, bufexporig.get(), bufexpfin.get(), originalmaskSH.get(), hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13102,7 +13105,7 @@ void ImProcFunctions::Lab_Local(
         float adjustr = 2.f;
         InverseColorLight_Local(tonequ, tonecurv, sp, 2, lp, originalmaskSH.get(), lightCurveloc, hltonecurveloc, shtonecurveloc, tonecurveloc, exlocalcurve, cclocalcurve, adjustr, localcutili, lllocalcurve, locallutili, original, transformed, cx, cy, hueref, chromaref, lumaref, sk);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13180,7 +13183,7 @@ void ImProcFunctions::Lab_Local(
 
             transit_shapedetect2(call, 3, bufexporig.get(), bufexpfin.get(), nullptr, hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13645,7 +13648,7 @@ void ImProcFunctions::Lab_Local(
                 tmp1.reset();
             }
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13696,7 +13699,7 @@ void ImProcFunctions::Lab_Local(
         //sharpen ellipse and transition
         Sharp_Local(call, loctemp, 0, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13711,7 +13714,7 @@ void ImProcFunctions::Lab_Local(
 
         InverseSharp_Local(loctemp, hueref, lumaref, chromaref, lp, original, transformed, cx, cy, sk);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13757,7 +13760,7 @@ void ImProcFunctions::Lab_Local(
 
             transit_shapedetect2(call, 30, bufexporig.get(), bufexpfin.get(), nullptr, hueref, chromaref, lumaref, sobelref, 0.f, nullptr, lp, original, transformed, cx, cy, sk);
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -13957,7 +13960,7 @@ void ImProcFunctions::Lab_Local(
 
             transit_shapedetect_retinex(call, 4, bufreti, tmpl, bufmask, buforigmas, buflight, bufchro, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -14059,7 +14062,7 @@ void ImProcFunctions::Lab_Local(
 
                 transit_shapedetect_retinex(call, 5, tmpl, tmpl, bufmask, buforigmas, buflight, bufchro, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
 
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -14298,7 +14301,7 @@ void ImProcFunctions::Lab_Local(
 
                 transit_shapedetect_retinex(call, 4, bufreti, tmpl, bufmask, buforigmas, buflight, bufchro, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
 
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -14395,7 +14398,7 @@ void ImProcFunctions::Lab_Local(
                 if (!lp.invret) {
                     transit_shapedetect_retinex(call, 5, tmpl, tmpl, bufmask, buforigmas, buflight, bufchro, hueref, chromaref, lumaref, lp, original, transformed, cx, cy, sk);
 
-                    if (params->locallab.spots.at(sp).recurs) {
+                    if (lp.recur) {
                         original->CopyFrom(transformed, multiThread);
                         float avge;
                         calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -14778,7 +14781,7 @@ void ImProcFunctions::Lab_Local(
                     transit_shapedetect2(call, 1, bufexporig.get(), bufexpfin.get(), originalmaskexp.get(), hueref, chromaref, lumaref, sobelref, meansob, blend2, lp, original, transformed, cx, cy, sk);
                 }
 
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -14864,7 +14867,7 @@ void ImProcFunctions::Lab_Local(
 
         InverseColorLight_Local(false, false, sp, 1, lp, originalmaskexp.get(), lightCurveloc, hltonecurveloc, shtonecurveloc, tonecurveloc, exlocalcurve, cclocalcurve, adjustr, localcutili, lllocalcurve, locallutili, original, transformed, cx, cy, hueref, chromaref, lumaref, sk);
 
-        if (params->locallab.spots.at(sp).recurs) {
+        if (lp.recur) {
             original->CopyFrom(transformed, multiThread);
             float avge;
             calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -15926,7 +15929,7 @@ void ImProcFunctions::Lab_Local(
 
                 }
 
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -16025,7 +16028,7 @@ void ImProcFunctions::Lab_Local(
         if (lp.showmaskcolmetinv == 0 || lp.enaColorMaskinv) {
             InverseColorLight_Local(false, false, sp, 0, lp, originalmaskcol.get(), lightCurveloc, hltonecurveloc, shtonecurveloc, tonecurveloc, exlocalcurve, cclocalcurve, adjustr, localcutili, lllocalcurve, locallutili, original, transformed, cx, cy, hueref, chromaref, lumaref, sk);
 
-            if (params->locallab.spots.at(sp).recurs) {
+            if (lp.recur) {
                 original->CopyFrom(transformed, multiThread);
                 float avge;
                 calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);
@@ -16194,7 +16197,7 @@ void ImProcFunctions::Lab_Local(
                 delete origsav;
                 origsav    = NULL;
                     
-                if (params->locallab.spots.at(sp).recurs) {
+                if (lp.recur) {
                     original->CopyFrom(transformed, multiThread);
                     float avge;
                     calc_ref(sp, original, transformed, 0, 0, original->W, original->H, sk, huerefblur, chromarefblur, lumarefblur, hueref, chromaref, lumaref, sobelref, avge, locwavCurveden, locwavdenutili);

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -1443,6 +1443,11 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorT
 
     ipf.vibrance (labView, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
     ipf.labColorCorrectionRegions(labView);
+    if (params.localContrast.enabled) {
+        // Alberto's local contrast
+        ipf.localContrast(labView, labView->L, params.localContrast, false, 16);
+    }
+
 
     if ((params.colorappearance.enabled && !params.colorappearance.tonecie) || !params.colorappearance.enabled) {
         ipf.EPDToneMap (labView, 5, 6);

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -1438,15 +1438,14 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorT
     CurveFactory::complexsgnCurve (autili, butili, ccutili, cclutili, params.labCurve.acurve, params.labCurve.bcurve, params.labCurve.cccurve,
                                    params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 16);
 
-
-	ipf.chromiLuminanceCurve (nullptr, 1, labView, labView, curve1, curve2, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
-
-    ipf.vibrance (labView, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
-    ipf.labColorCorrectionRegions(labView);
     if (params.localContrast.enabled) {
         // Alberto's local contrast
         ipf.localContrast(labView, labView->L, params.localContrast, false, 16);
     }
+    ipf.chromiLuminanceCurve (nullptr, 1, labView, labView, curve1, curve2, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
+
+    ipf.vibrance (labView, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
+    ipf.labColorCorrectionRegions(labView);
 
 
     if ((params.colorappearance.enabled && !params.colorappearance.tonecie) || !params.colorappearance.enabled) {

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -1346,6 +1346,10 @@ private:
         bool ccutili, cclutili;
         CurveFactory::complexsgnCurve(autili, butili, ccutili, cclutili, params.labCurve.acurve, params.labCurve.bcurve, params.labCurve.cccurve,
                                       params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 1);
+        if (params.localContrast.enabled) {
+            // Alberto's local contrast
+                ipf.localContrast(labView, labView->L, params.localContrast, false, 1);//scale);
+        }
 
         ipf.chromiLuminanceCurve(nullptr, 1, labView, labView, curve1, curve2, satcurve, lhskcurve, clcurve, lumacurve, utili, autili, butili, ccutili, cclutili, clcutili, dummy, dummy);
 
@@ -1356,10 +1360,6 @@ private:
 
         ipf.vibrance(labView, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
         ipf.labColorCorrectionRegions(labView);
-        if (params.localContrast.enabled) {
-            // Alberto's local contrast
-                ipf.localContrast(labView, labView->L, params.localContrast, false, 1);//scale);
-        }
 
         // for all treatments Defringe, Sharpening, Contrast detail ,Microcontrast they are activated if "CIECAM" function are disabled
 

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -1356,6 +1356,10 @@ private:
 
         ipf.vibrance(labView, params.vibrance, params.toneCurve.hrenabled, params.icm.workingProfile);
         ipf.labColorCorrectionRegions(labView);
+        if (params.localContrast.enabled) {
+            // Alberto's local contrast
+                ipf.localContrast(labView, labView->L, params.localContrast, false, 1);//scale);
+        }
 
         // for all treatments Defringe, Sharpening, Contrast detail ,Microcontrast they are activated if "CIECAM" function are disabled
 

--- a/rtgui/localcontrast.cc
+++ b/rtgui/localcontrast.cc
@@ -32,11 +32,17 @@ using namespace rtengine::procparams;
 LocalContrast::LocalContrast(): FoldableToolPanel(this, "localcontrast", M("TP_LOCALCONTRAST_LABEL"), false, true)
 {
     auto m = ProcEventMapper::getInstance();
-    EvLocalContrastEnabled = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_ENABLED");
+/*    EvLocalContrastEnabled = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_ENABLED");
     EvLocalContrastRadius = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_RADIUS");
     EvLocalContrastAmount = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_AMOUNT");
     EvLocalContrastDarkness = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_DARKNESS");
     EvLocalContrastLightness = m->newEvent(RGBCURVE, "HISTORY_MSG_LOCALCONTRAST_LIGHTNESS");
+*/
+    EvLocalContrastEnabled = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_LOCALCONTRAST_ENABLED");
+    EvLocalContrastRadius = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_LOCALCONTRAST_RADIUS");
+    EvLocalContrastAmount = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_LOCALCONTRAST_AMOUNT");
+    EvLocalContrastDarkness = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_LOCALCONTRAST_DARKNESS");
+    EvLocalContrastLightness = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_LOCALCONTRAST_LIGHTNESS");
     
     radius = Gtk::manage(new Adjuster(M("TP_LOCALCONTRAST_RADIUS"), 20., 200., 1., 80.));
     amount = Gtk::manage(new Adjuster(M("TP_LOCALCONTRAST_AMOUNT"), 0., 1., 0.01, 0.2));


### PR DESCRIPTION
This bug seems very old in principle. Some time ago, Ingo @heckflosse  and I tried to solve the incompatibilities between tone-mapping and "local contrast" 
https://github.com/Beep6581/RawTherapee/issues/6132
Now, it appears with "locallab"...in exposure, but also with all modules when Luminance change

It seems that it's due to placement of "Local contrast" which was in "rgbproc"
I change the placement, now, "Local contrast" is in Improccoordinator, dcop, simpleprocees, rtthumbnail just after Colorregion.
Of course I change the "events"

It seems to work... To verify

@heckflosse  @Thanatomanic  could you review :)

Thank you

Jacques