### PR TITLE
make spot removal tool bigger

### DIFF
--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -366,7 +366,7 @@ namespace procparams
 {
 
 const short SpotParams::minRadius = 5;
-const short SpotParams::maxRadius = 100;
+const short SpotParams::maxRadius = 400;
 
 
 ToneCurveParams::ToneCurveParams() :


### PR DESCRIPTION
this change makes the spot removal tool bigger (changes the maximal radius of the spot) so it can be used for very large photos and to remove larger spots.