### PR TITLE
Local adjustments - Added Guidedfilter to avoid color shift

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1285,6 +1285,7 @@ HISTORY_MSG_1037;Local - Nlmeans - radius
 HISTORY_MSG_1038;Local - Nlmeans - gamma
 HISTORY_MSG_1039;Local - Grain - gamma
 HISTORY_MSG_1040;Local - Spot - soft radius
+HISTORY_MSG_1041;Local - Spot - Munsell
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
@@ -2422,7 +2423,7 @@ TP_ICM_WORKING_TRC_TOOLTIP;Only for built-in profiles.
 TP_IMPULSEDENOISE_LABEL;Impulse Noise Reduction
 TP_IMPULSEDENOISE_THRESH;Threshold
 TP_LABCURVE_AVOIDCOLORSHIFT;Avoid color shift
-TP_LABCURVE_AVOIDCOLORSHIFT_TOOLTIP;Fit colors into gamut of the working color space and apply Munsell correction.
+TP_LABCURVE_AVOIDCOLORSHIFT_TOOLTIP;Fit colors into gamut of the working color space and apply Munsell correction (Uniform Perceptual Lab).
 TP_LABCURVE_BRIGHTNESS;Lightness
 TP_LABCURVE_CHROMATICITY;Chromaticity
 TP_LABCURVE_CHROMA_TOOLTIP;To apply B&amp;W toning, set Chromaticity to -100.
@@ -2488,6 +2489,7 @@ TP_LOCALLAB_ARTIF_TOOLTIP;ΔE scope threshold increases the range of deltaE scop
 TP_LOCALLAB_AUTOGRAY;Auto mean luminance (Yb%)
 TP_LOCALLAB_AVOID;Avoid color shift
 TP_LOCALLAB_AVOIDRAD;Soft radius
+TP_LOCALLAB_AVOIDMUN;Munsell correction only
 TP_LOCALLAB_BALAN;ab-L balance (ΔE)
 TP_LOCALLAB_BALANEXP;Laplacian balance
 TP_LOCALLAB_BALANH;C-H balance (ΔE)

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1284,6 +1284,7 @@ HISTORY_MSG_1036;Local - Nlmeans - patch
 HISTORY_MSG_1037;Local - Nlmeans - radius
 HISTORY_MSG_1038;Local - Nlmeans - gamma
 HISTORY_MSG_1039;Local - Grain - gamma
+HISTORY_MSG_1040;Local - Spot - soft radius
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
@@ -2486,6 +2487,7 @@ TP_LOCALLAB_ARTIF;Shape detection
 TP_LOCALLAB_ARTIF_TOOLTIP;ΔE scope threshold increases the range of deltaE scope. High values are for very wide gamut images.\nIncreasing deltaE decay can improve shape detection, but can also reduce the scope.
 TP_LOCALLAB_AUTOGRAY;Auto mean luminance (Yb%)
 TP_LOCALLAB_AVOID;Avoid color shift
+TP_LOCALLAB_AVOIDRAD;Soft radius
 TP_LOCALLAB_BALAN;ab-L balance (ΔE)
 TP_LOCALLAB_BALANEXP;Laplacian balance
 TP_LOCALLAB_BALANH;C-H balance (ΔE)

