### PR TITLE
[cmake] Enable mcpu=native for all Arm processors

### DIFF
--- a/ProcessorTargets.cmake
+++ b/ProcessorTargets.cmake
@@ -7,13 +7,8 @@ set(PROC_TARGET_1_FLAGS "-mtune=generic" CACHE STRING "Processor-1 flags")
 # This second choice should be used for your own build only
 set(PROC_TARGET_2_LABEL native CACHE STRING "Processor-2 label - use it for your own build")
 
-# Get the architecture on an Apple system (x86 or arm64)
-if(APPLE)
-    execute_process(COMMAND uname -m OUTPUT_VARIABLE APPLE_ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-
-# On Apple's M1 processor and with Apple's clang compiler, the native flag is different
-if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND APPLE_ARCHITECTURE STREQUAL arm64)
+# The flag is different on x86 and Arm based processors
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL arm64)
     set(PROC_TARGET_2_FLAGS "-mcpu=native" CACHE STRING "Processor-2 flags")
 else()
     set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")


### PR DESCRIPTION
Hi there,

Following the comments in #6152 I've enabled the `-mcpu=native` flag for all Arm based processors. Following the discussion [here](https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu) in the Arm community, this should give in general best performance and also works on Apple's M1 chip.

Thanks @adamreichold, didn't know cmake has the `CMAKE_HOST_SYSTEM_PROCESSOR` variable defined!

Cheers!