### PR TITLE
Strict temporary image file permissions

### DIFF
--- a/rtengine/winutils.h
+++ b/rtengine/winutils.h
@@ -1,0 +1,124 @@
+/*
+ *  This file is part of RawTherapee.
+ *
+ *  Copyright (c) 2021 Lawrence Lee
+ *
+ *  RawTherapee is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RawTherapee is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#ifdef WIN32
+
+#include <aclapi.h>
+#include <windows.h>
+
+#include "noncopyable.h"
+
+
+/**
+ * Wrapper for pointers to memory allocated by HeapAlloc.
+ *
+ * Memory is automatically freed when the object goes out of scope.
+ */
+template <typename T>
+class WinHeapPtr : public rtengine::NonCopyable
+{
+private:
+    const T ptr;
+
+public:
+    WinHeapPtr() = delete;
+
+    /** Allocates the specified number of bytes in the process heap. */
+    explicit WinHeapPtr(SIZE_T bytes): ptr(static_cast<T>(HeapAlloc(GetProcessHeap(), 0, bytes))) {};
+
+    ~WinHeapPtr()
+    {
+        // HeapFree does a null check.
+        HeapFree(GetProcessHeap(), 0, static_cast<LPVOID>(ptr));
+    }
+
+    T operator ->() const
+    {
+        return ptr;
+    }
+
+    operator T() const
+    {
+        return ptr;
+    }
+};
+
+/**
+ * Wrapper for HLOCAL pointers to memory allocated by LocalAlloc.
+ *
+ * Memory is automatically freed when the object goes out of scope.
+ */
+template <typename T>
+class WinLocalPtr : public rtengine::NonCopyable
+{
+private:
+    const T ptr;
+
+public:
+    WinLocalPtr() = delete;
+
+    /** Wraps a raw pointer. */
+    WinLocalPtr(T pointer): ptr(pointer) {};
+
+    ~WinLocalPtr()
+    {
+        // LocalFree does a null check.
+        LocalFree(static_cast<HLOCAL>(ptr));
+    }
+
+    T operator ->() const
+    {
+        return ptr;
+    }
+
+    operator T() const
+    {
+        return ptr;
+    }
+};
+
+/**
+ * Wrapper for HANDLEs.
+ *
+ * Handles are automatically closed when the object goes out of scope.
+ */
+class WinHandle : public rtengine::NonCopyable
+{
+private:
+    const HANDLE handle;
+
+public:
+    WinHandle() = delete;
+
+    /** Wraps a HANDLE. */
+    WinHandle(HANDLE handle): handle(handle) {};
+
+    ~WinHandle()
+    {
+        CloseHandle(handle);
+    }
+
+    operator HANDLE() const
+    {
+        return handle;
+    }
+};
+
+#endif

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -2200,6 +2200,8 @@ bool EditorPanel::idle_sentToGimp (ProgressConnector<int> *pc, rtengine::IImagef
         parent->setProgress (0.);
         bool success = false;
 
+        setUserOnlyPermission(Gio::File::create_for_path(filename), false);
+
         if (options.editorToSendTo == 1) {
             success = ExtProgStore::openInGimp (filename);
         } else if (options.editorToSendTo == 2) {

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -136,7 +136,7 @@ bool find_default_monitor_profile (GdkWindow *rootwin, Glib::ustring &defprof, G
 
 bool hasUserOnlyPermission(const Glib::ustring &dirname)
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
     const Glib::RefPtr<Gio::File> file = Gio::File::create_for_path(dirname);
     const Glib::RefPtr<Gio::FileInfo> file_info = file->query_info("owner::user,unix::mode");
 
@@ -159,7 +159,7 @@ bool hasUserOnlyPermission(const Glib::ustring &dirname)
  */
 void setUserOnlyPermission(const Glib::RefPtr<Gio::File> file, bool execute)
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
     const Glib::RefPtr<Gio::FileInfo> file_info = file->query_info("unix::mode");
     if (!file_info) {
         return;
@@ -179,7 +179,7 @@ void setUserOnlyPermission(const Glib::RefPtr<Gio::File> file, bool execute)
  */
 Glib::ustring getTmpDirectory()
 {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
     const int MAX_ATTEMPT = 100;
     int attempt;
     const Glib::ustring tmp_dir_root = Glib::get_tmp_dir();


### PR DESCRIPTION
This attempts to write temporary image files (the ones created when using send to external editor) in a private temporary directory and also sets the file itself to have read/write permissions for the user only. It is only implemented for Linux at the moment, but could be done for MacOS too if necessary.