--- a/rtengine/color.cc
+++ b/rtengine/color.cc
@@ -2183,7 +2183,6 @@ void Color::gamutLchonly (float HH, float &Lprov1, float &Chprov1, float &R, flo
     const float ClipLevel = 65535.0f;
     bool inGamut;
     float2  sincosval = xsincosf(HH);
-
     do {
         inGamut = true;
 
@@ -2351,7 +2350,8 @@ void Color::gamutLchonly (float HH, float2 sincosval, float &Lprov1, float &Chpr
                     }
             }
 
-            Chprov1 *= higherCoef; // decrease the chromaticity value
+                Chprov1 *= higherCoef; // decrease the chromaticity value
+           
 
             if (Chprov1 <= 3.0f) {
                 Lprov1 += lowerCoef;

--- a/rtengine/improcfun.h
+++ b/rtengine/improcfun.h
@@ -251,7 +251,7 @@ enum class BlurType {
                  int shortcu, bool delt, const float hueref, const float chromaref, const float lumaref,
                  float maxdE, float mindE, float maxdElim,  float mindElim, float iterat, float limscope, int scope, bool fftt, float blu_ma, float cont_ma, int indic);
 
-    void avoidcolshi(struct local_params& lp, int sp, LabImage * original, LabImage *transformed, int cy, int cx);
+    void avoidcolshi(struct local_params& lp, int sp, LabImage * original, LabImage *transformed, int cy, int cx, int sk);
 
     void deltaEforMask(float **rdE, int bfw, int bfh, LabImage* bufcolorig, const float hueref, const float chromaref, const float lumaref,
                           float maxdE, float mindE, float maxdElim,  float mindElim, float iterat, float limscope, int scope, float balance, float balanceh);

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10701,7 +10701,17 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
 #endif
             for (int y = 0; y < bh; y++) {
                 for (int x = 0; x < bw; x++) {
-                    float2 sincosval = xsincosf(xatan2f(transformed->b[y][x], transformed->a[y][x]));
+                    const float Chprov1 = sqrtf(SQR(transformed->a[y][x]) + SQR(transformed->b[y][x]));
+                    float2  sincosval;
+
+                    if (Chprov1 == 0.0f) {
+                        sincosval.y = 1.f;
+                        sincosval.x = 0.0f;
+                    } else {
+                        sincosval.y = transformed->a[y][x] / Chprov1;
+                        sincosval.x = transformed->b[y][x] / Chprov1;
+                    }
+
                     transformed->a[y][x] = 32768.f * blechro[y][x] * sincosval.y;
                     transformed->b[y][x] = 32768.f * blechro[y][x] * sincosval.x;
                 }

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10498,6 +10498,7 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
         };
 
         float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
+        bool muns = params->locallab.spots.at(sp).avoidmun;//Munsell control with 200 LUT
         //improve precision with mint and maxt
         float tr = std::min(4.f, softr);
         float mint = 0.15f - 0.03f * tr;//between 0.15f and 0.03f 
@@ -10620,8 +10621,9 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
                     Color::pregamutlab(Lprov1, HH, chr);
                     Chprov1 = rtengine::min(Chprov1, chr);
                     float R, G, B;
-                  //  Color::gamutLchonly(sincosval, Lprov1, Chprov1, wip, highlight, 0.15f, 0.92f);
-                    Color::gamutLchonly(HH, sincosval, Lprov1, Chprov1, R, G, B, wip, highlight, mint, maxt);//replace for best results
+                    if(!muns) {
+                        Color::gamutLchonly(HH, sincosval, Lprov1, Chprov1, R, G, B, wip, highlight, mint, maxt);//replace for best results
+                    }
                     transformed->L[y][x] = Lprov1 * 327.68f;
                     transformed->a[y][x] = 327.68f * Chprov1 * sincosval.y;
                     transformed->b[y][x] = 327.68f * Chprov1 * sincosval.x;
@@ -11214,6 +11216,7 @@ void ImProcFunctions::Lab_Local(
     constexpr int del = 3; // to avoid crash with [loy - begy] and [lox - begx] and bfh bfw  // with gtk2 [loy - begy-1] [lox - begx -1 ] and del = 1
     struct local_params lp;
     calcLocalParams(sp, oW, oH, params->locallab, lp, prevDeltaE, llColorMask, llColorMaskinv, llExpMask, llExpMaskinv, llSHMask, llSHMaskinv, llvibMask, lllcMask, llsharMask, llcbMask, llretiMask, llsoftMask, lltmMask, llblMask, lllogMask, ll_Mask, locwavCurveden, locwavdenutili);
+
     avoidcolshi(lp, sp, original, transformed, cy, cx, sk);
 
     const float radius = lp.rad / (sk * 1.4); //0 to 70 ==> see skip

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10497,11 +10497,11 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
             {wiprof[2][0], wiprof[2][1], wiprof[2][2]}
         };
 
-        float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
+        const float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
         //improve precision with mint and maxt
-        float tr = std::min(4.f, softr);
-        float mint = 0.15f - 0.03f * tr;//between 0.15f and 0.03f 
-        float maxt = 0.96f + 0.008f * tr;//between 0.96f and 0.992f
+        const float tr = std::min(4.f, softr);
+        const float mint = 0.15f - 0.03f * tr;//between 0.15f and 0.03f 
+        const float maxt = 0.96f + 0.008f * tr;//between 0.96f and 0.992f
 
         const bool highlight = params->toneCurve.hrenabled;
         const bool needHH =  true; //always Munsell to avoid bad behavior //(lp.chro != 0.f);
@@ -10645,13 +10645,9 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
                 }
             }
         }
