### PR TITLE
Add default spot size control

### DIFF
--- a/rtdata/languages/Francais
+++ b/rtdata/languages/Francais
@@ -2752,6 +2752,7 @@ TP_SPOT_COUNTLABEL;%1 point(s)
 TP_SPOT_ENTRYCHANGED;Modification d'un point
 TP_SPOT_HINT;Cliquez sur ce bouton pour pouvoir opérer sur la zone de prévisualisation.\n\nPour ajouter un spot, pressez Ctrl et le bouton gauche de la souris, tirez le cercle (la touche Ctrl peut être relâchée) vers la position source, puis relâchez le bouton de la souris.\n\nPour éditer un spot, placez le curseur au-dessus de la marque blanche situant une zone éditée, faisant apparaître la géométrie d'édition.\n\nPour déplacer le spot source ou destination, placez le curseur en son centre et tirez le.\n\nLe cercle intérieur (zone d'effet maximum) et le cercle "d'adoucicement" peuvent être redimmensionné en plaçant le curseur dessus (le cercle devient orange) et en le tirant (le cercle devient rouge).\n\nQuand les changements sont terminés, un clic droit en dehors de tout spot termine le mode d'édition, ou cliquez à nouveau sur ce bouton.
 TP_SPOT_LABEL;Retrait de taches
+TP_SPOT_DEFAULT_SIZE;Taille par défault des points
 TP_TM_FATTAL_AMOUNT;Quantité
 TP_TM_FATTAL_ANCHOR;Ancre
 TP_TM_FATTAL_LABEL;Compression de Plage Dynamique

--- a/rtdata/languages/Francais
+++ b/rtdata/languages/Francais
@@ -2749,10 +2749,10 @@ TP_SHARPENMICRO_UNIFORMITY;Uniformité
 TP_SOFTLIGHT_LABEL;Lumière douce
 TP_SOFTLIGHT_STRENGTH;Force
 TP_SPOT_COUNTLABEL;%1 point(s)
+TP_SPOT_DEFAULT_SIZE;Taille par défault des points
 TP_SPOT_ENTRYCHANGED;Modification d'un point
 TP_SPOT_HINT;Cliquez sur ce bouton pour pouvoir opérer sur la zone de prévisualisation.\n\nPour ajouter un spot, pressez Ctrl et le bouton gauche de la souris, tirez le cercle (la touche Ctrl peut être relâchée) vers la position source, puis relâchez le bouton de la souris.\n\nPour éditer un spot, placez le curseur au-dessus de la marque blanche situant une zone éditée, faisant apparaître la géométrie d'édition.\n\nPour déplacer le spot source ou destination, placez le curseur en son centre et tirez le.\n\nLe cercle intérieur (zone d'effet maximum) et le cercle "d'adoucicement" peuvent être redimmensionné en plaçant le curseur dessus (le cercle devient orange) et en le tirant (le cercle devient rouge).\n\nQuand les changements sont terminés, un clic droit en dehors de tout spot termine le mode d'édition, ou cliquez à nouveau sur ce bouton.
 TP_SPOT_LABEL;Retrait de taches
-TP_SPOT_DEFAULT_SIZE;Taille par défault des points
 TP_TM_FATTAL_AMOUNT;Quantité
 TP_TM_FATTAL_ANCHOR;Ancre
 TP_TM_FATTAL_LABEL;Compression de Plage Dynamique

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -3616,6 +3616,7 @@ TP_SHARPENMICRO_UNIFORMITY;Uniformity
 TP_SOFTLIGHT_LABEL;Soft Light
 TP_SOFTLIGHT_STRENGTH;Strength
 TP_SPOT_COUNTLABEL;%1 point(s)
+TP_SPOT_DEFAULT_SIZE;Default point size
 TP_SPOT_ENTRYCHANGED;Point changed
 TP_SPOT_HINT;Click on this button to be able to operate on the preview area.\n\nTo edit a spot, hover the white mark locating an edited area, making the editing geometry appear.\n\nTo add a spot, press Ctrl and left mouse button, drag the circle (Ctrl key can be released) to a source location, then release the mouse button.\n\nTo move the source or destination spot, hover its center then drag it.\n\nThe inner circle (maximum effect area) and the "feather" circle can be resized by hovering them (the circle becomes orange) and dragging it (the circle becomes red).\n\nWhen the changes are done, right click outside any spot to end the Spot editing mode, or click on this button again.
 TP_SPOT_LABEL;Spot Removal

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -74,8 +74,7 @@ Spot::Spot() :
     reset->set_border_width (0);
     reset->signal_clicked().connect ( sigc::mem_fun (*this, &Spot::resetPressed) );
 
-    spotSize = Gtk::manage(new Adjuster(M("TP_SPOT_DEFAULT_SIZE"), 5, 50, 1, 25));
-    spotSize->setAdjusterListener (this);
+    spotSize = Gtk::manage(new Adjuster(M("TP_SPOT_DEFAULT_SIZE"), SpotParams::minRadius, SpotParams::maxRadius, 1, 25));
 
     labelBox = Gtk::manage (new Gtk::Box());
     labelBox->set_spacing (2);
@@ -122,7 +121,6 @@ Spot::Spot() :
     EvSpotEnabledOPA = m->newEvent(SPOTADJUST, "TP_SPOT_LABEL");
     EvSpotEntry = m->newEvent(SPOTADJUST, "HISTORY_MSG_SPOT_ENTRY");
     EvSpotEntryOPA = m->newEvent(SPOTADJUST, "HISTORY_MSG_SPOT_ENTRY");
-    EvspotSize = m->newEvent(SPOTADJUST, "TP_SPOT_DEFAULT_SIZE");
 
     show_all();
 }
