### PR TITLE
ICM - Abstract profile - Added reset button

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2439,6 +2439,7 @@ TP_ICM_INPUTNONE_TOOLTIP;Use no input color profile at all.\nUse only in special
 TP_ICM_INPUTPROFILE;Input Profile
 TP_ICM_LABEL;Color Management 
 TP_ICM_LABGRID_CIEXY;R(x)=%1 R(y)=%2\nG(x)=%3 G(y)=%4\nB(x)=%5 B(y)=%6
+TP_ICM_NEUTRAL;Reset
 TP_ICM_NOICM;No ICM: sRGB Output
 TP_ICM_OUTPUTPROFILE;Output Profile
 TP_ICM_OUTPUTPROFILE_TOOLTIP;By default all RTv4 or RTv2 profiles are with TRC - sRGB: g=2.4 s=12.92\n\nWith 'ICC Profile Creator' you can generate v4 or v2 profiles with the following choices;\n-Primaries: Aces AP0, Aces AP1, AdobeRGB, Prophoto, Rec2020, sRGB, Widegamut, BestRGB, BetaRGB, BruceRGB, Custom\n-TRC: BT709, sRGB, linear, standard g=2.2, standard g=1.8, Custom\n-Illuminant: D41, D50, D55, D60, D65, D80, stdA 2856K

--- a/rtgui/icmpanel.cc
+++ b/rtgui/icmpanel.cc
@@ -522,6 +522,7 @@ void ICMPanel::neutral_pressed ()
     preser->setValue(defPar.preser);
     fbw->set_active(defPar.fbw);
     wTRC->set_active(toUnderlying(ColorManagementParams::WorkingTrc::NONE));//reset to none
+    will->set_active(toUnderlying(ColorManagementParams::Illuminant::DEFAULT));//reset to default - after wprim
 }
 
 void ICMPanel::updateRenderingIntent(const Glib::ustring &profile)

--- a/rtgui/icmpanel.cc
+++ b/rtgui/icmpanel.cc
@@ -520,6 +520,7 @@ void ICMPanel::neutral_pressed ()
     wGamma->setValue(defPar.workingTRCGamma);//2.4
     wSlope->setValue(defPar.workingTRCSlope);//12.92
     preser->setValue(defPar.preser);
+    fbw->set_active(defPar.fbw);
     wTRC->set_active(toUnderlying(ColorManagementParams::WorkingTrc::NONE));//reset to none
 }
 

--- a/rtgui/icmpanel.cc
+++ b/rtgui/icmpanel.cc
@@ -266,6 +266,17 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, "icm", M("TP_ICM_LABEL")), iuncha
     trcProfVBox->pack_start(*wprimBox, Gtk::PACK_EXPAND_WIDGET);
     trcProfVBox->pack_start(*fbw, Gtk::PACK_EXPAND_WIDGET);
 
