### PR TITLE
Fix predictor modes 2-7 for lossless JPEG

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -923,7 +923,7 @@ ushort * CLASS ljpeg_row (int jrow, struct jhead *jh)
     }
     getbits(-1);
   }
-  FORC3 row[c] = (jh->row + ((jrow & 1) + 1) * (jh->wide*jh->clrs*((jrow+c) & 1)));
+  FORC3 row[c] = jh->row + jh->wide*jh->clrs*((jrow+c) & 1);
   for (col=0; col < jh->wide; col++)
     FORC(jh->clrs) {
       diff = ljpeg_diff (jh->huff[c]);
@@ -9078,7 +9078,7 @@ void CLASS adobe_coeff (const char *make, const char *model)
     RT_matrix_from_constant = ThreeValBool::T;
   }
   // -- RT --------------------------------------------------------------------
-  
+
   for (i=0; i < sizeof table / sizeof *table; i++)
     if (!strncmp (name, table[i].prefix, strlen(table[i].prefix))) {
       if (RT_blacklevel_from_constant == ThreeValBool::T && table[i].black)   black   = (ushort) table[i].black;


### PR DESCRIPTION
Hi!

Predictor modes 2-7 were broken for `lossless_dng_load_raw` (which is used when "Canon" or "BlackMagic" isn't part of `Make`). I just copy-pasted one line from `dcraw.c` to fix the issue.

After this fix it should be possible to remove lj92 (the lib + `lossless_dnglj92_load_raw`) and always use `lossless_dng_load_raw` without having any special case for `Make`. (At least all the files I could find in #4285 seem to work with `lossless_dng_load_raw` after this fix.)

[predictor-example-files-make-test.zip](https://github.com/Beep6581/RawTherapee/files/6358269/predictor-example-files-make-test.zip)

Resolves #6036