### PR TITLE
Local adjustments - Small Improvement ciecam16 Log encoding with chroma and surround scene 'dark'

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1294,6 +1294,7 @@ HISTORY_MSG_1046;Local - Denoise strength
 HISTORY_MSG_1047;Local - SH and Tone Equalizer strength
 HISTORY_MSG_1048;Local - DR and Exposure strength
 HISTORY_MSG_1049;Local - TM strength
+HISTORY_MSG_1050;Local - Log encoding chroma
 HISTORY_MSG_BLSHAPE;Blur by level
 HISTORY_MSG_BLURCWAV;Blur chroma
 HISTORY_MSG_BLURWAV;Blur luminance
@@ -2557,6 +2558,7 @@ TP_LOCALLAB_CHROMACB_TOOLTIP;Increases or reduces the effect depending on the lu
 TP_LOCALLAB_CHROMALEV;Chroma levels
 TP_LOCALLAB_CHROMASKCOL;Chroma
 TP_LOCALLAB_CHROMASK_TOOLTIP;Changes the chroma of the mask if one exists (i.e. C(C) or LC(H) is activated).
+TP_LOCALLAB_CHROML;Chroma (C)
 TP_LOCALLAB_CHRRT;Chroma
 TP_LOCALLAB_CIEC;Use Ciecam environment parameters
 TP_LOCALLAB_CIECAMLOG_TOOLTIP;This module is based on the CIECAM color appearance model which was designed to better simulate how human vision perceives colors under different lighting conditions.\nThe first Ciecam process 'Scene conditions' is carried out by Log encoding, it also uses 'Absolute luminance' at the time of shooting.\nThe second Ciecam process  'Image adjustments' is simplified and uses only 3 variables (local contrast, contrast J, saturation s).\nThe third Ciecam process  'Viewing conditions' adapts the output to the intended viewing conditions (monitor, TV, projector, printer, etc.) so that the chromatic and contrast appearance is preserved across the display environment. 
@@ -2820,7 +2822,7 @@ TP_LOCALLAB_LOGREPART_TOOLTIP;Allows you to adjust the relative strength of the 
 TP_LOCALLAB_LOGSATURL_TOOLTIP;Saturation (s) in CIECAM16 corresponds to the color of a stimulus in relation to its own brightness.\nActs mainly on medium and highlights tones
 TP_LOCALLAB_LOGSCENE_TOOLTIP;Corresponds to the shooting conditions.
 TP_LOCALLAB_LOGSRCGREY_TOOLTIP;Estimated gray point value of the image.
-TP_LOCALLAB_LOGSURSOUR_TOOLTIP;Changes tones and colors to take into account the Scene conditions.\n\n<b>Average</b>: Average light environment (standard). The image will not change.\n\n<b>Dim</b>: Dim environment. The image will become slightly brighter.
+TP_LOCALLAB_LOGSURSOUR_TOOLTIP;Changes tones and colors to take into account the Scene conditions.\n\n<b>Average</b>: Average light environment (standard). The image will not change.\n\n<b>Dim</b>: Dim environment. The image will become slightly brighter.\n\n<b>Dark</b>: Dark environment. The image will become more bright.
 TP_LOCALLAB_LOGTARGGREY_TOOLTIP;You can adjust this value to suit.
 TP_LOCALLAB_LOGVIEWING_TOOLTIP;Corresponds to the medium on which the final image will be viewed (monitor, TV, projector, printer,..), as well as its environment.
 TP_LOCALLAB_LOG_TOOLNAME;Log Encoding

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -2565,6 +2565,10 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
             f  = 0.9f;
             c  = 0.59f;
             nc = 0.9f;
+        } else if (params->locallab.spots.at(sp).sursour == "Dark") {
+            f  = 0.8f;
+            c  = 0.525f;
+            nc = 0.8f;
         }
 
         //viewing condition for surround
@@ -2617,8 +2621,15 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
     
     float schr = 0.f;
     float mchr = 0.f;
