### PR TITLE
mac: clarify command-line interface instructions

### DIFF
--- a/tools/osx/INSTALL.readme.rtf
+++ b/tools/osx/INSTALL.readme.rtf
@@ -1,3 +1,7 @@
-An unsigned -cli is in the zip along with the .dmg. 
-You must install the app from the .dmg into /Applications and copy the -cli to your /usr/local/bin. 
-The -cli will load its libraries dynamically from the app in /Applications.
+To use the RawTherapee Application:
+    You must drag the app from the .dmg into the /Applications folder.
+
+If you wish to use the Command-Line Interface:
+    An unsigned -cli is in the zip along with the .dmg. 
+    You must install the app from the .dmg into /Applications and copy the -cli to your /usr/local/bin. 
+    The -cli will load its libraries dynamically from the app in /Applications.


### PR DESCRIPTION
cf. https://discuss.pixls.us/t/the-missing-cli-file/29510/18?u=hiram