### PR TITLE
[cmake] Enable native compilation on Apple M1

### DIFF
--- a/ProcessorTargets.cmake
+++ b/ProcessorTargets.cmake
@@ -6,7 +6,18 @@ set(PROC_TARGET_1_FLAGS "-mtune=generic" CACHE STRING "Processor-1 flags")
 
 # This second choice should be used for your own build only
 set(PROC_TARGET_2_LABEL native CACHE STRING "Processor-2 label - use it for your own build")
-set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")
+
+# Get the architecture on an Apple system (x86 or arm64)
+if(APPLE)
+    execute_process(COMMAND uname -m OUTPUT_VARIABLE APPLE_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+# On Apple's M1 processor and with Apple's clang compiler, the native flag is different
+if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND APPLE_ARCHITECTURE STREQUAL arm64)
+    set(PROC_TARGET_2_FLAGS "-mcpu=native" CACHE STRING "Processor-2 flags")
+else()
+    set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")
+endif()
 
 # The later choices is intended to be used if you want to provide specific builds, but it should match your own processor
 # You can cross compile but you have to know what you're doing, this mechanism has not been designed for that


### PR DESCRIPTION
Hi there,

**TL;DR:** This PR enables the cmake flag `-DPROC_TARGET_NUMBER="2"` to take into account the system and architecture so it picks the right compiler flag on Apple's M1.

I got asked how I've built RT on an Apple M1 machine, and here we go! I'm using homebrew and the default clang. Remember to source homebrew as follows (and don't forget to install the dependencies [here](https://rawpedia.rawtherapee.com/MacOS#Homebrew)):

```bash
# Source homebrew
eval $(/opt/homebrew/bin/brew shellenv)
```

With my last PR (see #6147), you should already be able to compile with the `-mtune=generic` flag (enabled by `DPROC_TARGET_NUMBER="1"`). However, if you want to built specifically for the M1, you should use `-mcpu=native`. Note that the default in RT for a native built is `-march=native`, which is not implemented for compilation on arm/M1. Also, there's not (yet?) a specific flag to enable compilation with `-march=<cpu type>`.

Finally, use the following commands:

```bash
# Checkout RT and make a build directory
cd RawTherapee/
mkdir build && cd build/

# Configure the build (-DPROC_TARGET_NUMBER="2" triggers the native build)
cmake -DCMAKE_BUILD_TYPE="release" \
      -DOSX_DEV_BUILD="ON" \
      -DPROC_TARGET_NUMBER="2" \
      -DCACHE_NAME_SUFFIX="5.8-dev" \
      -DCMAKE_C_COMPILER="clang" \
      -DCMAKE_CXX_COMPILER="clang++" \
      -DLENSFUNDBDIR="/Applications/RawTherapee.app/Contents/Resources/share/lensfun" \
      -DCMAKE_OSX_DEPLOYMENT_TARGET="11.2" \
      ..
      
 # Compile and install
make -j8 && make install

# Run RT
./release/MacOS/rawtherapee
```

Cheers!