### PR TITLE
LA - Move colortoning labgrid from rgb to lab - issue #6132

### DIFF
--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1171,6 +1171,10 @@ void Crop::update(int todo)
         bool cclutili = parent->cclutili;
 
         LUTu dummy;
+        bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
+        if (hasColorToningLabGrid) {
+            parent->ipf.colorToningLabGrid(labnCrop, 0,labnCrop->W , 0, labnCrop->H, false);
+        }
 
         parent->ipf.shadowsHighlights(labnCrop, params.sh.enabled, params.sh.lab,params.sh.highlights ,params.sh.shadows, params.sh.radius, skip, params.sh.htonalwidth, params.sh.stonalwidth);
         

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1171,8 +1171,7 @@ void Crop::update(int todo)
         bool cclutili = parent->cclutili;
 
         LUTu dummy;
-        bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
-        if (hasColorToningLabGrid) {
+        if (params.colorToning.enabled && params.colorToning.method == "LabGrid") {
             parent->ipf.colorToningLabGrid(labnCrop, 0,labnCrop->W , 0, labnCrop->H, false);
         }
 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1286,6 +1286,10 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
             nprevl->CopyFrom(oprevl);
             histCCurve.clear();
             histLCurve.clear();
+            bool hasColorToningLabGrid = params->colorToning.enabled && params->colorToning.method == "LabGrid";
+            if (hasColorToningLabGrid) {
+            ipf.colorToningLabGrid(nprevl, 0, nprevl->W, 0, nprevl->H, false);
+            }
 
             ipf.shadowsHighlights(nprevl, params->sh.enabled, params->sh.lab,params->sh.highlights ,params->sh.shadows, params->sh.radius, scale, params->sh.htonalwidth, params->sh.stonalwidth);
 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1286,8 +1286,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
             nprevl->CopyFrom(oprevl);
             histCCurve.clear();
             histLCurve.clear();
-            bool hasColorToningLabGrid = params->colorToning.enabled && params->colorToning.method == "LabGrid";
-            if (hasColorToningLabGrid) {
+            if (params->colorToning.enabled && params->colorToning.method == "LabGrid") {
             ipf.colorToningLabGrid(nprevl, 0, nprevl->W, 0, nprevl->H, false);
             }
 

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2231,7 +2231,7 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
     }
 
     bool hasColorToning = params->colorToning.enabled && bool (ctOpacityCurve) &&  bool (ctColorCurve) && params->colorToning.method != "LabGrid";
-    bool hasColorToningLabGrid = params->colorToning.enabled && params->colorToning.method == "LabGrid";
+//    bool hasColorToningLabGrid = params->colorToning.enabled && params->colorToning.method == "LabGrid";
     //  float satLimit = float(params->colorToning.satProtectionThreshold)/100.f*0.7f+0.3f;
     //  float satLimitOpacity = 1.f-(float(params->colorToning.saturatedOpacity)/100.f);
     float strProtect = pow_F((float (params->colorToning.strength) / 100.f), 0.4f);
@@ -3184,9 +3184,9 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
                         Color::RGB2Lab(&rtemp[ti * TS], &gtemp[ti * TS], &btemp[ti * TS], &(lab->L[i][jstart]), &(lab->a[i][jstart]), &(lab->b[i][jstart]), toxyz, tW - jstart);
                     }
 
