### PR TITLE
On-preview widget fixes

### DIFF
--- a/rtgui/controllines.cc
+++ b/rtgui/controllines.cc
@@ -199,6 +199,10 @@ bool ControlLineManager::pick3(bool picked)
 
 bool ControlLineManager::drag1(int modifierKey)
 {
+    if (action != Action::DRAGGING) {
+        return false;
+    }
+
     EditDataProvider* provider = getEditProvider();
 
     if (!provider || selected_object < 1) {
@@ -261,6 +265,20 @@ bool ControlLineManager::drag1(int modifierKey)
     }
 
     return false;
+}
+
+void ControlLineManager::releaseEdit(void)
+{
+    action = Action::NONE;
+
+    if (selected_object > 0) {
+        mouseOverGeometry[selected_object]->state = Geometry::NORMAL;
+    }
+
+    edited = true;
+    callbacks->lineChanged();
+    drawing_line = false;
+    selected_object = -1;
 }
 
 bool ControlLineManager::getEdited(void) const

--- a/rtgui/controllines.cc
+++ b/rtgui/controllines.cc
@@ -16,6 +16,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <assert.h>
 #include <memory>
 
 #include "controllines.h"
@@ -26,6 +27,53 @@
 #include "../rtengine/perspectivecorrection.h"
 
 using namespace rtengine;
+
+enum GeometryIndex {
+    MO_CANVAS,
+    MO_OBJECT_COUNT,
+
+    VISIBLE_OBJECT_COUNT = 0
+};
+
+/**
+ * Offsets for mouse-over geometry that can be compared to the mouse-over object
+ * ID modded with the control line object count.
+ */
+enum GeometryOffset {
+    OFFSET_LINE = (MO_OBJECT_COUNT + ::ControlLine::LINE) % ::ControlLine::OBJECT_COUNT,
+    OFFSET_ICON = (MO_OBJECT_COUNT + ::ControlLine::ICON) % ::ControlLine::OBJECT_COUNT,
+    OFFSET_BEGIN = (MO_OBJECT_COUNT + ::ControlLine::BEGIN) % ::ControlLine::OBJECT_COUNT,
+    OFFSET_END = (MO_OBJECT_COUNT + ::ControlLine::END) % ::ControlLine::OBJECT_COUNT,
+};
+
+namespace
+{
+
+/**
+ * Returns true if the object matches the offset.
+ */
+constexpr bool checkOffset(int object_id, enum GeometryOffset offset)
+{
+    return object_id % ::ControlLine::OBJECT_COUNT == offset;
+}
+
+/**
+ * Converts a control line mouse-over geometry ID to the visible geometry ID.
+ */
+constexpr int mouseOverIdToVisibleId(int mouse_over_id)
+{
+    return mouse_over_id - MO_OBJECT_COUNT + VISIBLE_OBJECT_COUNT;
+}
+
+/**
+ * Converts a control line mouse-over geometry ID to the control line ID.
+ */
+constexpr int mouseOverIdToLineId(int mouse_over_id)
+{
+    return (mouse_over_id - MO_OBJECT_COUNT) / ::ControlLine::OBJECT_COUNT;
+}
+
+}
 
 ::ControlLine::~ControlLine() = default;
 
@@ -96,8 +144,8 @@ bool ControlLineManager::button1Pressed(int modifierKey)
 
     const int object = dataProvider->getObject();
 
