### PR TITLE
Mac: Set RgbDenoiseThreadLimit = 2 to avoid crash

### DIFF
--- a/rtdata/options/options.osx
+++ b/rtdata/options/options.osx
@@ -42,3 +42,7 @@ CustomProfileBuilder=
 # Set the included font as default
 FontFamily=Droid Sans Mono Slashed
 CPFontFamily=Droid Sans Mono Slashed
+
+[Performance]
+# Set rgbDenoiseThreadLimit = 2 to avoid crash
+RgbDenoiseThreadLimit = 2


### PR DESCRIPTION
Changes the options keyfile for mac to avoid a crash.
https://discuss.pixls.us/t/rawtherapee-dev-apple-m1-test/26596/41