+    float cchr = 0.f;
 
     if (ciec) {
+        
+        cchr = params->locallab.spots.at(sp).chroml;
+        if (cchr == -100.0f) {
+                cchr = -99.8f;
+        }
+
         schr = params->locallab.spots.at(sp).saturl;
 
         if (schr > 0.f) {
@@ -2773,7 +2784,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                 if(ciec) {
                     Qpro = CAMBrightCurveQ[(float)(Qpro * coefQ)] / coefQ;   //brightness and contrast
                     float rstprotection = 50.f;//default value to avoid 1 slider
-                    float chr = 0.f;//no use of chroma 
+                   // float chr = 0.f;//no use of chroma 
                     float Mp, sres;
                     Mp = Mpro / 100.0f;
                     Ciecam02::curvecolorfloat(mchr, Mp, sres, 2.5f);
@@ -2801,7 +2812,7 @@ void ImProcFunctions::ciecamloc_02float(int sp, LabImage* lab, int call)
                     Qpro = QproFactor * sqrtf(Jpro);
                     float Cp = (spro * spro * Qpro) / (1000000.f);
                     Cpro = Cp * 100.f;
-                    Ciecam02::curvecolorfloat(chr, Cp, sres, 1.8f);
+                    Ciecam02::curvecolorfloat(cchr, Cp, sres, 1.8f);
                     Color::skinredfloat(Jpro, hpro, sres, Cp, 55.f, 30.f, 1, rstprotection, 100.f, Cpro);
                 }
 

--- a/rtengine/procevents.h
+++ b/rtengine/procevents.h
@@ -1072,6 +1072,7 @@ enum ProcEventCode {
     Evlocallabreparsh = 1046,
     Evlocallabreparexp = 1047,
     Evlocallabrepartm = 1048,
+    Evlocallabchroml = 1049,
     NUMOFEVENTS
 };
 

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -3985,6 +3985,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     targetGray(18.),
     catad(0.),
     saturl(0.),
+    chroml(0.),
     lightl(0.),
     lightq(0.),
     contl(0.),
@@ -4707,6 +4708,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && targetGray == other.targetGray
         && catad == other.catad
         && saturl == other.saturl
+        && chroml == other.chroml
         && lightl == other.lightl
         && lightq == other.lightq
         && contl == other.contl
@@ -6360,6 +6362,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                     saveToKeyfile(!pedited || spot_edited->targetGray, "Locallab", "TargetGray_" + index_str, spot.targetGray, keyFile);
                     saveToKeyfile(!pedited || spot_edited->catad, "Locallab", "Catad_" + index_str, spot.catad, keyFile);
                     saveToKeyfile(!pedited || spot_edited->saturl, "Locallab", "Saturl_" + index_str, spot.saturl, keyFile);
+                    saveToKeyfile(!pedited || spot_edited->saturl, "Locallab", "Chroml_" + index_str, spot.chroml, keyFile);
                     saveToKeyfile(!pedited || spot_edited->LcurveL, "Locallab", "LCurveL_" + index_str, spot.LcurveL, keyFile);
                     saveToKeyfile(!pedited || spot_edited->lightl, "Locallab", "Lightl_" + index_str, spot.lightl, keyFile);
                     saveToKeyfile(!pedited || spot_edited->lightq, "Locallab", "Brightq_" + index_str, spot.lightq, keyFile);
@@ -8265,6 +8268,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "TargetGray_" + index_str, pedited, spot.targetGray, spotEdited.targetGray);
                 assignFromKeyfile(keyFile, "Locallab", "Catad_" + index_str, pedited, spot.catad, spotEdited.catad);
                 assignFromKeyfile(keyFile, "Locallab", "Saturl_" + index_str, pedited, spot.saturl, spotEdited.saturl);
+                assignFromKeyfile(keyFile, "Locallab", "Chroml_" + index_str, pedited, spot.chroml, spotEdited.chroml);
                 assignFromKeyfile(keyFile, "Locallab", "Lightl_" + index_str, pedited, spot.lightl, spotEdited.lightl);
                 assignFromKeyfile(keyFile, "Locallab", "Brightq_" + index_str, pedited, spot.lightq, spotEdited.lightq);
                 assignFromKeyfile(keyFile, "Locallab", "Contl_" + index_str, pedited, spot.contl, spotEdited.contl);

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1496,6 +1496,7 @@ struct LocallabParams {
         double targetGray;
         double catad;
         double saturl;
+        double chroml;
         double lightl;
         double lightq;
         double contl;

--- a/rtengine/refreshmap.cc
+++ b/rtengine/refreshmap.cc
@@ -1075,7 +1075,8 @@ int refreshmap[rtengine::NUMOFEVENTS] = {
     AUTOEXP,   // Evlocallabreparden
     AUTOEXP,   // Evlocallabreparsh
     AUTOEXP,   // Evlocallabreparexp
-    AUTOEXP   // Evlocallabrepartm
+    AUTOEXP,   // Evlocallabrepartm
+    AUTOEXP   // Evlocallabchroml
 
 
 };

--- a/rtgui/locallabtools.h
+++ b/rtgui/locallabtools.h
@@ -1330,6 +1330,7 @@ private:
     Adjuster* const contthres;
     Adjuster* const colorfl;
     Adjuster* const saturl;
+    Adjuster* const chroml;
     MyExpander* const expL;
     CurveEditorGroup* const CurveEditorL;
     DiagonalCurveEditor* const LshapeL;

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -5162,6 +5162,7 @@ LocallabLog::LocallabLog():
     contthres(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGCONTHRES"), -1., 1., 0.01, 0.))),
     colorfl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGCOLORFL"), -100., 100., 0.5, 0.))),
     saturl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATURV"), -100., 100., 0.5, 0.))),
+    chroml(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CHROML"), -100., 100., 0.5, 0.))),
     expL(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_LOGEXP")))),
     CurveEditorL(new CurveEditorGroup(options.lastlocalCurvesDir, M("TP_LOCALLAB_LOGCONTQ"))),
     LshapeL(static_cast<DiagonalCurveEditor*>(CurveEditorL->addCurve(CT_Diagonal, "Q(Q)"))),
@@ -5231,6 +5232,8 @@ LocallabLog::LocallabLog():
 
     saturl->setAdjusterListener(this);
 
+    chroml->setAdjusterListener(this);
+
     lightl->setAdjusterListener(this);
 
     lightq->setAdjusterListener(this);
@@ -5272,7 +5275,7 @@ LocallabLog::LocallabLog():
     surHBox->pack_start (*surLabel, Gtk::PACK_SHRINK);
     sursour->append (M ("TP_COLORAPP_SURROUND_AVER"));
     sursour->append (M ("TP_COLORAPP_SURROUND_DIM"));
-//    sursour->append (M ("TP_COLORAPP_SURROUND_DARK"));
+    sursour->append (M ("TP_COLORAPP_SURROUND_DARK"));
     sursour->set_active (0);
     surHBox->pack_start (*sursour);
     sursourconn = sursour->signal_changed().connect ( sigc::mem_fun (*this, &LocallabLog::sursourChanged) );
@@ -5362,10 +5365,13 @@ LocallabLog::LocallabLog():
     logP1Box->pack_start(*contl);
     logP1Box->pack_start(*contthres);
     logP1Box->pack_start(*saturl);
+    Gtk::Separator* const separatorchro = Gtk::manage(new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
     ToolParamBlock* const logP11Box = Gtk::manage(new ToolParamBlock());
     logP11Box->pack_start(*lightl);
     logP11Box->pack_start(*lightq);
     logP11Box->pack_start(*contq);
+    logP11Box->pack_start(*separatorchro);
+    logP11Box->pack_start(*chroml);
     logP11Box->pack_start(*colorfl);
     expL->add(*logP11Box, false);
     logP1Box->pack_start(*expL, false, false);
@@ -5463,6 +5469,7 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         lightl->set_tooltip_text(M("TP_LOCALLAB_LOGLIGHTL_TOOLTIP"));        
         lightq->set_tooltip_text(M("TP_LOCALLAB_LOGLIGHTQ_TOOLTIP"));        
         saturl->set_tooltip_text(M("TP_LOCALLAB_LOGSATURL_TOOLTIP"));
+        chroml->set_tooltip_text(M("TP_COLORAPP_CHROMA_TOOLTIP"));
         detail->set_tooltip_text(M("TP_LOCALLAB_LOGDETAIL_TOOLTIP"));
         catad->set_tooltip_text(M("TP_LOCALLAB_LOGCATAD_TOOLTIP"));
         sensilog->set_tooltip_text(M("TP_LOCALLAB_SENSI_TOOLTIP"));
@@ -5512,6 +5519,7 @@ void LocallabLog::updateAdviceTooltips(const bool showTooltips)
         contthres->set_tooltip_text("");
         colorfl->set_tooltip_text("");
         saturl->set_tooltip_text("");
+        chroml->set_tooltip_text("");
         catad->set_tooltip_text("");
         expmaskL->set_tooltip_markup("");
         CCmaskshapeL->setTooltip("");
@@ -5607,6 +5615,8 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
             sursour->set_active (0);
         } else if (spot.sursour == "Dim") {
             sursour->set_active (1);
+        } else if (spot.sursour == "Dark") {
+            sursour->set_active (2);
         }
 
 
@@ -5631,6 +5641,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         sourceabs->setValue(spot.sourceabs);
         catad->setValue(spot.catad);
         saturl->setValue(spot.saturl);
+        chroml->setValue(spot.chroml);
         lightl->setValue(spot.lightl);
         lightq->setValue(spot.lightq);
         contl->setValue(spot.contl);
@@ -5694,6 +5705,7 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.targetGray = targetGray->getValue();
         spot.catad = catad->getValue();
         spot.saturl = saturl->getValue();
+        spot.chroml = chroml->getValue();
         spot.lightl = lightl->getValue();
         spot.lightq = lightq->getValue();
         spot.contl = contl->getValue();
@@ -5724,6 +5736,8 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
             spot.sursour = "Average";
         } else if (sursour->get_active_row_number() == 1) {
             spot.sursour = "Dim";
+        } else if (sursour->get_active_row_number() == 2) {
+            spot.sursour = "Dark";
         }
 
         if (surround->get_active_row_number() == 0) {
@@ -5778,6 +5792,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
             sourceabs->hide();
             targabs->hide();
             saturl->hide();
+            chroml->hide();
             contl->hide();
             contthres->hide();
             lightl->hide();
@@ -5805,6 +5820,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
             targabs->show();
             catad->show();
             saturl->show();
+            chroml->show();
             lightl->show();
             lightq->show();
             contl->show();
@@ -5838,6 +5854,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
             targabs->show();
             catad->show();
             saturl->show();
+            chroml->show();
             lightl->show();
             lightq->show();
             contl->show();
@@ -5984,6 +6001,7 @@ void LocallabLog::setDefaults(const rtengine::procparams::ProcParams* defParams,
         targetGray->setDefault(defSpot.targetGray);
         catad->setDefault(defSpot.catad);
         saturl->setDefault(defSpot.saturl);
+        chroml->setDefault(defSpot.chroml);
         lightl->setDefault(defSpot.lightl);
         lightq->setDefault(defSpot.lightq);
         contl->setDefault(defSpot.contl);
@@ -6072,6 +6090,13 @@ void LocallabLog::adjusterChanged(Adjuster* a, double newval)
             if (listener) {
                 listener->panelChanged(Evlocallabsaturl,
                                        saturl->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
+            }
+        }
+
+        if (a == chroml) {
+            if (listener) {
+                listener->panelChanged(Evlocallabchroml,
+                                       chroml->getTextValue() + " (" + escapeHtmlChars(spotName) + ")");
             }
         }
 

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1572,6 +1572,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).targetGray = locallab.spots.at(j).targetGray && pSpot.targetGray == otherSpot.targetGray;
                 locallab.spots.at(j).catad = locallab.spots.at(j).catad && pSpot.catad == otherSpot.catad;
                 locallab.spots.at(j).saturl = locallab.spots.at(j).saturl && pSpot.saturl == otherSpot.saturl;
+                locallab.spots.at(j).chroml = locallab.spots.at(j).chroml && pSpot.chroml == otherSpot.chroml;
                 locallab.spots.at(j).lightl = locallab.spots.at(j).lightl && pSpot.lightl == otherSpot.lightl;
                 locallab.spots.at(j).lightq = locallab.spots.at(j).lightq && pSpot.lightq == otherSpot.lightq;
                 locallab.spots.at(j).contl = locallab.spots.at(j).contl && pSpot.contl == otherSpot.contl;
@@ -5240,6 +5241,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
             toEdit.locallab.spots.at(i).saturl = mods.locallab.spots.at(i).saturl;
         }
 
+        if (locallab.spots.at(i).chroml) {
+            toEdit.locallab.spots.at(i).chroml = mods.locallab.spots.at(i).chroml;
+        }
+
         if (locallab.spots.at(i).lightl) {
             toEdit.locallab.spots.at(i).lightl = mods.locallab.spots.at(i).lightl;
         }
@@ -7195,6 +7200,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     targetGray(v),
     catad(v),
     saturl(v),
+    chroml(v),
     lightl(v),
     lightq(v),
     contl(v),
@@ -7780,6 +7786,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     targetGray = v;
     catad = v;
     saturl = v;
+    chroml = v;
     lightl = v;
     lightq = v;
     contl = v;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -904,6 +904,7 @@ public:
         bool targetGray;
         bool catad;
         bool saturl;
+        bool chroml;
         bool lightl;
         bool lightq;
         bool contl;


### PR DESCRIPTION
These improvment are consistent with the basic version Ciecam02/16 and concern only the "advanced" mode
* add chroma (c)  in addition to saturation (s) and colorfullness (M)
* add surround 'dark' to 'scene conditions'
jacques 