### PR TITLE
dcraw: increase linear table parsing to 65536 values

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6292,11 +6292,11 @@ void CLASS parse_mos (int offset)
 void CLASS linear_table (unsigned len)
 {
   int i;
-  if (len > 0x1000) len = 0x1000;
+  if (len > 0x10000) len = 0x10000;
   read_shorts (curve, len);
-  for (i=len; i < 0x1000; i++)
+  for (i=len; i < 0x10000; i++)
     curve[i] = curve[i-1];
-  maximum = curve[0xfff];
+  maximum = curve[0xffff];
 }
 
 void CLASS parse_kodak_ifd (int base)


### PR DESCRIPTION
The dcraw linear_table method limits the max values to 4096.
But 16 bit per channel linear DNGs can provide a LinearizationTable with
65536 entries.

This patch changes the dcraw linear_table method to accept 65536
entries.