+
         //Guidedfilter to reduce artifacts in transitions
         if (softr != 0.f) {//soft for L a b because we change color...
-            int bw = transformed->W;
-            int bh = transformed->H;
-            array2D<float> ble(bw, bh);
-            array2D<float> guid(bw, bh);
-
             const float tmpblur = softr < 0.f ? -1.f / softr : 1.f + softr;
             const int r1 = rtengine::max<int>(4 / sk * tmpblur + 0.5f, 1);
             const int r2 = rtengine::max<int>(25 / sk * tmpblur + 0.5f, 1);
@@ -10663,8 +10659,13 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
             constexpr float bepsil = epsilmin;
             const float epsil = softr < 0.f ? 0.001f : aepsil * softr + bepsil;
 
+            const int bw = transformed->W;
+            const int bh = transformed->H;
+            array2D<float> ble(bw, bh);
+            array2D<float> guid(bw, bh);
+
 #ifdef _OPENMP
-        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+            #pragma omp parallel for schedule(dynamic,16) if (multiThread)
 #endif
 
             for (int y = 0; y < bh ; y++) {
@@ -10675,7 +10676,7 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
             }
             rtengine::guidedFilter(guid, ble, ble, r2, 0.2f * epsil, multiThread);
 #ifdef _OPENMP
-        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+            #pragma omp parallel for schedule(dynamic,16) if (multiThread)
 #endif
             for (int y = 0; y < bh; y++) {
                 for (int x = 0; x < bw; x++) {
@@ -10684,9 +10685,8 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
             }
 
             array2D<float> &blechro = ble; // reuse buffer
-
 #ifdef _OPENMP
-        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+            #pragma omp parallel for schedule(dynamic,16) if (multiThread)
 #endif
 
             for (int y = 0; y < bh ; y++) {
@@ -10697,7 +10697,7 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
             rtengine::guidedFilter(guid, blechro, blechro, r1, epsil, multiThread);
 
 #ifdef _OPENMP
-        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+            #pragma omp parallel for schedule(dynamic,16) if (multiThread)
 #endif
             for (int y = 0; y < bh; y++) {
                 for (int x = 0; x < bw; x++) {

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10498,11 +10498,11 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
         };
 
         const float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
-        bool muns = params->locallab.spots.at(sp).avoidmun;//Munsell control with 200 LUT
+        const bool muns = params->locallab.spots.at(sp).avoidmun;//Munsell control with 200 LUT
         //improve precision with mint and maxt
         const float tr = std::min(2.f, softr);
         const float mint = 0.15f - 0.06f * tr;//between 0.15f and 0.03f 
-        const float maxt = 0.96f + 0.016f * tr;//between 0.96f and 0.992f
+        const float maxt = 0.98f + 0.008f * tr;//between 0.98f and 0.996f
 
         const bool highlight = params->toneCurve.hrenabled;
         const bool needHH =  true; //always Munsell to avoid bad behavior //(lp.chro != 0.f);

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10500,9 +10500,9 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
         const float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
         bool muns = params->locallab.spots.at(sp).avoidmun;//Munsell control with 200 LUT
         //improve precision with mint and maxt
-        const float tr = std::min(4.f, softr);
-        const float mint = 0.15f - 0.03f * tr;//between 0.15f and 0.03f 
-        const float maxt = 0.96f + 0.008f * tr;//between 0.96f and 0.992f
+        const float tr = std::min(2.f, softr);
+        const float mint = 0.15f - 0.06f * tr;//between 0.15f and 0.03f 
+        const float maxt = 0.96f + 0.016f * tr;//between 0.96f and 0.992f
 
         const bool highlight = params->toneCurve.hrenabled;
         const bool needHH =  true; //always Munsell to avoid bad behavior //(lp.chro != 0.f);
@@ -10651,8 +10651,8 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
         //Guidedfilter to reduce artifacts in transitions
         if (softr != 0.f) {//soft for L a b because we change color...
             const float tmpblur = softr < 0.f ? -1.f / softr : 1.f + softr;
-            const int r1 = rtengine::max<int>(4 / sk * tmpblur + 0.5f, 1);
-            const int r2 = rtengine::max<int>(25 / sk * tmpblur + 0.5f, 1);
+            const int r1 = rtengine::max<int>(6 / sk * tmpblur + 0.5f, 1);
+            const int r2 = rtengine::max<int>(10 / sk * tmpblur + 0.5f, 1);
 
             constexpr float epsilmax = 0.005f;
             constexpr float epsilmin = 0.00001f;

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10701,7 +10701,7 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
 #endif
             for (int y = 0; y < bh; y++) {
                 for (int x = 0; x < bw; x++) {
-                    const float Chprov1 = sqrtf(SQR(transformed->a[y][x]) + SQR(transformed->b[y][x]));
+                    const float Chprov1 = std::sqrt(SQR(transformed->a[y][x]) + SQR(transformed->b[y][x]));
                     float2  sincosval;
 
                     if (Chprov1 == 0.0f) {

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10647,7 +10647,6 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
         }
         //Guidedfilter to reduce artifacts in transitions
         if (softr != 0.f) {//soft for L a b because we change color...
-StopWatch Stop1("softr");
             int bw = transformed->W;
             int bh = transformed->H;
             array2D<float> ble(bw, bh);

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10485,7 +10485,7 @@ void clarimerge(struct local_params& lp, float &mL, float &mC, bool &exec, LabIm
     }
 }
 
-void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * original, LabImage *transformed, int cy, int cx)
+void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * original, LabImage *transformed, int cy, int cx, int sk)
 {
     if (params->locallab.spots.at(sp).avoid  && lp.islocal) {
         const float ach = lp.trans / 100.f;
@@ -10633,6 +10633,56 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
                         transformed->a[y][x] = 327.68f * Chprov * sincosval.y; // apply Munsell
                         transformed->b[y][x] = 327.68f * Chprov * sincosval.x;
                     }
+                }
+            }
+        }
+        //Guidedfilter to reduce artifacts in transitions
+        const float softr = 0.7f;//try others values...between 0.1f and 2.f
+        if (softr != 0.f) {//soft for L a b because we change color...
+
+            int bw = transformed->W;
+            int bh = transformed->H;
+            array2D<float> blechro(bw, bh);
+            array2D<float> ble(bw, bh);
+            array2D<float> hue(bw, bh);
+            array2D<float> guid(bw, bh);
+        
+#ifdef _OPENMP
+        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+#endif
+
+            for (int y = 0; y < bh ; y++) {
+                for (int x = 0; x < bw; x++) {
+                    hue[y][x] = xatan2f(transformed->b[y][x], transformed->a[y][x]);
+                    const float chromah = std::sqrt(SQR(transformed->b[y][x]) + SQR(transformed->a[y][x]));
+                    ble[y][x] = transformed->L[y][x] / 32768.f;
+                    blechro[y][x] = chromah / 32768.f;
+                    guid[y][x] = original->L[y][x] / 32768.f;
+                }
+            }
+            const float tmpblur = softr < 0.f ? -1.f / softr : 1.f + softr;
+            const int r1 = rtengine::max<int>(4 / sk * tmpblur + 0.5f, 1);
+            const int r2 = rtengine::max<int>(25 / sk * tmpblur + 0.5f, 1);
+
+            constexpr float epsilmax = 0.005f;
+            constexpr float epsilmin = 0.00001f;
+
+            constexpr float aepsil = (epsilmax - epsilmin) / 100.f;
+            constexpr float bepsil = epsilmin;
+            const float epsil = softr < 0.f ? 0.001f : aepsil * softr + bepsil;
+
+            rtengine::guidedFilter(guid, blechro, blechro, r1, epsil, multiThread);
+            rtengine::guidedFilter(guid, ble, ble, r2, 0.2f * epsil, multiThread);
+
+#ifdef _OPENMP
+        #pragma omp parallel for schedule(dynamic,16) if (multiThread)
+#endif
+            for (int y = 0; y < bh; y++) {
+                for (int x = 0; x < bw; x++) {
+                    float2 sincosval = xsincosf(hue[y][x]);
+                    transformed->L[y][x] = 32768.f * ble[y][x];
+                    transformed->a[y][x] = 32768.f * blechro[y][x] * sincosval.y;
+                    transformed->b[y][x] = 32768.f * blechro[y][x] * sincosval.x;
                 }
             }
         }
@@ -11133,7 +11183,7 @@ void ImProcFunctions::Lab_Local(
     constexpr int del = 3; // to avoid crash with [loy - begy] and [lox - begx] and bfh bfw  // with gtk2 [loy - begy-1] [lox - begx -1 ] and del = 1
     struct local_params lp;
     calcLocalParams(sp, oW, oH, params->locallab, lp, prevDeltaE, llColorMask, llColorMaskinv, llExpMask, llExpMaskinv, llSHMask, llSHMaskinv, llvibMask, lllcMask, llsharMask, llcbMask, llretiMask, llsoftMask, lltmMask, llblMask, lllogMask, ll_Mask, locwavCurveden, locwavdenutili);
-    avoidcolshi(lp, sp, original, transformed, cy, cx);
+    avoidcolshi(lp, sp, original, transformed, cy, cx, sk);
 
     const float radius = lp.rad / (sk * 1.4); //0 to 70 ==> see skip
     int levred;
@@ -16207,7 +16257,7 @@ void ImProcFunctions::Lab_Local(
 //end common mask
 
 // Gamut and Munsell control - very important do not deactivated to avoid crash
-    avoidcolshi(lp, sp, original, transformed, cy, cx);
+    avoidcolshi(lp, sp, original, transformed, cy, cx, sk);
 }
 
 }

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -10499,8 +10499,9 @@ void ImProcFunctions::avoidcolshi(struct local_params& lp, int sp, LabImage * or
 
         float softr = params->locallab.spots.at(sp).avoidrad;//max softr = 30
         //improve precision with mint and maxt
-        float mint = 0.15f - 0.004f * softr;//between 0.15f and 0.03f 
-        float maxt = 0.96f + 0.001f * softr;//between 0.96f and 0.99f
+        float tr = std::min(4.f, softr);
+        float mint = 0.15f - 0.03f * tr;//between 0.15f and 0.03f 
+        float maxt = 0.96f + 0.008f * tr;//between 0.96f and 0.992f
 
         const bool highlight = params->toneCurve.hrenabled;
         const bool needHH =  true; //always Munsell to avoid bad behavior //(lp.chro != 0.f);

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -1063,6 +1063,7 @@ enum ProcEventCode {
     Evlocallabnlgam = 1037,
     Evlocallabdivgr = 1038,
     EvLocallabSpotavoidrad = 1039,
+    EvLocallabSpotavoidmun = 1040,
     NUMOFEVENTS
 };
 

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -1062,6 +1062,7 @@ enum ProcEventCode {
     Evlocallabnlrad = 1036,
     Evlocallabnlgam = 1037,
     Evlocallabdivgr = 1038,
+    EvLocallabSpotavoidrad = 1039,
     NUMOFEVENTS
 };
 

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -2780,6 +2780,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     hishow(false),
     activ(true),
     avoid(false),
+    avoidmun(false),
     blwh(false),
     recurs(false),
     laplac(true),
@@ -4201,6 +4202,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && hishow == other.hishow
         && activ == other.activ
         && avoid == other.avoid
+        && avoidmun == other.avoidmun
         && blwh == other.blwh
         && recurs == other.recurs
         && laplac == other.laplac
@@ -5843,6 +5845,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                 saveToKeyfile(!pedited || spot_edited->hishow, "Locallab", "Hishow_" + index_str, spot.hishow, keyFile);
                 saveToKeyfile(!pedited || spot_edited->activ, "Locallab", "Activ_" + index_str, spot.activ, keyFile);
                 saveToKeyfile(!pedited || spot_edited->avoid, "Locallab", "Avoid_" + index_str, spot.avoid, keyFile);
+                saveToKeyfile(!pedited || spot_edited->avoidmun, "Locallab", "Avoidmun_" + index_str, spot.avoidmun, keyFile);
                 saveToKeyfile(!pedited || spot_edited->blwh, "Locallab", "Blwh_" + index_str, spot.blwh, keyFile);
                 saveToKeyfile(!pedited || spot_edited->recurs, "Locallab", "Recurs_" + index_str, spot.recurs, keyFile);
                 saveToKeyfile(!pedited || spot_edited->laplac, "Locallab", "Laplac_" + index_str, spot.laplac, keyFile);
@@ -7660,6 +7663,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "Hishow_" + index_str, pedited, spot.hishow, spotEdited.hishow);
                 assignFromKeyfile(keyFile, "Locallab", "Activ_" + index_str, pedited, spot.activ, spotEdited.activ);
                 assignFromKeyfile(keyFile, "Locallab", "Avoid_" + index_str, pedited, spot.avoid, spotEdited.avoid);
+                assignFromKeyfile(keyFile, "Locallab", "Avoidmun_" + index_str, pedited, spot.avoidmun, spotEdited.avoidmun);
                 assignFromKeyfile(keyFile, "Locallab", "Blwh_" + index_str, pedited, spot.blwh, spotEdited.blwh);
                 assignFromKeyfile(keyFile, "Locallab", "Recurs_" + index_str, pedited, spot.recurs, spotEdited.recurs);
                 assignFromKeyfile(keyFile, "Locallab", "Laplac_" + index_str, pedited, spot.laplac, spotEdited.laplac);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -2774,6 +2774,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     balanh(1.0),
     colorde(5.0),
     colorscope(30.0),
+    avoidrad(0.7),
     transitweak(1.0),
     transitgrad(0.0),
     hishow(false),
@@ -4194,6 +4195,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && balanh == other.balanh
         && colorde == other.colorde
         && colorscope == other.colorscope
+        && avoidrad == other.avoidrad
         && transitweak == other.transitweak
         && transitgrad == other.transitgrad
         && hishow == other.hishow
@@ -5835,6 +5837,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                 saveToKeyfile(!pedited || spot_edited->balanh, "Locallab", "Balanh_" + index_str, spot.balanh, keyFile);
                 saveToKeyfile(!pedited || spot_edited->colorde, "Locallab", "Colorde_" + index_str, spot.colorde, keyFile);
                 saveToKeyfile(!pedited || spot_edited->colorscope, "Locallab", "Colorscope_" + index_str, spot.colorscope, keyFile);
+                saveToKeyfile(!pedited || spot_edited->avoidrad, "Locallab", "Avoidrad_" + index_str, spot.avoidrad, keyFile);
                 saveToKeyfile(!pedited || spot_edited->transitweak, "Locallab", "Transitweak_" + index_str, spot.transitweak, keyFile);
                 saveToKeyfile(!pedited || spot_edited->transitgrad, "Locallab", "Transitgrad_" + index_str, spot.transitgrad, keyFile);
                 saveToKeyfile(!pedited || spot_edited->hishow, "Locallab", "Hishow_" + index_str, spot.hishow, keyFile);
@@ -7651,6 +7654,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "Balanh_" + index_str, pedited, spot.balanh, spotEdited.balanh);
                 assignFromKeyfile(keyFile, "Locallab", "Colorde_" + index_str, pedited, spot.colorde, spotEdited.colorde);
                 assignFromKeyfile(keyFile, "Locallab", "Colorscope_" + index_str, pedited, spot.colorscope, spotEdited.colorscope);
+                assignFromKeyfile(keyFile, "Locallab", "Avoidrad_" + index_str, pedited, spot.avoidrad, spotEdited.avoidrad);
                 assignFromKeyfile(keyFile, "Locallab", "Transitweak_" + index_str, pedited, spot.transitweak, spotEdited.transitweak);
                 assignFromKeyfile(keyFile, "Locallab", "Transitgrad_" + index_str, pedited, spot.transitgrad, spotEdited.transitgrad);
                 assignFromKeyfile(keyFile, "Locallab", "Hishow_" + index_str, pedited, spot.hishow, spotEdited.hishow);

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1015,6 +1015,7 @@ struct LocallabParams {
         bool hishow;
         bool activ;
         bool avoid;
+        bool avoidmun;
         bool blwh;
         bool recurs;
         bool laplac;

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1009,6 +1009,7 @@ struct LocallabParams {
         double balanh;
         double colorde;
         double colorscope;
+        double avoidrad;
         double transitweak;
         double transitgrad;
         bool hishow;

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -1065,7 +1065,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     AUTOEXP,   // Evlocallabnlpat
     AUTOEXP,   // Evlocallabnlrad
     AUTOEXP,   // Evlocallabnlgam
-    AUTOEXP   // Evlocallabdivgr
+    AUTOEXP,   // Evlocallabdivgr
+    AUTOEXP   // EvLocallabSpotavoidrad
 
 
 };

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -1066,7 +1066,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     AUTOEXP,   // Evlocallabnlrad
     AUTOEXP,   // Evlocallabnlgam
     AUTOEXP,   // Evlocallabdivgr
-    AUTOEXP   // EvLocallabSpotavoidrad
+    AUTOEXP,   // EvLocallabSpotavoidrad
+    AUTOEXP   // EvLocallabSpotavoidmun
 
 
 };

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -83,6 +83,7 @@ ControlSpotPanel::ControlSpotPanel():
     hishow_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_PREVSHOW")))),
     activ_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ACTIVSPOT")))),
     avoid_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AVOID")))),
+    avoidmun_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AVOIDMUN")))),
     blwh_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_BLWH")))),
     recurs_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_RECURS")))),
     laplac_(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LAPLACC")))),
@@ -395,12 +396,15 @@ ControlSpotPanel::ControlSpotPanel():
 
     avoidConn_  = avoid_->signal_toggled().connect(
                       sigc::mem_fun(*this, &ControlSpotPanel::avoidChanged));
+    avoidmunConn_  = avoidmun_->signal_toggled().connect(
+                      sigc::mem_fun(*this, &ControlSpotPanel::avoidmunChanged));
     
     Gtk::Frame* const avFrame = Gtk::manage(new Gtk::Frame());
     ToolParamBlock* const avbox = Gtk::manage(new ToolParamBlock());
     avFrame->set_label_align(0.025, 0.5);
     avFrame->set_label_widget(*avoid_);
     avbox->pack_start(*avoidrad_);
+    avbox->pack_start(*avoidmun_);
     avFrame->add(*avbox);
     specCaseBox->pack_start(*avFrame);
 
@@ -840,6 +844,7 @@ void ControlSpotPanel::load_ControlSpot_param()
     hishow_->set_active(row[spots_.hishow]);
     activ_->set_active(row[spots_.activ]);
     avoid_->set_active(row[spots_.avoid]);
+    avoidmun_->set_active(row[spots_.avoidmun]);
     blwh_->set_active(row[spots_.blwh]);
     recurs_->set_active(row[spots_.recurs]);
    // laplac_->set_active(row[spots_.laplac]);
@@ -1588,6 +1593,31 @@ void ControlSpotPanel::avoidChanged()
     }
 }
 
+void ControlSpotPanel::avoidmunChanged()
+{
+    // printf("avoidmunChanged\n");
+
+    // Get selected control spot
+    const auto s = treeview_->get_selection();
+
+    if (!s->count_selected_rows()) {
+        return;
+    }
+
+    const auto iter = s->get_selected();
+    Gtk::TreeModel::Row row = *iter;
+    row[spots_.avoidmun] = avoidmun_->get_active();
+
+    // Raise event
+    if (listener) {
+        if (avoidmun_->get_active()) {
+            listener->panelChanged(EvLocallabSpotavoidmun, M("GENERAL_ENABLED"));
+        } else {
+            listener->panelChanged(EvLocallabSpotavoidmun, M("GENERAL_DISABLED"));
+        }
+    }
+}
+
 void ControlSpotPanel::activChanged()
 {
     // printf("activChanged\n");
@@ -1809,6 +1839,7 @@ void ControlSpotPanel::disableParamlistener(bool cond)
     hishowconn_.block(cond);
     activConn_.block(cond);
     avoidConn_.block(cond);
+    avoidmunConn_.block(cond);
     blwhConn_.block(cond);
     recursConn_.block(cond);
     laplacConn_.block(cond);
@@ -1854,6 +1885,7 @@ void ControlSpotPanel::setParamEditable(bool cond)
     hishow_->set_sensitive(cond);
     activ_->set_sensitive(cond);
     avoid_->set_sensitive(cond);
+    avoidmun_->set_sensitive(cond);
     blwh_->set_sensitive(cond);
     recurs_->set_sensitive(cond);
     laplac_->set_sensitive(cond);
@@ -2537,6 +2569,7 @@ ControlSpotPanel::SpotRow* ControlSpotPanel::getSpot(const int index)
             r->hishow = row[spots_.hishow];
             r->activ = row[spots_.activ];
             r->avoid = row[spots_.avoid];
+            r->avoidmun = row[spots_.avoidmun];
             r->blwh = row[spots_.blwh];
             r->recurs = row[spots_.recurs];
             r->laplac = row[spots_.laplac];
@@ -2669,6 +2702,7 @@ void ControlSpotPanel::addControlSpot(SpotRow* newSpot)
     row[spots_.hishow] = newSpot->hishow;
     row[spots_.activ] = newSpot->activ;
     row[spots_.avoid] = newSpot->avoid;
+    row[spots_.avoidmun] = newSpot->avoidmun;
     row[spots_.blwh] = newSpot->blwh;
     row[spots_.recurs] = newSpot->recurs;
     row[spots_.laplac] = newSpot->laplac;
@@ -2786,6 +2820,7 @@ ControlSpotPanel::ControlSpots::ControlSpots()
     add(hishow);
     add(activ);
     add(avoid);
+    add(avoidmun);
     add(blwh);
     add(recurs);
     add(laplac);

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -76,6 +76,7 @@ ControlSpotPanel::ControlSpotPanel():
     balanh_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BALANH"), 0.2, 2.5, 0.1, 1.0, Gtk::manage(new RTImage("rawtherapee-logo-16.png")), Gtk::manage(new RTImage("circle-red-green-small.png"))))),
     colorde_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_COLORDE"), -15, 15, 2, 5, Gtk::manage(new RTImage("circle-blue-yellow-small.png")), Gtk::manage(new RTImage("circle-gray-green-small.png"))))),
     colorscope_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_COLORSCOPE"), 0., 100.0, 1., 30.))),
+    avoidrad_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_AVOIDRAD"), 0., 30.0, 0.1, 0.7))),
     scopemask_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SCOPEMASK"), 0, 100, 1, 60))),
     lumask_(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LUMASK"), -50, 30, 1, 10, Gtk::manage(new RTImage("circle-yellow-small.png")), Gtk::manage(new RTImage("circle-gray-small.png")) ))),
 
@@ -354,6 +355,7 @@ ControlSpotPanel::ControlSpotPanel():
     balanh_->setAdjusterListener(this);
     colorde_->setAdjusterListener(this);
     colorscope_->setAdjusterListener(this);
+    avoidrad_->setAdjusterListener(this);
 
     preview_->set_active(false);
     previewConn_ = preview_->signal_clicked().connect(
@@ -393,7 +395,14 @@ ControlSpotPanel::ControlSpotPanel():
 
     avoidConn_  = avoid_->signal_toggled().connect(
                       sigc::mem_fun(*this, &ControlSpotPanel::avoidChanged));
-    specCaseBox->pack_start(*avoid_);
+    
+    Gtk::Frame* const avFrame = Gtk::manage(new Gtk::Frame());
+    ToolParamBlock* const avbox = Gtk::manage(new ToolParamBlock());
+    avFrame->set_label_align(0.025, 0.5);
+    avFrame->set_label_widget(*avoid_);
+    avbox->pack_start(*avoidrad_);
+    avFrame->add(*avbox);
+    specCaseBox->pack_start(*avFrame);
 
     blwhConn_  = blwh_->signal_toggled().connect(
                      sigc::mem_fun(*this, &ControlSpotPanel::blwhChanged));
@@ -827,6 +836,7 @@ void ControlSpotPanel::load_ControlSpot_param()
     balanh_->setValue((double)row[spots_.balanh]);
     colorde_->setValue((double)row[spots_.colorde]);
     colorscope_->setValue((double)row[spots_.colorscope]);
+    avoidrad_->setValue((double)row[spots_.avoidrad]);
     hishow_->set_active(row[spots_.hishow]);
     activ_->set_active(row[spots_.activ]);
     avoid_->set_active(row[spots_.avoid]);
@@ -1481,6 +1491,14 @@ void ControlSpotPanel::adjusterChanged(Adjuster* a, double newval)
         }
     }
 
+    if (a == avoidrad_) {
+        row[spots_.avoidrad] = avoidrad_->getValue();
+
+        if (listener) {
+            listener->panelChanged(EvLocallabSpotavoidrad, avoidrad_->getTextValue());
+        }
+    }
+
     if (a == scopemask_) {
         row[spots_.scopemask] = scopemask_->getIntValue();
 
@@ -1787,6 +1805,7 @@ void ControlSpotPanel::disableParamlistener(bool cond)
     balanh_->block(cond);
     colorde_->block(cond);
     colorscope_->block(cond);
+    avoidrad_->block(cond);
     hishowconn_.block(cond);
     activConn_.block(cond);
     avoidConn_.block(cond);
@@ -1831,6 +1850,7 @@ void ControlSpotPanel::setParamEditable(bool cond)
     balanh_->set_sensitive(cond);
     colorde_->set_sensitive(cond);
     colorscope_->set_sensitive(cond);
+    avoidrad_->set_sensitive(cond);
     hishow_->set_sensitive(cond);
     activ_->set_sensitive(cond);
     avoid_->set_sensitive(cond);
@@ -2509,6 +2529,7 @@ ControlSpotPanel::SpotRow* ControlSpotPanel::getSpot(const int index)
             r->balanh = row[spots_.balanh];
             r->colorde = row[spots_.colorde];
             r->colorscope = row[spots_.colorscope];
+            r->avoidrad = row[spots_.avoidrad];
             r->transitweak = row[spots_.transitweak];
             r->transitgrad = row[spots_.transitgrad];
             r->scopemask = row[spots_.scopemask];
@@ -2644,6 +2665,7 @@ void ControlSpotPanel::addControlSpot(SpotRow* newSpot)
     row[spots_.balanh] = newSpot->balanh;
     row[spots_.colorde] = newSpot->colorde;
     row[spots_.colorscope] = newSpot->colorscope;
+    row[spots_.avoidrad] = newSpot->avoidrad;
     row[spots_.hishow] = newSpot->hishow;
     row[spots_.activ] = newSpot->activ;
     row[spots_.avoid] = newSpot->avoid;
@@ -2717,6 +2739,7 @@ void ControlSpotPanel::setDefaults(const rtengine::procparams::ProcParams * defP
         balanh_->setDefault(defSpot.balanh);
         colorde_->setDefault(defSpot.colorde);
         colorscope_->setDefault(defSpot.colorscope);
+        avoidrad_->setDefault(defSpot.avoidrad);
         scopemask_->setDefault((double)defSpot.scopemask);
         lumask_->setDefault((double)defSpot.lumask);
     }
@@ -2759,6 +2782,7 @@ ControlSpotPanel::ControlSpots::ControlSpots()
     add(balanh);
     add(colorde);
     add(colorscope);
+    add(avoidrad);
     add(hishow);
     add(activ);
     add(avoid);

--- a/rtgui/controlspotpanel.h
+++ b/rtgui/controlspotpanel.h
@@ -79,6 +79,7 @@ public:
         bool hishow;
         bool activ;
         bool avoid;
+        bool avoidmun;
         bool blwh;
         bool recurs;
         bool laplac;
@@ -250,6 +251,7 @@ private:
     void hishowChanged();
     void activChanged();
     void avoidChanged();
+    void avoidmunChanged();
     void blwhChanged();
     void recursChanged();
     void laplacChanged();
@@ -312,6 +314,7 @@ private:
         Gtk::TreeModelColumn<bool> hishow;
         Gtk::TreeModelColumn<bool> activ;
         Gtk::TreeModelColumn<bool> avoid;
+        Gtk::TreeModelColumn<bool> avoidmun;
         Gtk::TreeModelColumn<bool> blwh;
         Gtk::TreeModelColumn<bool> recurs;
         Gtk::TreeModelColumn<bool> laplac;
@@ -406,6 +409,8 @@ private:
     sigc::connection activConn_;
     Gtk::CheckButton* const avoid_;
     sigc::connection avoidConn_;
+    Gtk::CheckButton* const avoidmun_;
+    sigc::connection avoidmunConn_;
     Gtk::CheckButton* const blwh_;
     sigc::connection blwhConn_;
     Gtk::CheckButton* const recurs_;

--- a/rtgui/controlspotpanel.h
+++ b/rtgui/controlspotpanel.h
@@ -75,6 +75,7 @@ public:
         double balanh;
         double colorde;
         double colorscope;
+        double avoidrad;
         bool hishow;
         bool activ;
         bool avoid;
@@ -307,6 +308,7 @@ private:
         Gtk::TreeModelColumn<double> balanh;
         Gtk::TreeModelColumn<double> colorde;
         Gtk::TreeModelColumn<double> colorscope;
+        Gtk::TreeModelColumn<double> avoidrad;
         Gtk::TreeModelColumn<bool> hishow;
         Gtk::TreeModelColumn<bool> activ;
         Gtk::TreeModelColumn<bool> avoid;
@@ -394,6 +396,7 @@ private:
     Adjuster* const balanh_;
     Adjuster* const colorde_;
     Adjuster* const colorscope_;
+    Adjuster* const avoidrad_;
     Adjuster* const scopemask_;
     Adjuster* const lumask_;
 

--- a/rtgui/locallab.cc
+++ b/rtgui/locallab.cc
@@ -320,6 +320,7 @@ void Locallab::read(const rtengine::procparams::ProcParams* pp, const ParamsEdit
         r->hishow = pp->locallab.spots.at(i).hishow;
         r->activ = pp->locallab.spots.at(i).activ;
         r->avoid = pp->locallab.spots.at(i).avoid;
+        r->avoidmun = pp->locallab.spots.at(i).avoidmun;
         r->blwh = pp->locallab.spots.at(i).blwh;
         r->recurs = pp->locallab.spots.at(i).recurs;
         r->laplac = true; //pp->locallab.spots.at(i).laplac;
@@ -499,6 +500,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r->hishow = newSpot->hishow;
             r->activ = newSpot->activ;
             r->avoid = newSpot->avoid;
+            r->avoidmun = newSpot->avoidmun;
             r->blwh = newSpot->blwh;
             r->recurs = newSpot->recurs;
             r->laplac = newSpot->laplac;
@@ -786,6 +788,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r->avoidrad = newSpot->avoidrad;
             r->activ = newSpot->activ;
             r->avoid = newSpot->avoid;
+            r->avoidmun = newSpot->avoidmun;
             r->blwh = newSpot->blwh;
             r->recurs = newSpot->recurs;
             r->laplac = newSpot->laplac;
@@ -938,6 +941,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
                     pp->locallab.spots.at(pp->locallab.selspot).hishow = r->hishow;
                     pp->locallab.spots.at(pp->locallab.selspot).activ = r->activ;
                     pp->locallab.spots.at(pp->locallab.selspot).avoid = r->avoid;
+                    pp->locallab.spots.at(pp->locallab.selspot).avoidmun = r->avoidmun;
                     pp->locallab.spots.at(pp->locallab.selspot).blwh = r->blwh;
                     pp->locallab.spots.at(pp->locallab.selspot).recurs = r->recurs;
                     pp->locallab.spots.at(pp->locallab.selspot).laplac = r->laplac;

--- a/rtgui/locallab.cc
+++ b/rtgui/locallab.cc
@@ -316,6 +316,7 @@ void Locallab::read(const rtengine::procparams::ProcParams* pp, const ParamsEdit
         r->balanh = pp->locallab.spots.at(i).balanh;
         r->colorde = pp->locallab.spots.at(i).colorde;
         r->colorscope = pp->locallab.spots.at(i).colorscope;
+        r->avoidrad = pp->locallab.spots.at(i).avoidrad;
         r->hishow = pp->locallab.spots.at(i).hishow;
         r->activ = pp->locallab.spots.at(i).activ;
         r->avoid = pp->locallab.spots.at(i).avoid;
@@ -494,6 +495,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r->balanh = newSpot->balanh;
             r->colorde = newSpot->colorde;
             r->colorscope = newSpot->colorscope;
+            r->avoidrad = newSpot->avoidrad;
             r->hishow = newSpot->hishow;
             r->activ = newSpot->activ;
             r->avoid = newSpot->avoid;
@@ -781,6 +783,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r->balanh = newSpot->balanh;
             r->colorde = newSpot->colorde;
             r->colorscope = newSpot->colorscope;
+            r->avoidrad = newSpot->avoidrad;
             r->activ = newSpot->activ;
             r->avoid = newSpot->avoid;
             r->blwh = newSpot->blwh;
@@ -931,6 +934,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
                     pp->locallab.spots.at(pp->locallab.selspot).balanh = r->balanh;
                     pp->locallab.spots.at(pp->locallab.selspot).colorde = r->colorde;
                     pp->locallab.spots.at(pp->locallab.selspot).colorscope = r->colorscope;
+                    pp->locallab.spots.at(pp->locallab.selspot).avoidrad = r->avoidrad;
                     pp->locallab.spots.at(pp->locallab.selspot).hishow = r->hishow;
                     pp->locallab.spots.at(pp->locallab.selspot).activ = r->activ;
                     pp->locallab.spots.at(pp->locallab.selspot).avoid = r->avoid;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1078,6 +1078,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).balanh = locallab.spots.at(j).balanh && pSpot.balanh == otherSpot.balanh;
                 locallab.spots.at(j).colorde = locallab.spots.at(j).colorde && pSpot.colorde == otherSpot.colorde;
                 locallab.spots.at(j).colorscope = locallab.spots.at(j).colorscope && pSpot.colorscope == otherSpot.colorscope;
+                locallab.spots.at(j).avoidrad = locallab.spots.at(j).avoidrad && pSpot.avoidrad == otherSpot.avoidrad;
                 locallab.spots.at(j).transitweak = locallab.spots.at(j).transitweak && pSpot.transitweak == otherSpot.transitweak;
                 locallab.spots.at(j).transitgrad = locallab.spots.at(j).transitgrad && pSpot.transitgrad == otherSpot.transitgrad;
                 locallab.spots.at(j).hishow = locallab.spots.at(j).hishow && pSpot.hishow == otherSpot.hishow;
@@ -3311,6 +3312,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
         if (locallab.spots.at(i).colorscope) {
             toEdit.locallab.spots.at(i).colorscope = mods.locallab.spots.at(i).colorscope;
+        }
+
+        if (locallab.spots.at(i).avoidrad) {
+            toEdit.locallab.spots.at(i).avoidrad = mods.locallab.spots.at(i).avoidrad;
         }
 
         if (locallab.spots.at(i).transitweak) {
@@ -6659,6 +6664,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     balanh(v),
     colorde(v),
     colorscope(v),
+    avoidrad(v),
     transitweak(v),
     transitgrad(v),
     hishow(v),
@@ -7227,6 +7233,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     balanh = v;
     colorde = v;
     colorscope = v;
+    avoidrad = v;
     transitweak = v;
     transitgrad = v;
     hishow = v;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1084,6 +1084,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).hishow = locallab.spots.at(j).hishow && pSpot.hishow == otherSpot.hishow;
                 locallab.spots.at(j).activ = locallab.spots.at(j).activ && pSpot.activ == otherSpot.activ;
                 locallab.spots.at(j).avoid = locallab.spots.at(j).avoid && pSpot.avoid == otherSpot.avoid;
+                locallab.spots.at(j).avoidmun = locallab.spots.at(j).avoidmun && pSpot.avoidmun == otherSpot.avoidmun;
                 locallab.spots.at(j).blwh = locallab.spots.at(j).blwh && pSpot.blwh == otherSpot.blwh;
                 locallab.spots.at(j).recurs = locallab.spots.at(j).recurs && pSpot.recurs == otherSpot.recurs;
                 locallab.spots.at(j).laplac = locallab.spots.at(j).laplac && pSpot.laplac == otherSpot.laplac;
@@ -3336,6 +3337,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
         if (locallab.spots.at(i).avoid) {
             toEdit.locallab.spots.at(i).avoid = mods.locallab.spots.at(i).avoid;
+        }
+
+        if (locallab.spots.at(i).avoidmun) {
+            toEdit.locallab.spots.at(i).avoidmun = mods.locallab.spots.at(i).avoidmun;
         }
 
         if (locallab.spots.at(i).blwh) {
@@ -6670,6 +6675,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     hishow(v),
     activ(v),
     avoid(v),
+    avoidmun(v),
     blwh(v),
     recurs(v),
     laplac(v),
@@ -7239,6 +7245,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     hishow = v;
     activ = v;
     avoid = v;
+    avoidmun = v;
     blwh = v;
     recurs = v;
     laplac = v;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -423,6 +423,7 @@ public:
         bool hishow;
         bool activ;
         bool avoid;
+        bool avoidmun;
         bool blwh;
         bool recurs;
         bool laplac;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -417,6 +417,7 @@ public:
         bool balanh;
         bool colorde;
         bool colorscope;
+        bool avoidrad;
         bool transitweak;
         bool transitgrad;
         bool hishow;


### PR DESCRIPTION
All is in the titlle

I add a guidefilter on "L", "a", and "b" with a very small radius, to reduce artfiacts in transitions - due to Munsell and Relative colorimetry

@heckflosse 
Ingo, could you review this PR

Thank you :)

Jacques