### PR TITLE
Better ARQ Support

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6590,9 +6590,10 @@ int CLASS parse_tiff_ifd (int base)
 	break;
       case 258:				/* BitsPerSample */
       case 61443:
-	tiff_ifd[ifd].samples = len & 7;
+        if(!tiff_ifd[ifd].samples || tag != 258)
+            tiff_ifd[ifd].samples = len & 7;
 	if ((tiff_ifd[ifd].bps = getint(type)) > 32)
-        tiff_ifd[ifd].bps = 8;
+            tiff_ifd[ifd].bps = 8;
 	if (tiff_bps < tiff_ifd[ifd].bps)
 	    tiff_bps = tiff_ifd[ifd].bps;
 	break;
@@ -7288,7 +7289,7 @@ void CLASS apply_tiff()
 		     load_raw = &CLASS olympus_load_raw;
                    // ------- RT -------
                    if (!strncmp(make,"SONY",4) &&
-                       (!strncmp(model,"ILCE-7RM3",9) || !strncmp(model,"ILCE-7RM4",9)) &&
+                       (!strncmp(model,"ILCE-7RM3",9) || !strncmp(model,"ILCE-7RM4",9)  || !strncmp(model,"ILCE-1",6)) &&
                        tiff_samples == 4 &&
                        tiff_ifd[raw].bytes == raw_width*raw_height*tiff_samples*2) {
                        load_raw = &CLASS sony_arq_load_raw;

--- a/rtengine/pixelshift.cc
+++ b/rtengine/pixelshift.cc
@@ -592,6 +592,7 @@ BENCHFUN
 
     static const float ePerIsoILCE7RM3 = 0.8f;
 
+    //TODO: Add data for ILCE-7RM4, and ILCE-1
     if(plistener) {
         plistener->setProgressStr(Glib::ustring::compose(M("TP_RAW_DMETHOD_PROGRESSBAR"), M("TP_RAW_PIXELSHIFT")));
         plistener->setProgress(0.0);
@@ -610,18 +611,29 @@ BENCHFUN
 
     int nReadIndex = static_cast<int>(round(log2(idata->getISOSpeed() /  100.f) * 3.f));
 
-    if(model.find("K-3") != string::npos) {
-        nRead = nReadK3II[nReadIndex];
-        eperIsoModel = ePerIsoK3II;
-    } else if(model.find("K-1") != string::npos) { // this also matches K-1 Mark II
-        nRead = nReadK1[nReadIndex];
-        eperIsoModel = ePerIsoK1;
-    } else if(model.find("ILCE-7RM3") != string::npos) {
-        nRead = nReadILCE7RM3[nReadIndex];
-        eperIsoModel = ePerIsoILCE7RM3;
-    } else { // as long as we don't have values for Pentax KP, we use the values from K-70
-        nRead = nReadK70[nReadIndex];
-        eperIsoModel = ePerIsoK70;
+    if(make.find("Sony") != string::npos) {
+        if(model.find("ILCE-7RM3") != string::npos) {
+            nRead = nReadILCE7RM3[nReadIndex];
+            eperIsoModel = ePerIsoILCE7RM3;
+        /* TODO: When we have data for missing ILCE-7RM4, and ILCE-1, add it here
+        } else if(model.find("ILCE-7RM4") != string::npos) {
+        } else if(model.find("ILCE-1") != string::npos) {
+        */
+        } else { // default to ILCE-7RM3 for Sony cameras without data
+           nRead = nReadILCE7RM3[nReadIndex];
+           eperIsoModel = ePerIsoILCE7RM3;
+        }
+    } else { // Pentax
+        if(model.find("K-3") != string::npos) {
+            nRead = nReadK3II[nReadIndex];
+            eperIsoModel = ePerIsoK3II;
+        } else if(model.find("K-1") != string::npos) { // this also matches K-1 Mark II
+            nRead = nReadK1[nReadIndex];
+            eperIsoModel = ePerIsoK1;
+        } else { // as long as we don't have values for Pentax KP, we use the values from K-70
+            nRead = nReadK70[nReadIndex];
+            eperIsoModel = ePerIsoK70;
+        }
     }
 
     eperIsoModel *= pow(2.f, eperIso - 1.f);


### PR DESCRIPTION
Added Support for ARQ files from ILCE-1, both 4 and 16 shot
<strike>Added Support for ARQ files from ILCE-7M4</strike>

"Fixed" possible bug where tiff_ifd[].samples was getting overwritten. This probably hasn't been noticed since it requires the TIFF tags to be parsed in a specific order, and affects files with 4 samples per pixel (pixel shift)

Some pixel shift data about Sony bodies other than ILCE-7RM3 is missing, added some TODOs to show where to add the data. 

Sony bodies without the proper pixel shift data will default to ILCE-7RM3. Pentax still defaults to Pentax.

This is my first time contributing to an open source project, so please let me know if I've made any mistakes during this process.