### PR TITLE
dcraw: use the right black levels for linear DNGs

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6404,6 +6404,9 @@ int CLASS parse_tiff_ifd (int base)
       case 3: case 257: case 61442:	/* ImageHeight */
 	tiff_ifd[ifd].height = getint(type);
 	break;
+      case 254:
+	tiff_ifd[ifd].new_sub_file_type = getint(type);
+	break;
       case 258:				/* BitsPerSample */
       case 61443:
 	tiff_ifd[ifd].samples = len & 7;
@@ -6737,14 +6740,17 @@ guess_cfa_pc:
 	linear_table (len);
 	break;
       case 50713:			/* BlackLevelRepeatDim */
+	if (tiff_ifd[ifd].new_sub_file_type != 0) continue;
 	cblack[4] = get2();
 	cblack[5] = get2();
 	if (cblack[4] * cblack[5] > sizeof cblack / sizeof *cblack - 6)
 	    cblack[4] = cblack[5] = 1;
 	break;
       case 61450:
+	if (tiff_ifd[ifd].new_sub_file_type != 0) continue;
 	cblack[4] = cblack[5] = MIN(sqrt(len),64);
       case 50714:			/* BlackLevel */
+	if (tiff_ifd[ifd].new_sub_file_type != 0) continue;
                 RT_blacklevel_from_constant = ThreeValBool::F;
 //-----------------------------------------------------------------------------
 // taken from LibRaw.

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -209,7 +209,7 @@ protected:
     } first_decode[2048], *second_decode, *free_decode;
 
     struct tiff_ifd {
-      int width, height, bps, comp, phint, offset, flip, samples, bytes;
+      int new_sub_file_type, width, height, bps, comp, phint, offset, flip, samples, bytes;
       int tile_width, tile_length, sample_format, predictor;
       float shutter;
     } tiff_ifd[10];


### PR DESCRIPTION
Linear dng (like the one created by Adobe DNG Converter) contains
multiple tiff subifd with different kind of images (the Primary Image
and multiple previews), these defines different kind of black levels.

Currently dcraw has a global cblack array that is overwritten by the
last parsed tiff ifd. With such kind of linear dng it's the last subifd.
This causes the use of the wrong black levels with the image having
usually a magenta color cast.

The dng spec uses the NewSubFileType tag to define the primary image
with tag value as 0.
This patch reads also the NewSubFileType tag and populates the cblack
array provided by the other tags only if it's the primary image.

Fixes #6443

**Note** 

This patch tries to handle the current dcraw.cc code that tries handle all kind of raw images in a single class.
A cleaner fix will be to save the cblack levels for every tiff_ifd and then use the right one. But the global cblack is also uses in other places for other raw files.
Additionally, for DNG files could be possible to exactly know the right raw image using the `NewSubFileType` instead currently there's a quite convoluted code to detect which one to use.

ART has the same issue when using the dcraw code. Enabling libraw support in ART instead returns the right black levels.