### PR TITLE
Allow really tiny spots for removal

### DIFF
--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -365,7 +365,7 @@ namespace rtengine
 namespace procparams
 {
 
-const short SpotParams::minRadius = 5;
+const short SpotParams::minRadius = 1;
 const short SpotParams::maxRadius = 400;
 
 


### PR DESCRIPTION
I may be a very picky person, but I want to repair really tiny specks of dust on my negative scans.
I tried setting the SpotParams::minRadius to 1 and this seems to work fine. I can zoom in in the
UI and still manipulate things with point and click. I guess 1 is a natural lower boundary for the
radius that should be explored;-)