-                    if (hasColorToningLabGrid) {
-                        colorToningLabGrid(lab, jstart, tW, istart, tH, false);
-                    }
+                   // if (hasColorToningLabGrid) {
+                   //     colorToningLabGrid(lab, jstart, tW, istart, tH, false);
+                   // }
                 } else { // black & white
                     // Auto channel mixer needs whole image, so we now copy to tmpImage and close the tiled processing
                     for (int i = istart, ti = 0; i < tH; i++, ti++) {
@@ -3565,9 +3565,9 @@ void ImProcFunctions::rgbProc (Imagefloat* working, LabImage* lab, PipetteBuffer
         for (int i = 0; i < tH; i++) {
             Color::RGB2Lab(tmpImage->r(i), tmpImage->g(i), tmpImage->b(i), lab->L[i], lab->a[i], lab->b[i], toxyz, tW);
 
-            if (hasColorToningLabGrid) {
-                colorToningLabGrid(lab, 0, tW, i, i + 1, false);
-            }
+           // if (hasColorToningLabGrid) {
+               // colorToningLabGrid(lab, 0, tW, i, i + 1, false);
+           // }
         }
 
 

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -1439,8 +1439,7 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorT
                                    params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 16);
 
 
-    bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
-    if (hasColorToningLabGrid) {
+    if (params.colorToning.enabled && params.colorToning.method == "LabGrid") {
         ipf.colorToningLabGrid(labView, 0,labView->W , 0, labView->H, false);
     }
 

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -1438,6 +1438,12 @@ IImage8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorT
     CurveFactory::complexsgnCurve (autili, butili, ccutili, cclutili, params.labCurve.acurve, params.labCurve.bcurve, params.labCurve.cccurve,
                                    params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 16);
 
+
+    bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
+    if (hasColorToningLabGrid) {
+        ipf.colorToningLabGrid(labView, 0,labView->W , 0, labView->H, false);
+    }
+
     ipf.shadowsHighlights(labView, params.sh.enabled, params.sh.lab,params.sh.highlights ,params.sh.shadows, params.sh.radius, 16, params.sh.htonalwidth, params.sh.stonalwidth);
 
     if (params.localContrast.enabled) {

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -1347,6 +1347,12 @@ private:
         CurveFactory::complexsgnCurve(autili, butili, ccutili, cclutili, params.labCurve.acurve, params.labCurve.bcurve, params.labCurve.cccurve,
                                       params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 1);
 
+
+        bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
+        if (hasColorToningLabGrid) {
+            ipf.colorToningLabGrid(labView, 0,labView->W , 0, labView->H, false);
+        }
+
         ipf.shadowsHighlights(labView, params.sh.enabled, params.sh.lab,params.sh.highlights ,params.sh.shadows, params.sh.radius, 1, params.sh.htonalwidth, params.sh.stonalwidth);
 
         if (params.localContrast.enabled) {

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -1348,8 +1348,7 @@ private:
                                       params.labCurve.lccurve, curve1, curve2, satcurve, lhskcurve, 1);
 
 
-        bool hasColorToningLabGrid = params.colorToning.enabled && params.colorToning.method == "LabGrid";
-        if (hasColorToningLabGrid) {
+        if (params.colorToning.enabled && params.colorToning.method == "LabGrid") {
             ipf.colorToningLabGrid(labView, 0,labView->W , 0, labView->H, false);
         }
 

--- a/rtgui/colortoning.cc
+++ b/rtgui/colortoning.cc
@@ -346,7 +346,8 @@ ColorToning::ColorToning () : FoldableToolPanel(this, "colortoning", M("TP_COLOR
     //------------------------------------------------------------------------
     // LAB grid
     auto m = ProcEventMapper::getInstance();
-    EvColorToningLabGridValue = m->newEvent(RGBCURVE, "HISTORY_MSG_COLORTONING_LABGRID_VALUE");
+//    EvColorToningLabGridValue = m->newEvent(RGBCURVE, "HISTORY_MSG_COLORTONING_LABGRID_VALUE");
+    EvColorToningLabGridValue = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_COLORTONING_LABGRID_VALUE");
     labgrid = Gtk::manage(new LabGrid(EvColorToningLabGridValue, M("TP_COLORTONING_LABGRID_VALUES")));
     pack_start(*labgrid, Gtk::PACK_EXPAND_WIDGET, 4);
     //------------------------------------------------------------------------


### PR DESCRIPTION
@Thanatomanic @chaimav
I made the same modification as for shadows-highlight (main) and local contrast (main).
Move the "lab" code from rgbproc to Lab 

jacques