### PR TITLE
Film Simulation ComboBox for long HaldCLUT names

### DIFF
--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -64,9 +64,6 @@ FilmSimulation::FilmSimulation()
     :   FoldableToolPanel( this, "filmsimulation", M("TP_FILMSIMULATION_LABEL"), false, true )
 {
     m_clutComboBox = Gtk::manage( new ClutComboBox(options.clutsDir) );
-	// The following line, inspired by https://stackoverflow.com/questions/43414163/gtk-mm-limit-width-of-combobox,
-	// makes the Film Simulation ComboBox look better if there are HaldCLUT names that are too long to fit into it
-	((Gtk::CellRendererText*)m_clutComboBox->get_first_cell())->property_ellipsize() = Pango::ELLIPSIZE_END;
 
     int foundClutsCount = m_clutComboBox->foundClutsCount();
 
@@ -222,7 +219,13 @@ ClutComboBox::ClutComboBox(const Glib::ustring &path):
     set_model(m_model());
 
     if (cm->count > 0) {
-        pack_start(m_columns().label, false);
+		// Pack a CellRendererText in order to display long Clut file names properly
+		Gtk::CellRendererText *renderer;
+
+		renderer = new Gtk::CellRendererText;
+		renderer->property_ellipsize() = Pango::ELLIPSIZE_END;
+		pack_start(*renderer, false); 
+		add_attribute(*renderer, "text", 0);
     }
 
     if (!options.multiDisplayMode) {

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -64,6 +64,10 @@ FilmSimulation::FilmSimulation()
     :   FoldableToolPanel( this, "filmsimulation", M("TP_FILMSIMULATION_LABEL"), false, true )
 {
     m_clutComboBox = Gtk::manage( new ClutComboBox(options.clutsDir) );
+	// The following line, inspired by https://stackoverflow.com/questions/43414163/gtk-mm-limit-width-of-combobox,
+	// makes the Film Simulation ComboBox look better if there are HaldCLUT names that are too long to fit into it
+	((Gtk::CellRendererText*)m_clutComboBox->get_first_cell())->property_ellipsize() = Pango::ELLIPSIZE_END;
+
     int foundClutsCount = m_clutComboBox->foundClutsCount();
 
     if ( foundClutsCount == 0 ) {

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -220,9 +220,7 @@ ClutComboBox::ClutComboBox(const Glib::ustring &path):
 
     if (cm->count > 0) {
 		// Pack a CellRendererText in order to display long Clut file names properly
-		Gtk::CellRendererText *renderer;
-
-		renderer = Gtk::manage(new Gtk::CellRendererText);
+		Gtk::CellRendererText* const renderer = Gtk::manage(new Gtk::CellRendererText);
 		renderer->property_ellipsize() = Pango::ELLIPSIZE_END;
 		pack_start(*renderer, false); 
 		add_attribute(*renderer, "text", 0);

--- a/rtgui/filmsimulation.cc
+++ b/rtgui/filmsimulation.cc
@@ -222,7 +222,7 @@ ClutComboBox::ClutComboBox(const Glib::ustring &path):
 		// Pack a CellRendererText in order to display long Clut file names properly
 		Gtk::CellRendererText *renderer;
 
-		renderer = new Gtk::CellRendererText;
+		renderer = Gtk::manage(new Gtk::CellRendererText);
 		renderer->property_ellipsize() = Pango::ELLIPSIZE_END;
 		pack_start(*renderer, false); 
 		add_attribute(*renderer, "text", 0);


### PR DESCRIPTION
I propose a fix for issue #6417.

As indicated in the comment in the code, I found this solution on stackoverflow. I don't know if this is the best possible solution, but it seems to work.

Feel free to not use this fix if there is a reason why the current behavior is like it is.