### PR TITLE
[cmake] Use absolute path to cmake in UpdateInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,7 +683,7 @@ if(WIN32)
 elseif(APPLE)
     set(
          ABOUT_COMMAND_WITH_ARGS
-         cmake
+         ${CMAKE_COMMAND}
              -DPROJECT_SOURCE_DIR:STRING=${PROJECT_SOURCE_DIR}
              -DCACHE_NAME_SUFFIX:STRING=${CACHE_NAME_SUFFIX}
              -P ${PROJECT_SOURCE_DIR}/UpdateInfo.cmake


### PR DESCRIPTION
- Recommended for usage of cmake from custom commands
- Enables building with Xcode using the project generated with 'cmake -GXcode ..'

I tried to package RT through Xcode, however, failed :/ Still, here a tiny fix I had to make to build RT via the Xcode project generated by cmake.