### PR TITLE
Fix so E-Mount lens names are retrieved

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -557,7 +557,7 @@ FrameData::FrameData(rtexif::TagDirectory* frameRootDir_, rtexif::TagDirectory* 
                 } else if (!make.compare (0, 4, "SONY") || !make.compare (0, 6, "KONICA")) {
                     if (mnote->getTag ("LensID")) {
                         lens = validateUft8(mnote->getTag("LensID")->valueToString());
-                        if (lens == "Unknown") {
+                        if (!lens.compare (0, 7, "Unknown")) {
                             lens_from_make_and_model();
                         }
                     }


### PR DESCRIPTION
This is related to issue #5670 though I don't know whether it can be considered a definite fix or not.

Problem: Sony E-Mount lenses are not retrieved correctly. Instead, something like "Unknown (28mm f/2.0)" is returned (see attached).

The reason for this apparently is that for E-Mount lenses Sony uses a "lenstype2" mechanism which is not implemented in RT. Instead, RT tries to retrieve a lens with lens ID 65535 (which is usually -- always? -- assigned to E-Mount lenses), finds more than one, can't decide which one is correct, and returns this "Unknown ..." string as lens name. A fallback mechanism to get the lens model from the exif tag is implemented but checks for a string _equal _to__ "Unknown" instead of _beginning _with__ "Unknown", and fails.

The change I propose here fixes that.

----------------------------------
I personally don't like this Makernotes-based mechanism at all. It is apparently undocumented and may change, and apparently has in the past, with any new camera. The way it is implemented in RT, with hard-coded lens lists, also means that new lenses can only be added with new releases of RT, which haven't been that frequent recently.

So, in my locally compiled version of RT, I bypass this mechanism and immediately read the lens model tag, just as it is done for Fujifilm lenses. I know that for my lenses this works; however, I can't be sure that this is _always_ the case. Which is why I propose a different solution above that seems to be more in line with the original developer's intention.

![Capture](https://user-images.githubusercontent.com/38507161/158842333-b3621c5d-59b3-4145-b8cc-8125519eeb7b.JPG)
.