### PR TITLE
Fix auto perspective correction not working sometimes

### DIFF
--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -1022,6 +1022,16 @@ void ToolPanelCoordinator::autoPerspRequested (bool corr_pitch, bool corr_yaw, d
     rtengine::procparams::ProcParams params;
     ipc->getParams(&params);
 
+    // If focal length or crop factor are undetermined, use the defaults.
+    if (params.perspective.camera_focal_length <= 0) {
+        params.perspective.camera_focal_length =
+            PerspectiveParams::DEFAULT_CAMERA_FOCAL_LENGTH;
+    }
+    if (params.perspective.camera_crop_factor <= 0) {
+        params.perspective.camera_crop_factor =
+            PerspectiveParams::DEFAULT_CAMERA_CROP_FACTOR;
+    }
+
     auto res = rtengine::PerspectiveCorrection::autocompute(src, corr_pitch, corr_yaw, &params, src->getMetaData(), lines);
     rot = res.angle;
     pitch = res.pitch;


### PR DESCRIPTION
Automatic perspective correction with control lines or automatically-detected lines fails if the image has no metadata, the focal length is 24mm, or the crop factor is 1. This PR uses the default focal length or crop factor if necessary for computing the perspective correction parameters.