### PR TITLE
More preview widget fixes

### DIFF
--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -794,6 +794,13 @@ void CropWindow::buttonRelease (int button, int num, int bstate, int x, int y)
         iarea->setToolHand ();
     }
 
+    if (state != SEditDrag1 && state != SEditDrag2 && state != SEditDrag3) {
+        iarea->deltaImage.set(0, 0);
+        iarea->deltaScreen.set(0, 0);
+        iarea->deltaPrevImage.set(0, 0);
+        iarea->deltaPrevScreen.set(0, 0);
+    }
+
     if (cropgl && (state == SCropSelecting || state == SResizeH1 || state == SResizeH2 || state == SResizeW1 || state == SResizeW2 || state == SResizeTL || state == SResizeTR || state == SResizeBL || state == SResizeBR || state == SCropMove)) {
         cropgl->cropManipReady ();
         iarea->setToolHand ();

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -667,6 +667,7 @@ bool Spot::button3Pressed (int modifierKey)
         return true;
     } else if (! (modifierKey & (GDK_SHIFT_MASK | GDK_SHIFT_MASK))) {
         EditSubscriber::action = EditSubscriber::Action::PICKING;
+        return true;
     }
 
     return false;

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -428,6 +428,11 @@ void Spot::updateGeometry()
             sourceCircle.setVisible(draggedSide != DraggedSide::SOURCE);
             targetCircle.setVisible(draggedSide != DraggedSide::TARGET);
         } else {
+            targetCircle.state = Geometry::NORMAL;
+            sourceCircle.state = Geometry::NORMAL;
+            targetFeatherCircle.state = Geometry::NORMAL;
+            sourceFeatherCircle.state = Geometry::NORMAL;
+
             targetCircle.setActive (false);
             targetMODisc.setActive (false);
             sourceIcon.setActive (false);


### PR DESCRIPTION
Fixes:
- Dragging a spot removal spot causes a sudden jump in position if the user previously right-clicked while dragging another spot.
- Spot removal widgets remain highlighted after deletion.