-    if (object > 0) { // A control line.
-        if (object % ::ControlLine::OBJ_COUNT == 2) { // Icon.
+    if (object >= MO_OBJECT_COUNT) { // A control line.
+        if (checkOffset(object, OFFSET_ICON)) { // Icon.
             action = Action::PICKING;
         } else {
             selected_object = object;
@@ -109,7 +157,7 @@ bool ControlLineManager::button1Pressed(int modifierKey)
         }
         addLine(dataProvider->posImage, dataProvider->posImage);
         drawing_line = true;
-        selected_object = mouseOverGeometry.size() - 1; // Select endpoint.
+        selected_object = mouseOverGeometry.size() - ::ControlLine::OBJECT_COUNT + ::ControlLine::END; // Select endpoint.
         action = Action::DRAGGING;
     }
 
@@ -120,7 +168,7 @@ bool ControlLineManager::button1Released(void)
 {
     action = Action::NONE;
 
-    if (selected_object > 0) {
+    if (selected_object >= MO_OBJECT_COUNT) {
         mouseOverGeometry[selected_object]->state = Geometry::NORMAL;
     }
 
@@ -137,7 +185,7 @@ bool ControlLineManager::button3Pressed(int modifierKey)
 
     action = Action::NONE;
 
-    if (!provider || provider->getObject() < 1) {
+    if (!provider || provider->getObject() < MO_OBJECT_COUNT) {
         return false;
     }
 
@@ -155,14 +203,13 @@ bool ControlLineManager::pick1(bool picked)
 
     EditDataProvider* provider = getEditProvider();
 
-    if (!provider || provider->getObject() % ::ControlLine::OBJ_COUNT != 2) {
+    if (!provider || !checkOffset(provider->getObject(), OFFSET_ICON)) {
         return false;
     }
 
     // Change line type.
     int object_id = provider->getObject();
-    ::ControlLine& line =
-        *control_lines[(object_id - 1) / ::ControlLine::OBJ_COUNT];
+    ::ControlLine& line = *control_lines[mouseOverIdToLineId(object_id)];
 
     if (line.type == rtengine::ControlLine::HORIZONTAL) {
         line.icon = line.icon_v;
@@ -172,7 +219,7 @@ bool ControlLineManager::pick1(bool picked)
         line.type = rtengine::ControlLine::HORIZONTAL;
     }
 
-    visibleGeometry[object_id - 1] = line.icon.get();
+    visibleGeometry[mouseOverIdToVisibleId(object_id)] = line.icon.get();
 
     edited = true;
     callbacks->lineChanged();
@@ -194,7 +241,7 @@ bool ControlLineManager::pick3(bool picked)
         return false;
     }
 
-    removeLine((provider->getObject() - 1) / ::ControlLine::OBJ_COUNT);
+    removeLine(mouseOverIdToLineId(provider->getObject()));
     prev_obj = -1;
     selected_object = -1;
     return true;
@@ -208,28 +255,28 @@ bool ControlLineManager::drag1(int modifierKey)
 
     EditDataProvider* provider = getEditProvider();
 
-    if (!provider || selected_object < 1) {
+    if (!provider || selected_object < MO_OBJECT_COUNT) {
         return false;
     }
 
     ::ControlLine& control_line =
-        *control_lines[(selected_object - 1) / ::ControlLine::OBJ_COUNT];
+        *control_lines[mouseOverIdToLineId(selected_object)];
     // 0 == end, 1 == line, 2 == icon, 3 == begin
-    int component = selected_object % ::ControlLine::OBJ_COUNT;
+    int component = selected_object % ::ControlLine::OBJECT_COUNT;
     Coord mouse = provider->posImage + provider->deltaImage;
     Coord delta = provider->deltaImage - drag_delta;
     int ih, iw;
     provider->getImageSize(iw, ih);
 
     switch (component) {
-        case (0): // end
+        case (OFFSET_END): // end
             control_line.end->center = mouse;
             control_line.end->center.clip(iw, ih);
             control_line.line->end = control_line.end->center;
             control_line.end->state = Geometry::DRAGGED;
             break;
 
-        case (1): { // line
+        case (OFFSET_LINE): { // line
             // Constrain delta so the end stays above the image.
             Coord new_delta = control_line.end->center + delta;
             new_delta.clip(iw, ih);
@@ -248,7 +295,7 @@ bool ControlLineManager::drag1(int modifierKey)
             break;
         }
 
-        case (3): // begin
+        case (OFFSET_BEGIN): // begin
             control_line.begin->center = mouse;
             control_line.begin->center.clip(iw, ih);
             control_line.line->begin = control_line.begin->center;
@@ -274,11 +321,11 @@ void ControlLineManager::releaseEdit(void)
 {
     action = Action::NONE;
 
-    if (selected_object > 0) {
+    if (selected_object >= MO_OBJECT_COUNT) {
         mouseOverGeometry[selected_object]->state = Geometry::NORMAL;
     }
-    if (prev_obj > 0) {
-        visibleGeometry[prev_obj - 1]->state = Geometry::NORMAL;
+    if (prev_obj >= MO_OBJECT_COUNT) {
+        visibleGeometry[mouseOverIdToVisibleId(prev_obj)]->state = Geometry::NORMAL;
     }
 
     edited = true;
@@ -307,7 +354,7 @@ bool ControlLineManager::mouseOver(int modifierKey)
 
     int cur_obj = provider->getObject();
 
-    if (cur_obj == 0) { // Canvas
+    if (cur_obj == MO_CANVAS) { // Canvas
         if (draw_mode && modifierKey & GDK_CONTROL_MASK) {
             cursor = CSCrosshair;
         } else {
@@ -315,16 +362,16 @@ bool ControlLineManager::mouseOver(int modifierKey)
         }
     } else if (cur_obj < 0) { // Nothing
         cursor = CSArrow;
-    } else if (cur_obj % ::ControlLine::OBJ_COUNT == 2) { // Icon
-        visibleGeometry[cur_obj - 1]->state = Geometry::PRELIGHT;
+    } else if (checkOffset(cur_obj, OFFSET_ICON)) { // Icon
+        visibleGeometry[mouseOverIdToVisibleId(cur_obj)]->state = Geometry::PRELIGHT;
         cursor = CSArrow;
     } else { // Object
-        visibleGeometry[cur_obj - 1]->state = Geometry::PRELIGHT;
+        visibleGeometry[mouseOverIdToVisibleId(cur_obj)]->state = Geometry::PRELIGHT;
         cursor = CSMove2D;
     }
 
-    if (prev_obj != cur_obj && prev_obj > 0) {
-        visibleGeometry[prev_obj - 1]->state = Geometry::NORMAL;
+    if (prev_obj != cur_obj && prev_obj >= MO_OBJECT_COUNT) {
+        visibleGeometry[mouseOverIdToVisibleId(prev_obj)]->state = Geometry::NORMAL;
     }
 
     prev_obj = cur_obj;
@@ -418,14 +465,29 @@ void ControlLineManager::addLine(Coord begin, Coord end,
     control_line->line = std::move(line);
     control_line->type = type;
 
+    auto assertEqual = [](size_t a, int b) {
+        assert(b >= 0);
+        assert(a == static_cast<size_t>(b));
+    };
+
+    const int base_visible_offset = VISIBLE_OBJECT_COUNT + ::ControlLine::OBJECT_COUNT * control_lines.size();
+    assertEqual(visibleGeometry.size(), base_visible_offset + ::ControlLine::LINE);
     EditSubscriber::visibleGeometry.push_back(control_line->line.get());
+    assertEqual(visibleGeometry.size(), base_visible_offset + ::ControlLine::ICON);
     EditSubscriber::visibleGeometry.push_back(control_line->icon.get());
+    assertEqual(visibleGeometry.size(), base_visible_offset + ::ControlLine::BEGIN);
     EditSubscriber::visibleGeometry.push_back(control_line->begin.get());
+    assertEqual(visibleGeometry.size(), base_visible_offset + ::ControlLine::END);
     EditSubscriber::visibleGeometry.push_back(control_line->end.get());
 
+    const int base_mo_count = MO_OBJECT_COUNT + ::ControlLine::OBJECT_COUNT * control_lines.size();
+    assertEqual(mouseOverGeometry.size(), base_mo_count + ::ControlLine::LINE);
     EditSubscriber::mouseOverGeometry.push_back(control_line->line.get());
+    assertEqual(mouseOverGeometry.size(), base_mo_count + ::ControlLine::ICON);
     EditSubscriber::mouseOverGeometry.push_back(control_line->icon.get());
+    assertEqual(mouseOverGeometry.size(), base_mo_count + ::ControlLine::BEGIN);
     EditSubscriber::mouseOverGeometry.push_back(control_line->begin.get());
+    assertEqual(mouseOverGeometry.size(), base_mo_count + ::ControlLine::END);
     EditSubscriber::mouseOverGeometry.push_back(control_line->end.get());
 
     control_lines.push_back(std::move(control_line));
@@ -433,7 +495,7 @@ void ControlLineManager::addLine(Coord begin, Coord end,
 
 void ControlLineManager::autoSetLineType(int object_id)
 {
-    int line_id = (object_id - 1) / ::ControlLine::OBJ_COUNT;
+    int line_id = mouseOverIdToLineId(object_id);
     ::ControlLine& line = *control_lines[line_id];
 
     int dx = line.begin->center.x - line.end->center.x;
@@ -461,7 +523,8 @@ void ControlLineManager::autoSetLineType(int object_id)
     if (type != line.type) { // Need to update line type.
         line.type = type;
         line.icon = icon;
-        visibleGeometry[line_id * ::ControlLine::OBJ_COUNT + 1] =
+        visibleGeometry[line_id * ::ControlLine::OBJECT_COUNT
++ VISIBLE_OBJECT_COUNT + ::ControlLine::ICON] =
             line.icon.get();
     }
 }
@@ -469,7 +532,7 @@ void ControlLineManager::autoSetLineType(int object_id)
 void ControlLineManager::removeAll(void)
 {
     visibleGeometry.clear();
-    mouseOverGeometry.erase(mouseOverGeometry.begin() + 1,
+    mouseOverGeometry.erase(mouseOverGeometry.begin() + MO_OBJECT_COUNT,
                             mouseOverGeometry.end());
     control_lines.clear();
     prev_obj = -1;
@@ -485,14 +548,13 @@ void ControlLineManager::removeLine(size_t line_id)
     }
 
     visibleGeometry.erase(
-        visibleGeometry.begin() + ::ControlLine::OBJ_COUNT * line_id,
-        visibleGeometry.begin() + ::ControlLine::OBJ_COUNT * line_id
-        + ::ControlLine::OBJ_COUNT
+        visibleGeometry.begin() + ::ControlLine::OBJECT_COUNT * line_id + VISIBLE_OBJECT_COUNT,
+        visibleGeometry.begin() + ::ControlLine::OBJECT_COUNT * line_id + VISIBLE_OBJECT_COUNT
+        + ::ControlLine::OBJECT_COUNT
     );
     mouseOverGeometry.erase(
-        mouseOverGeometry.begin() + ::ControlLine::OBJ_COUNT * line_id + 1,
-        mouseOverGeometry.begin() + ::ControlLine::OBJ_COUNT * line_id
-        + ::ControlLine::OBJ_COUNT + 1
+        mouseOverGeometry.begin() + ::ControlLine::OBJECT_COUNT * line_id + MO_OBJECT_COUNT,
+        mouseOverGeometry.begin() + ::ControlLine::OBJECT_COUNT * line_id + MO_OBJECT_COUNT + ::ControlLine::OBJECT_COUNT
     );
     control_lines.erase(control_lines.begin() + line_id);
 

--- a/rtgui/controllines.cc
+++ b/rtgui/controllines.cc
@@ -104,6 +104,9 @@ bool ControlLineManager::button1Pressed(int modifierKey)
             action = Action::DRAGGING;
         }
     } else if (draw_mode && (modifierKey & GDK_CONTROL_MASK)) { // Add new line.
+        if (object < 0) {
+            return false;
+        }
         addLine(dataProvider->posImage, dataProvider->posImage);
         drawing_line = true;
         selected_object = mouseOverGeometry.size() - 1; // Select endpoint.
@@ -125,7 +128,7 @@ bool ControlLineManager::button1Released(void)
     callbacks->lineChanged();
     drawing_line = false;
     selected_object = -1;
-    return false;
+    return true;
 }
 
 bool ControlLineManager::button3Pressed(int modifierKey)
@@ -139,7 +142,7 @@ bool ControlLineManager::button3Pressed(int modifierKey)
     }
 
     action = Action::PICKING;
-    return false;
+    return true;
 }
 
 bool ControlLineManager::pick1(bool picked)
@@ -194,7 +197,7 @@ bool ControlLineManager::pick3(bool picked)
     removeLine((provider->getObject() - 1) / ::ControlLine::OBJ_COUNT);
     prev_obj = -1;
     selected_object = -1;
-    return false;
+    return true;
 }
 
 bool ControlLineManager::drag1(int modifierKey)
@@ -264,7 +267,7 @@ bool ControlLineManager::drag1(int modifierKey)
         autoSetLineType(selected_object);
     }
 
-    return false;
+    return true;
 }
 
 void ControlLineManager::releaseEdit(void)

--- a/rtgui/controllines.cc
+++ b/rtgui/controllines.cc
@@ -274,6 +274,9 @@ void ControlLineManager::releaseEdit(void)
     if (selected_object > 0) {
         mouseOverGeometry[selected_object]->state = Geometry::NORMAL;
     }
+    if (prev_obj > 0) {
+        visibleGeometry[prev_obj - 1]->state = Geometry::NORMAL;
+    }
 
     edited = true;
     callbacks->lineChanged();

--- a/rtgui/controllines.h
+++ b/rtgui/controllines.h
@@ -30,7 +30,14 @@ class Rectangle;
 class RTSurface;
 
 struct ControlLine {
-    static constexpr int OBJ_COUNT = 4;
+    enum ObjectIndex {
+        LINE,
+        ICON,
+        BEGIN,
+        END,
+        OBJECT_COUNT
+    };
+
     std::unique_ptr<Line> line;
     std::shared_ptr<OPIcon> icon;
     std::shared_ptr<OPIcon> icon_h, icon_v;

--- a/rtgui/controllines.h
+++ b/rtgui/controllines.h
@@ -87,6 +87,8 @@ public:
     ~ControlLineManager();
 
     bool getEdited(void) const;
+    /** Release anything that is currently being dragged. */
+    void releaseEdit(void);
     void removeAll(void);
     /** Sets whether or not the lines are visible and interact-able. */
     void setActive(bool active);

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -540,7 +540,7 @@ void CropWindow::buttonPress (int button, int type, int bstate, int x, int y)
                         action_y = 0;
                     }
 
-                } else if (iarea->getToolMode () == TMHand) {  // events outside of the image domain
+                } else if (iarea->getToolMode () == TMHand || iarea->getToolMode() == TMPerspective) {  // events outside of the image domain
                     EditSubscriber *editSubscriber = iarea->getCurrSubscriber();
 
                     if (editSubscriber && editSubscriber->getEditingType() == ET_OBJECTS) {

--- a/rtgui/gradient.cc
+++ b/rtgui/gradient.cc
@@ -12,6 +12,14 @@
 using namespace rtengine;
 using namespace rtengine::procparams;
 
+enum GeometryIndex {
+    H_LINE,
+    V_LINE,
+    FEATHER_LINE_1,
+    FEATHER_LINE_2,
+    CENTER_CIRCLE,
+};
+
 Gradient::Gradient () : FoldableToolPanel(this, "gradient", M("TP_GRADIENT_LABEL"), false, true), EditSubscriber(ET_OBJECTS), lastObject(-1), draggedPointOldAngle(-1000.)
 {
 
@@ -191,24 +199,24 @@ void Gradient::updateGeometry(const int centerX, const int centerY, const double
     };
 
     // update horizontal line
-    updateLine (visibleGeometry.at(0), 1500., 0., 180.);
-    updateLine (mouseOverGeometry.at(0), 1500., 0., 180.);
+    updateLine (visibleGeometry.at(H_LINE), 1500., 0., 180.);
+    updateLine (mouseOverGeometry.at(H_LINE), 1500., 0., 180.);
 
     // update vertical line
-    updateLine (visibleGeometry.at(1), 700., 90., 270.);
-    updateLine (mouseOverGeometry.at(1), 700., 90., 270.);
+    updateLine (visibleGeometry.at(V_LINE), 700., 90., 270.);
+    updateLine (mouseOverGeometry.at(V_LINE), 700., 90., 270.);
 
     // update upper feather line
-    updateLineWithDecay (visibleGeometry.at(2), 350., 270.);
-    updateLineWithDecay (mouseOverGeometry.at(2), 350., 270.);
+    updateLineWithDecay (visibleGeometry.at(FEATHER_LINE_1), 350., 270.);
+    updateLineWithDecay (mouseOverGeometry.at(FEATHER_LINE_1), 350., 270.);
 
     // update lower feather line
-    updateLineWithDecay (visibleGeometry.at(3), 350., 90.);
-    updateLineWithDecay (mouseOverGeometry.at(3), 350., 90.);
+    updateLineWithDecay (visibleGeometry.at(FEATHER_LINE_2), 350., 90.);
+    updateLineWithDecay (mouseOverGeometry.at(FEATHER_LINE_2), 350., 90.);
 
     // update circle's position
-    updateCircle (visibleGeometry.at(4));
-    updateCircle (mouseOverGeometry.at(4));
+    updateCircle (visibleGeometry.at(CENTER_CIRCLE));
+    updateCircle (mouseOverGeometry.at(CENTER_CIRCLE));
 }
 
 void Gradient::write (ProcParams* pp, ParamsEdited* pedited)
@@ -333,12 +341,12 @@ void Gradient::editToggled ()
 CursorShape Gradient::getCursor(int objectID, int xPos, int yPos) const
 {
     switch (objectID) {
-    case (0):
-    case (1):
+    case (H_LINE):
+    case (V_LINE):
         return CSMoveRotate;
 
-    case (2):
-    case (3): {
+    case (FEATHER_LINE_1):
+    case (FEATHER_LINE_2): {
         int angle = degree->getIntValue();
 
         if (angle < -135 || (angle >= -45 && angle <= 45) || angle > 135) {
@@ -348,7 +356,7 @@ CursorShape Gradient::getCursor(int objectID, int xPos, int yPos) const
         return CSMove1DH;
     }
 
-    case (4):
+    case (CENTER_CIRCLE):
         return CSMove2D;
 
     default:
@@ -362,18 +370,18 @@ bool Gradient::mouseOver(int modifierKey)
 
     if (editProvider && editProvider->getObject() != lastObject) {
         if (lastObject > -1) {
-            if (lastObject == 2 || lastObject == 3) {
-                EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
-                EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
+            if (lastObject == FEATHER_LINE_1 || lastObject == FEATHER_LINE_2) {
+                EditSubscriber::visibleGeometry.at(FEATHER_LINE_1)->state = Geometry::NORMAL;
+                EditSubscriber::visibleGeometry.at(FEATHER_LINE_2)->state = Geometry::NORMAL;
             } else {
                 EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
             }
         }
 
         if (editProvider->getObject() > -1) {
-            if (editProvider->getObject() == 2 || editProvider->getObject() == 3) {
-                EditSubscriber::visibleGeometry.at(2)->state = Geometry::PRELIGHT;
-                EditSubscriber::visibleGeometry.at(3)->state = Geometry::PRELIGHT;
+            if (editProvider->getObject() == FEATHER_LINE_1 || editProvider->getObject() == FEATHER_LINE_2) {
+                EditSubscriber::visibleGeometry.at(FEATHER_LINE_1)->state = Geometry::PRELIGHT;
+                EditSubscriber::visibleGeometry.at(FEATHER_LINE_2)->state = Geometry::PRELIGHT;
             } else {
                 EditSubscriber::visibleGeometry.at(editProvider->getObject())->state = Geometry::PRELIGHT;
             }
@@ -415,7 +423,7 @@ bool Gradient::button1Pressed(int modifierKey)
         //printf("\ndraggedPointOldAngle=%.3f\n\n", draggedPointOldAngle);
         draggedPointAdjusterAngle = degree->getValue();
 
-        if (lastObject == 2 || lastObject == 3) {
+        if (lastObject == FEATHER_LINE_1 || lastObject == FEATHER_LINE_2) {
             // Dragging a line to change the angle
             PolarCoord draggedPoint;
             rtengine::Coord currPos;
@@ -431,7 +439,7 @@ bool Gradient::button1Pressed(int modifierKey)
             // compute the projected value of the dragged point
             draggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*rtengine::RT_PI);
 
-            if (lastObject == 3) {
+            if (lastObject == FEATHER_LINE_2) {
                 draggedFeatherOffset = -draggedFeatherOffset;
             }
 
@@ -442,9 +450,9 @@ bool Gradient::button1Pressed(int modifierKey)
         return false;
     } else { // should theoretically always be true
         // this will let this class ignore further drag events
-        if (lastObject == 2 || lastObject == 3) {
-            EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
-            EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
+        if (lastObject == FEATHER_LINE_1 || lastObject == FEATHER_LINE_2) {
+            EditSubscriber::visibleGeometry.at(FEATHER_LINE_1)->state = Geometry::NORMAL;
+            EditSubscriber::visibleGeometry.at(FEATHER_LINE_2)->state = Geometry::NORMAL;
         } else {
             EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
         }
@@ -472,7 +480,7 @@ bool Gradient::drag1(int modifierKey)
     double halfSizeW = imW / 2.;
     double halfSizeH = imH / 2.;
 
-    if (lastObject == 0 || lastObject == 1) {
+    if (lastObject == H_LINE || lastObject == V_LINE) {
 
         // Dragging a line to change the angle
         PolarCoord draggedPoint;
@@ -516,7 +524,7 @@ bool Gradient::drag1(int modifierKey)
 
             return true;
         }
-    } else if (lastObject == 2 || lastObject == 3) {
+    } else if (lastObject == FEATHER_LINE_1 || lastObject == FEATHER_LINE_2) {
         // Dragging the upper or lower feather bar
         PolarCoord draggedPoint;
         rtengine::Coord currPos;
@@ -533,11 +541,11 @@ bool Gradient::drag1(int modifierKey)
         draggedPoint = currPos - centerPos;
         double currDraggedFeatherOffset = draggedPoint.radius * sin((draggedPoint.angle - degree->getValue()) / 180.*rtengine::RT_PI);
 
-        if (lastObject == 2)
+        if (lastObject == FEATHER_LINE_1)
             // Dragging the upper feather bar
         {
             currDraggedFeatherOffset -= draggedFeatherOffset;
-        } else if (lastObject == 3)
+        } else if (lastObject == FEATHER_LINE_2)
             // Dragging the lower feather bar
         {
             currDraggedFeatherOffset = -currDraggedFeatherOffset + draggedFeatherOffset;
@@ -555,7 +563,7 @@ bool Gradient::drag1(int modifierKey)
 
             return true;
         }
-    } else if (lastObject == 4) {
+    } else if (lastObject == CENTER_CIRCLE) {
         // Dragging the circle to change the center
         rtengine::Coord currPos;
         draggedCenter += provider->deltaPrevImage;
@@ -583,9 +591,9 @@ bool Gradient::drag1(int modifierKey)
 void Gradient::releaseEdit()
 {
     if (lastObject >= 0) {
-        if (lastObject == 2 || lastObject == 3) {
-            EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
-            EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
+        if (lastObject == FEATHER_LINE_1 || lastObject == FEATHER_LINE_2) {
+            EditSubscriber::visibleGeometry.at(FEATHER_LINE_1)->state = Geometry::NORMAL;
+            EditSubscriber::visibleGeometry.at(FEATHER_LINE_2)->state = Geometry::NORMAL;
         } else {
             EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
         }

--- a/rtgui/gradient.cc
+++ b/rtgui/gradient.cc
@@ -325,6 +325,7 @@ void Gradient::editToggled ()
     if (edit->get_active()) {
         subscribe();
     } else {
+        releaseEdit();
         unsubscribe();
     }
 }
@@ -577,6 +578,19 @@ bool Gradient::drag1(int modifierKey)
     }
 
     return false;
+}
+
+void Gradient::releaseEdit()
+{
+    if (lastObject >= 0) {
+        if (lastObject == 2 || lastObject == 3) {
+            EditSubscriber::visibleGeometry.at(2)->state = Geometry::NORMAL;
+            EditSubscriber::visibleGeometry.at(3)->state = Geometry::NORMAL;
+        } else {
+            EditSubscriber::visibleGeometry.at(lastObject)->state = Geometry::NORMAL;
+        }
+    }
+    action = Action::NONE;
 }
 
 void Gradient::switchOffEditMode ()

--- a/rtgui/gradient.h
+++ b/rtgui/gradient.h
@@ -35,6 +35,7 @@ protected:
     sigc::connection editConn;
 
     void editToggled ();
+    void releaseEdit();
 
 public:
 

--- a/rtgui/perspective.cc
+++ b/rtgui/perspective.cc
@@ -778,6 +778,7 @@ void PerspCorrection::linesEditButtonPressed(void)
             listener->unsetTweakOperator(this);
             listener->refreshPreview(EvPerspRender);
         }
+        lines->releaseEdit();
         lines->setDrawMode(false);
         lines->setActive(false);
         if (panel_listener) {

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -185,6 +185,25 @@ void Spot::resetPressed()
     }
 }
 
+/**
+ * Release anything that's currently being dragged.
+ */
+void Spot::releaseEdit()
+{
+    Geometry *loGeom = getVisibleGeometryFromMO (lastObject);
+
+    if (!loGeom) {
+        EditSubscriber::action = EditSubscriber::Action::NONE;
+        return;
+    }
+
+    loGeom->state = Geometry::ACTIVE;
+    sourceIcon.state = Geometry::ACTIVE;
+    EditSubscriber::action = EditSubscriber::Action::NONE;
+    draggedSide = DraggedSide::NONE;
+    updateGeometry();
+}
+
 void Spot::setBatchMode (bool batchMode)
 {
     ToolPanel::setBatchMode (batchMode);
@@ -237,6 +256,7 @@ void Spot::editToggled ()
             listener->refreshPreview(EvSpotEnabledOPA); // reprocess the preview w/o creating History entry
             subscribe();
         } else {
+            releaseEdit();
             unsubscribe();
             listener->unsetTweakOperator(this);
             listener->refreshPreview(EvSpotEnabled); // reprocess the preview w/o creating History entry

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -208,14 +208,14 @@ void Spot::releaseEdit()
 {
     Geometry *loGeom = getVisibleGeometryFromMO (lastObject);
 
+    EditSubscriber::action = EditSubscriber::Action::NONE;
+
     if (!loGeom) {
-        EditSubscriber::action = EditSubscriber::Action::NONE;
         return;
     }
 
     loGeom->state = Geometry::NORMAL;
     sourceIcon.state = Geometry::NORMAL;
-    EditSubscriber::action = EditSubscriber::Action::NONE;
     draggedSide = DraggedSide::NONE;
     updateGeometry();
 }
@@ -686,8 +686,6 @@ bool Spot::button3Released()
     updateGeometry();
     EditSubscriber::action = EditSubscriber::Action::NONE;
     return true;
-
-    return false;
 }
 
 bool Spot::drag1 (int modifierKey)

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -567,6 +567,12 @@ bool Spot::button1Pressed (int modifierKey)
 
     if (editProvider) {
         if (lastObject == -1 && (modifierKey & GDK_CONTROL_MASK)) {
+            int imW, imH;
+            const auto startPos = editProvider->posImage;
+            editProvider->getImageSize(imW, imH);
+            if (startPos.x < 0 || startPos.y < 0 || startPos.x > imW || startPos.y > imH) {
+                return false; // Outside of image area.
+            }
             draggedSide = DraggedSide::SOURCE;
             addNewEntry();
             EditSubscriber::action = EditSubscriber::Action::DRAGGING;

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -172,6 +172,7 @@ void Spot::resetPressed()
         }
     } else {
         if (!spots.empty()) {
+            EditSubscriber::action = EditSubscriber::Action::NONE;
             spots.clear();
             activeSpot = -1;
             lastObject = -1;
@@ -657,6 +658,10 @@ bool Spot::button3Released()
 
 bool Spot::drag1 (int modifierKey)
 {
+    if (EditSubscriber::action != EditSubscriber::Action::DRAGGING) {
+        return false;
+    }
+
     EditDataProvider *editProvider = getEditProvider();
     int imW, imH;
     editProvider->getImageSize (imW, imH);
@@ -738,6 +743,10 @@ bool Spot::drag1 (int modifierKey)
 
 bool Spot::drag3 (int modifierKey)
 {
+    if (EditSubscriber::action != EditSubscriber::Action::DRAGGING) {
+        return false;
+    }
+
     EditDataProvider *editProvider = getEditProvider();
     int imW, imH;
     editProvider->getImageSize (imW, imH);

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -198,8 +198,8 @@ void Spot::releaseEdit()
         return;
     }
 
-    loGeom->state = Geometry::ACTIVE;
-    sourceIcon.state = Geometry::ACTIVE;
+    loGeom->state = Geometry::NORMAL;
+    sourceIcon.state = Geometry::NORMAL;
     EditSubscriber::action = EditSubscriber::Action::NONE;
     draggedSide = DraggedSide::NONE;
     updateGeometry();

--- a/rtgui/spot.h
+++ b/rtgui/spot.h
@@ -82,6 +82,7 @@ private:
     void addNewEntry ();
     void deleteSelectedEntry ();
     void resetPressed ();
+    void releaseEdit();
 
 protected:
     Gtk::Box* labelBox;


### PR DESCRIPTION
Fixes some problems with displaying on-preview editing widgets after the enter/return key is pressed while adjusting or hovering over the widgets (#6244). Still don't now how to fix the problem with dragging a spot removal spot.