+    neutral = Gtk::manage (new Gtk::Button (M ("TP_ICM_NEUTRAL")));
+    setExpandAlignProperties (neutral, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
+    RTImage *resetImg = Gtk::manage (new RTImage ("undo-small.png", "redo-small.png"));
+    setExpandAlignProperties (resetImg, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+    neutral->set_image (*resetImg);
+    neutralconn = neutral->signal_pressed().connect ( sigc::mem_fun (*this, &ICMPanel::neutral_pressed) );
+    neutral->show();
+
+    trcProfVBox->pack_start (*neutral);
+
+
     wprim->append(M("TP_ICM_WORKING_PRIM_NONE"));
     wprim->append(M("TP_ICM_WORKING_PRIM_SRGB"));
     wprim->append(M("TP_ICM_WORKING_PRIM_ADOB"));
@@ -480,6 +491,36 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, "icm", M("TP_ICM_LABEL")), iuncha
     saveRef->signal_pressed().connect(sigc::mem_fun(*this, &ICMPanel::saveReferencePressed));
 
     show_all();
+}
+
+void ICMPanel::neutral_pressed ()
+{   //find working profile and set the same destination proile
+    if (wProfNames->get_active_text() == "Rec2020") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::REC2020));
+    } else if (wProfNames->get_active_text() == "sRGB") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::SRGB));
+    } else if (wProfNames->get_active_text() == "Adobe RGB") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::ADOBE_RGB));
+    } else if (wProfNames->get_active_text() == "ProPhoto") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::PRO_PHOTO));
+    } else if (wProfNames->get_active_text() == "ACESp1") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::ACES_P1));
+    } else if (wProfNames->get_active_text() == "WideGamut") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::WIDE_GAMUT));
+    } else if (wProfNames->get_active_text() == "ACESp0") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::ACES_P0));
+    } else if (wProfNames->get_active_text() == "BruceRGB") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::BRUCE_RGB));
+    } else if (wProfNames->get_active_text() == "Beta RGB") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::BETA_RGB));
+    } else if (wProfNames->get_active_text() == "BestRGB") {
+        wprim->set_active(toUnderlying(ColorManagementParams::Primaries::BEST_RGB));
+    }
+    const ColorManagementParams defPar;
+    wGamma->setValue(defPar.workingTRCGamma);//2.4
+    wSlope->setValue(defPar.workingTRCSlope);//12.92
+    preser->setValue(defPar.preser);
+    wTRC->set_active(toUnderlying(ColorManagementParams::WorkingTrc::NONE));//reset to none
 }
 
 void ICMPanel::updateRenderingIntent(const Glib::ustring &profile)

--- a/rtgui/icmpanel.h
+++ b/rtgui/icmpanel.h
@@ -65,7 +65,9 @@ protected:
     Gtk::Label* blr;
     Gtk::Label* blg;
     Gtk::Label* blb;
+    Gtk::Button* neutral;
 
+    sigc::connection neutralconn;
     bool lastToneCurve;
     sigc::connection tcurveconn;
     bool lastApplyLookTable;
@@ -185,6 +187,7 @@ public:
     void adjusterChanged(Adjuster* a, double newval) override;
     void primChanged (float rx, float ry, float bx, float by, float gx, float gy) override;
     void iprimChanged (float r_x, float r_y, float b_x, float b_y, float g_x, float g_y, float w_x, float w_y) override;
+    void neutral_pressed();
 
     void wpChanged();
     void wtrcinChanged();

--- a/rtgui/retinex.cc
+++ b/rtgui/retinex.cc
@@ -494,7 +494,7 @@ Retinex::Retinex () : FoldableToolPanel (this, "retinex", M ("TP_RETINEX_LABEL")
     RTImage *resetImg = Gtk::manage (new RTImage ("undo-small.png", "redo-small.png"));
     setExpandAlignProperties (resetImg, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
     neutral->set_image (*resetImg);
-    neutral->set_tooltip_text (M ("TP_RETINEX_NEUTRAL_TIP"));
+    neutral->set_tooltip_text (M ("TP_ICM_NEUTRAL_TIP"));
     neutralconn = neutral->signal_pressed().connect ( sigc::mem_fun (*this, &Retinex::neutral_pressed) );
     neutral->show();
 

--- a/rtgui/retinex.cc
+++ b/rtgui/retinex.cc
@@ -494,7 +494,7 @@ Retinex::Retinex () : FoldableToolPanel (this, "retinex", M ("TP_RETINEX_LABEL")
     RTImage *resetImg = Gtk::manage (new RTImage ("undo-small.png", "redo-small.png"));
     setExpandAlignProperties (resetImg, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
     neutral->set_image (*resetImg);
-    neutral->set_tooltip_text (M ("TP_ICM_NEUTRAL_TIP"));
+    neutral->set_tooltip_text (M ("TP_RETINEX_NEUTRAL_TIP"));
     neutralconn = neutral->signal_pressed().connect ( sigc::mem_fun (*this, &Retinex::neutral_pressed) );
     neutral->show();
 


### PR DESCRIPTION
This button "reset all"

* Set the destination  primaries to the same value that "working profile"
* set gamma slope, preserv to default values
* set general menu  TRC to none

jacques