### PR TITLE
RFC : Fix parametric curve

### DIFF
--- a/rtengine/curves.h
+++ b/rtengine/curves.h
@@ -464,15 +464,6 @@ protected:
             : t + (1.0 - sh) * hl * (0.5 + CurveFactory::baseu_alt(2.0 * x - 1.0) * 0.5) + sh * (1.0 - hl) * (0.5 + CurveFactory::basel_alt(2.0 * x - 1.0) * 0.5);
     }
 
-    //compute pow(x,a) for x, a in [0,1]
-    static inline double curve_pow(double x, double a){
-
-        if (x <= 0.0) return 0.0;
-        double y = xlog(x)*a;
-        if (xisinf(y) ) return 0.0;
-        return xexp(y);
-    }
-
     void fillHash();
     void fillDyByDx();
 

--- a/rtengine/curves.h
+++ b/rtengine/curves.h
@@ -142,10 +142,18 @@ protected:
         double lx = xlog(x);
         return m2 * x + (1.0 - m2) * (2.0 - xexp(k * lx)) * xexp(l * lx);
     }
+    static inline double basel_alt(double x)
+    {
+        return (2.0 - x) * x * x * x;
+    }
     // basic concave function between (0,0) and (1,1). m1 and m2 controls the slope at the start and end point
     static inline double baseu(double x, double m1, double m2)
     {
         return 1.0 - basel(1.0 - x, m1, m2);
+    }
+    static inline double baseu_alt(double x)
+    {
+        return x * (2.0 + (x - 2.0) * x * x);
     }
     // convex curve between (0,0) and (1,1) with slope m at (0,0). hr controls the highlight recovery
     static inline double cupper(double x, double m, double hr)
@@ -447,6 +455,22 @@ protected:
     static inline double pfull(double x, double prot, double sh, double hl)
     {
         return (1 - sh) * (1 - hl) * p00(x, prot) + sh * hl * p11(x, prot) + (1 - sh) * hl * p01(x, prot) + sh * (1 - hl) * p10(x, prot);
+    }
+    static inline double pfull_alt(double x, double sh, double hl)
+    {
+        double t = (1.0 - sh) * (1.0 - hl) * CurveFactory::basel_alt(x) + sh * hl * CurveFactory::baseu_alt(x);
+        return x <= 0.5
+            ? t + (1.0 - sh) * hl * CurveFactory::basel_alt(2.0 * x) * 0.5 + sh * (1.0 - hl) * CurveFactory::baseu_alt(2.0 * x) * 0.5
+            : t + (1.0 - sh) * hl * (0.5 + CurveFactory::baseu_alt(2.0 * x - 1.0) * 0.5) + sh * (1.0 - hl) * (0.5 + CurveFactory::basel_alt(2.0 * x - 1.0) * 0.5);
+    }
+
+    //compute pow(x,a) for x, a in [0,1]
+    static inline double curve_pow(double x, double a){
+
+        if (x <= 0.0) return 0.0;
+        double y = xlog(x)*a;
+        if (xisinf(y) ) return 0.0;
+        return xexp(y);
     }
 
     void fillHash();

--- a/rtengine/diagonalcurves.cc
+++ b/rtengine/diagonalcurves.cc
@@ -448,9 +448,8 @@ double DiagonalCurve::getVal (double t) const
             double htv = xexp(max(mhc * xlog((stretched - mfc) / (1.0 - mfc)),-236.0));
             double hbase = pfull_alt (htv, 0.5, x[4]);
             //this part of the curve isn't affected by highlight, return the base curve
-            if (hbase < 1e-14 ){ 
-                hbase = xexp(max(xlog((stretched - mfc) / (1.0 - mfc)),-236.0));
-                return mfc + (1.0 - mfc) * hbase;
+            if (hbase < 1e-6 ){ 
+                return stretched;
             } else {
                 return mfc + (1.0 - mfc) * xexp(xlog(hbase) / mhc);
             }

--- a/rtengine/diagonalcurves.cc
+++ b/rtengine/diagonalcurves.cc
@@ -104,13 +104,6 @@ DiagonalCurve::DiagonalCurve (const std::vector<double>& p, int poly_pn)
                 for (int i = 1; i < 4; i++) {
                     x[i] = min(max(p[i], 0.001), 0.99);
                 }
-                // the curve becomes glitchy when the highlight parameter is too high
-                // soft-clamp is to 96% (starting from 95%) and make sure we keep 2% between parameters
-                if (x[3] > 0.95){
-                    x[3] = 0.95 + 0.01*(x[3]-0.95)/0.05;
-                    x[2] = min(x[2], x[3] - 0.02);
-                    x[1] = min(x[1], x[2] - 0.02);
-                }
 
                 for (int i = 4; i < 8; i++) {
                     x[i] = (p[i] + 100.0) / 200.0;
@@ -454,7 +447,13 @@ double DiagonalCurve::getVal (double t) const
             // add highlights effect:
             double htv = xexp(max(mhc * xlog((stretched - mfc) / (1.0 - mfc)),-236.0));
             double hbase = pfull_alt (htv, 0.5, x[4]);
-            return mfc + (1.0 - mfc) * xexp(xlog(hbase) / mhc);
+            //this part of the curve isn't affected by highlight, return the base curve
+            if (hbase < 1e-14 ){ 
+                hbase = xexp(max(xlog((stretched - mfc) / (1.0 - mfc)),-236.0));
+                return mfc + (1.0 - mfc) * hbase;
+            } else {
+                return mfc + (1.0 - mfc) * xexp(xlog(hbase) / mhc);
+            }
         }
 
         break;


### PR DESCRIPTION
I've been looking at the parametric curve glitches, one of the main culprit are parameters at 1.0 or 0.0 (1.0 for the "smoothness" of the curve and 0.0 for the sliders). That said the clamping to 1e-14 were also causing some issues, and removing those lead to segfaults in some cases (not sure why), so I've replaced the `xlog(xexp(...` by `pow` and that solved the crashes. Is there a good reason to use those instead of pow ? Performance wise I don't really see a difference.

![raw_curve](https://user-images.githubusercontent.com/5859344/116449326-59ad8880-a85a-11eb-91e9-bb41e20b8bc6.png)


Fixes #5859