### PR TITLE
Enable installation on arm64 processors on windows

### DIFF
--- a/UpdateInfo.cmake
+++ b/UpdateInfo.cmake
@@ -106,9 +106,9 @@ if(WIN32)
     elseif(BIT_DEPTH EQUAL 8)
         set(BUILD_BIT_DEPTH 64)
         # Restricting the 64 bits builds to 64 bits systems only
-        set(ARCHITECTURE_ALLOWED "x64 ia64")
+        set(ARCHITECTURE_ALLOWED "x64 ia64 arm64")
         # installing in 64 bits mode for all 64 bits processors, even for itanium architecture
-        set(INSTALL_MODE "x64 ia64")
+        set(INSTALL_MODE "x64 ia64 arm64")
     endif()
     # set part of the output archive name
     set(SYSTEM_NAME "WinVista")


### PR DESCRIPTION
When trying to install RawTherapee on Windows ARM64 devices, the following error appears when opening the setup application:

![image](https://user-images.githubusercontent.com/31840085/168466898-e66d4470-3db5-4639-a849-043d713ca69b.png)

However, Windows 11 has x64 emulation enabled by default on ARM devices, meaning that RawTherapee actually works under emulation (albeit with a performance penalty). Prior to this, I was using RawTherapee on my Surface Pro X from the .zip file as the architecture check only prevents you from running the set-up, but the program runs fine.

This PR adds arm64 to the architecture check, so that it doesn't error out and it can be installed on arm64 devices. (I forked onto a separate repo so that I could build artifacts without cluttering the main repository, in case something did not work).

I have tested this on my Surface Pro X - packages are published, the install executes successfully and the program can be run with no issues. This is of course still under emulation, this is a very small PR that doesn't enable arm-native compilation.