### PR TITLE
Resize tool values not computed when profile is loaded

### DIFF
--- a/rtengine/jdatasrc.cc
+++ b/rtengine/jdatasrc.cc
@@ -4,13 +4,6 @@
 #include "jpeg.h"
 
 /*
- * HA 2021-03-12
- * Modification according to
- * https://github.com/Beep6581/RawTherapee/commit/be67261d0bdeb21ffe15fe968dd5bc16edd407e0
- * because otherwise it won't compile.
- */
-  
-/*
  * jdatasrc.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
@@ -32,11 +25,6 @@
 
 #define JFREAD(file,buf,sizeofbuf)  \
   ((size_t) fread((void *) (buf), (size_t) 1, (size_t) (sizeofbuf), (file)))
-#define JFWRITE(file,buf,sizeofbuf)  \
-  ((size_t) fwrite((const void *) (buf), (size_t) 1, (size_t) (sizeofbuf), (file)))
-
-
-
 
 /* Expanded data source object for stdio input */
 namespace
@@ -260,11 +248,6 @@ my_error_exit (j_common_ptr cinfo)
 }
 
 
-//const char * const jpeg_std_message_table[] = {
-//#include "jerror.h"
-//  NULL
-//};
-
 #ifdef WIN32
 #define JVERSION	"6b  27-Mar-1998"
 #define JCOPYRIGHT_SHORT	"(C) 1998, Thomas G. Lane"
@@ -277,7 +260,6 @@ const char * const jpeg_std_message_table[] = {
 #else
 extern const char * const jpeg_std_message_table[];
 #endif
-
 
 /*
  * Actual output of an error or trace message.
@@ -397,9 +379,9 @@ format_message (j_common_ptr cinfo, char * buffer)
 
     /* Format the message into the passed buffer */
     if (isstring) {
-        sprintf(buffer, msgtext, err->msg_parm.s);
+        snprintf(buffer, JMSG_LENGTH_MAX, msgtext, err->msg_parm.s);
     } else
-        sprintf(buffer, msgtext,
+        snprintf(buffer, JMSG_LENGTH_MAX, msgtext,
                 err->msg_parm.i[0], err->msg_parm.i[1],
                 err->msg_parm.i[2], err->msg_parm.i[3],
                 err->msg_parm.i[4], err->msg_parm.i[5],

--- a/rtengine/jdatasrc.cc
+++ b/rtengine/jdatasrc.cc
@@ -4,6 +4,13 @@
 #include "jpeg.h"
 
 /*
+ * HA 2021-03-12
+ * Modification according to
+ * https://github.com/Beep6581/RawTherapee/commit/be67261d0bdeb21ffe15fe968dd5bc16edd407e0
+ * because otherwise it won't compile.
+ */
+  
+/*
  * jdatasrc.c
  *
  * Copyright (C) 1994-1996, Thomas G. Lane.
@@ -257,7 +264,19 @@ my_error_exit (j_common_ptr cinfo)
 //#include "jerror.h"
 //  NULL
 //};
+
+#ifdef WIN32
+#define JVERSION	"6b  27-Mar-1998"
+#define JCOPYRIGHT_SHORT	"(C) 1998, Thomas G. Lane"
+#define JMESSAGE(code,string)	string ,
+
+const char * const jpeg_std_message_table[] = {
+#include "jerror.h"
+  NULL
+};
+#else
 extern const char * const jpeg_std_message_table[];
+#endif
 
 
 /*

--- a/rtgui/resize.cc
+++ b/rtgui/resize.cc
@@ -190,6 +190,8 @@ void Resize::read (const ProcParams* pp, const ParamsEdited* pedited)
         set_inconsistent (multiImage && !pedited->resize.enabled);
     }
 
+    setDimensions(); // fixes the issue that values in GUI are not recomputed when loading profile
+    
     scale->block(false);
     sconn.block (false);
     wconn.block (false);


### PR DESCRIPTION
Hope this is better... Original text:

This is a small change I propose to address the minor issue already mentioned in [https://github.com/Beep6581/RawTherapee/issues/5182#issuecomment-821986311](url) (last paragraph).

To reproduce the issue:

- Open a picture.
- Enable Crop and crop to some unusual aspect ratio.
- Enable Resize, select "Width" and set width to a reasonable value.
- Do Partial Profile Save with only selecting Resize.
- Open another picture.
- Load the partial profile you just saved.
- => Both width and height are set to the values from the loaded partial profile. Height is not recomputed to fit the dimensions of the new picture, as it would be if the same value for width were entered manually.

The proposed change (one line in resize.cc) seems to fix this