### PR TITLE
Handle linear DNG as other raw images

### DIFF
--- a/rtengine/demosaic_algos.cc
+++ b/rtengine/demosaic_algos.cc
@@ -878,7 +878,7 @@ void RawImageSource::nodemosaic(bool bw)
         for (int j = 0; j < W; j++) {
             if (bw) {
                 red[i][j] = green[i][j] = blue[i][j] = rawData[i][j];
-            } else if(ri->getSensorType() != ST_FUJI_XTRANS) {
+            } else if(ri->getSensorType() == ST_BAYER) {
                 switch( FC(i, j)) {
                 case 0:
                     red[i][j] = rawData[i][j];
@@ -895,7 +895,7 @@ void RawImageSource::nodemosaic(bool bw)
                     red[i][j] = green[i][j] = 0;
                     break;
                 }
-            } else {
+            } else if(ri->getSensorType() == ST_FUJI_XTRANS) {
                 switch( ri->XTRANSFC(i, j)) {
                 case 0:
                     red[i][j] = rawData[i][j];
@@ -912,6 +912,10 @@ void RawImageSource::nodemosaic(bool bw)
                     red[i][j] = green[i][j] = 0;
                     break;
                 }
+            } else {
+                red[i][j] = rawData[i][j * 3 + 0];
+                green[i][j] = rawData[i][j * 3 + 1];
+                blue[i][j] = rawData[i][j * 3 + 2];
             }
         }
     }

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -821,7 +821,7 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
             int i = sy1 + skip * ix;
             i = std::min(i, maxy - skip); // avoid trouble
 
-            if (ri->getSensorType() == ST_BAYER || ri->getSensorType() == ST_FUJI_XTRANS || ri->get_colors() == 1) {
+            if (ri->getSensorType() == ST_BAYER || ri->getSensorType() == ST_FUJI_XTRANS || ri->get_colors() == 1 || ri->get_colors() == 3) {
                 for (int j = 0, jx = sx1; j < imwidth; j++, jx += skip) {
                     jx = std::min(jx, maxx - skip); // avoid trouble
 
@@ -1683,6 +1683,9 @@ void RawImageSource::demosaic(const RAWParams &raw, bool autoContrast, double &c
     } else if (ri->get_colors() == 1) {
         // Monochrome
         nodemosaic(true);
+    } else {
+        // RGB
+        nodemosaic(false);
     }
 
     t2.set();


### PR DESCRIPTION
RawTherapee already handle linear DNGs as a RawImageSource but the red,
green, blue RawImageSource arrays aren't populated.
So operations that rely on them like Highlight recovery with color
Propagation and Retinex have no effect.

This patch populates the above arrays by calling nodemoasic for images
that have 3 color and not a CFA. Then these channels will be used by
RawImageSource::getImage like done with CFA or monochrome images

Fixes #6441

Question: Is there a test suite to check that this PR doesn't causes some regressions?