@@ -862,10 +860,6 @@ void Spot::switchOffEditMode ()
     listener->refreshPreview(EvSpotEnabled); // reprocess the preview w/o creating History entry
 }
 
-void Spot::adjusterChanged(Adjuster* a, double newval)
-{
-
-}
 
 void Spot::tweakParams(procparams::ProcParams& pparams)
 {

--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -74,7 +74,7 @@ Spot::Spot() :
     reset->set_border_width (0);
     reset->signal_clicked().connect ( sigc::mem_fun (*this, &Spot::resetPressed) );
 
-    spotSize = Gtk::manage(new Adjuster(M("Default spot size"), 5, 50, 1, 25));
+    spotSize = Gtk::manage(new Adjuster(M("TP_SPOT_DEFAULT_SIZE"), 5, 50, 1, 25));
     spotSize->setAdjusterListener (this);
 
     labelBox = Gtk::manage (new Gtk::Box());
@@ -122,7 +122,7 @@ Spot::Spot() :
     EvSpotEnabledOPA = m->newEvent(SPOTADJUST, "TP_SPOT_LABEL");
     EvSpotEntry = m->newEvent(SPOTADJUST, "HISTORY_MSG_SPOT_ENTRY");
     EvSpotEntryOPA = m->newEvent(SPOTADJUST, "HISTORY_MSG_SPOT_ENTRY");
-    EvspotSize = m->newEvent(SPOTADJUST, "Default spot size");
+    EvspotSize = m->newEvent(SPOTADJUST, "TP_SPOT_DEFAULT_SIZE");
 
     show_all();
 }
@@ -178,7 +178,6 @@ void Spot::write (ProcParams* pp, ParamsEdited* pedited)
     if (pedited) {
         pedited->spot.enabled = !get_inconsistent();
         pedited->spot.entries = editedCheckBox->get_active();
-        //pedited->spot.strength = spotSize->getEditedState ()
     }
 }
 
@@ -865,12 +864,7 @@ void Spot::switchOffEditMode ()
 
 void Spot::adjusterChanged(Adjuster* a, double newval)
 {
-    if (listener && getEnabled()) {
 
-        if (a == spotSize) {
-            listener->panelChanged (EvspotSize, spotSize->getTextValue());
-        }
-    }
 }
 
 void Spot::tweakParams(procparams::ProcParams& pparams)

--- a/rtgui/spot.h
+++ b/rtgui/spot.h
@@ -54,7 +54,7 @@
  * (the point will be deleted on button release).
  */
 
-class Spot : public ToolParamBlock, public FoldableToolPanel, public AdjusterListener, public rtengine::TweakOperator, public EditSubscriber
+class Spot : public ToolParamBlock, public FoldableToolPanel, public rtengine::TweakOperator, public EditSubscriber
 {
 
 private:
@@ -112,8 +112,6 @@ public:
 
     void setBatchMode (bool batchMode) override;
 
-    void adjusterChanged(Adjuster* a, double newval) override;
-
     // EditSubscriber interface
     CursorShape getCursor (int objectID, int xPos, int yPos) const override;
     bool mouseOver (int modifierKey) override;
@@ -135,7 +133,6 @@ public:
     rtengine::ProcEvent EvSpotEnabledOPA; // used to toggle-on the Spot 'On Preview Adjustment' mode
     rtengine::ProcEvent EvSpotEntry;
     rtengine::ProcEvent EvSpotEntryOPA;
-    rtengine::ProcEvent EvspotSize;
 };
 
 #endif

--- a/rtgui/spot.h
+++ b/rtgui/spot.h
@@ -23,6 +23,7 @@
 #include <gtkmm.h>
 #include "toolpanel.h"
 #include "editwidgets.h"
+#include "adjuster.h"
 #include "../rtengine/procparams.h"
 #include "../rtengine/tweakoperator.h"
 
@@ -53,7 +54,7 @@
  * (the point will be deleted on button release).
  */
 
-class Spot : public ToolParamBlock, public FoldableToolPanel, public rtengine::TweakOperator, public EditSubscriber
+class Spot : public ToolParamBlock, public FoldableToolPanel, public AdjusterListener, public rtengine::TweakOperator, public EditSubscriber
 {
 
 private:
@@ -90,6 +91,7 @@ protected:
     Gtk::Label* countLabel;
     Gtk::ToggleButton* edit;
     Gtk::Button* reset;
+    Adjuster* spotSize;
     sigc::connection editConn, editedConn;
 
     void editToggled ();
@@ -109,6 +111,8 @@ public:
     void setEditProvider (EditDataProvider* provider) override;
 
     void setBatchMode (bool batchMode) override;
+
+    void adjusterChanged(Adjuster* a, double newval) override;
 
     // EditSubscriber interface
     CursorShape getCursor (int objectID, int xPos, int yPos) const override;
@@ -131,6 +135,7 @@ public:
     rtengine::ProcEvent EvSpotEnabledOPA; // used to toggle-on the Spot 'On Preview Adjustment' mode
     rtengine::ProcEvent EvSpotEntry;
     rtengine::ProcEvent EvSpotEntryOPA;
+    rtengine::ProcEvent EvspotSize;
 };
 
 #endif


### PR DESCRIPTION
This adds a control for the default size of spot in the spot removal tool. When I remove dust from negative the default size is too large and changing it for every spot quickly gets old.

I'm not sure if I really need the empty `adjusterChanged` method but I didn't manage to compile without. 

![spot_size](https://user-images.githubusercontent.com/5859344/135453636-86513a81-84e3-4e05-b0d2-b9acc8b80df8.JPG)
