### PR TITLE
Fix various source comment typos

### DIFF
--- a/rtengine/ashift_dt.c
+++ b/rtengine/ashift_dt.c
@@ -1653,7 +1653,7 @@ static int fact(const int n)
 // original RANSAC works on linear optimization problems. Our model is nonlinear. We
 // take advantage of the fact that lines interesting for our model are vantage lines
 // that meet in one vantage point for each subset of lines (vertical/horizontal).
-// Stragegy: we construct a model by (random) sampling within the subset of lines and
+// Strategy: we construct a model by (random) sampling within the subset of lines and
 // calculate the vantage point. Then we check the "distance" of all other lines to the
 // vantage point. The model that gives highest number of lines combined with the highest
 // total weight and lowest overall "distance" wins.
@@ -1751,7 +1751,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
         const float *L3 = lines[index_set[n]].L;
 
         // we take the absolute value of the dot product of V and L as a measure
-        // of the "distance" between point and line. Note that this is not the real euclidian
+        // of the "distance" between point and line. Note that this is not the real euclidean
         // distance but - with the given normalization - just a pragmatically selected number
         // that goes to zero if V lies on L and increases the more V and L are apart
         const float d = fabs(vec3scalar(V, L3));

--- a/rtengine/ashift_lsd.c
+++ b/rtengine/ashift_lsd.c
@@ -21,7 +21,7 @@
  * Changes versus the original code:
  *      do not include "lsd.h" (not needed)
  *      make all interface functions static
- *      comment out unsused interface functions
+ *      comment out unused interface functions
  *      catch (unlikely) division by zero near line 2035
  *      rename rad1 and rad2 to radius1 and radius2 in reduce_region_radius()
  *        to avoid naming conflict in windows build

--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1427,7 +1427,7 @@ Camera constants:
         "make_model": "FUJIFILM X-PRO2",
         "dcraw_matrix": [ 11434,-4948,-1210,-3746,12042,1903,-666,1479,5235 ], // DNG_v9.4 D65
         "raw_crop": [ 0, 5, 6032, 4026 ], // see X-T2
-        "ranges": { "white": [ 16105, 16270, 16082 ] } // These values are the lowest pixel values >16000 for all ISOs. LENR has a negligble effect.
+        "ranges": { "white": [ 16105, 16270, 16082 ] } // These values are the lowest pixel values >16000 for all ISOs. LENR has a negligible effect.
         // No aperture scaling data provided, but likely negligible
     },
     


### PR DESCRIPTION
Found via `codespell -q 3 -S ./rtdata/languages -L ba,bord,childs,hist,fo,reall,bloc,alph,dof,inout,thre,makro,chang,currentry,preserv,portugues,struc,trough,vektor,`