### PR TITLE
Local adjustments - Fix apply/paste actions with LA

### DIFF
--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -3382,14 +3382,15 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
     if (locallab.enabled) {
         toEdit.locallab.enabled   = mods.locallab.enabled;
+
+        // In that case, locallab is impacted by the combine:
+        // Resizing locallab spots vector according to pedited
+        toEdit.locallab.spots.resize(locallab.spots.size());
     }
 
     if (locallab.selspot) {
         toEdit.locallab.selspot   = mods.locallab.selspot;
     }
-
-    // Resizing locallab spots vector according to pedited
-    toEdit.locallab.spots.resize(locallab.spots.size());
 
     // Updating each locallab spot according to pedited
     for (size_t i = 0; i < toEdit.locallab.spots.size() && i < mods.locallab.spots.size() && i < locallab.spots.size(); i++) {
@@ -8048,7 +8049,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     lightlzcam(v),
     lightqzcam(v),
     contlzcam(v),
-    contqzcam(v), 
+    contqzcam(v),
     contthreszcam(v),
     colorflzcam(v),
     saturzcam(v),
@@ -8747,7 +8748,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     lightlzcam = v;
     lightqzcam = v;
     contlzcam = v;
-    contqzcam = v; 
+    contqzcam = v;
     contthreszcam = v;
     colorflzcam = v;
     saturzcam = v;

--- a/rtgui/partialpastedlg.cc
+++ b/rtgui/partialpastedlg.cc
@@ -35,9 +35,9 @@ PartialSpotWidget::PartialSpotWidget():
     // Widget listener
     selListener(nullptr)
 {
-    
+
     set_orientation(Gtk::ORIENTATION_VERTICAL);
-    
+
     // Configure tree view
     treeview->set_model(treemodel);
     treeview->set_enable_search(false);
@@ -342,7 +342,7 @@ PartialPasteDlg::PartialPasteDlg (const Glib::ustring &title, Gtk::Window* paren
     vboxes[1]->pack_start (*hseps[1], Gtk::PACK_SHRINK, 2);
     vboxes[1]->pack_start (*spot, Gtk::PACK_SHRINK, 2);
     vboxes[1]->pack_start (*sharpen, Gtk::PACK_SHRINK, 2);
-    vboxes[1]->pack_start (*localcontrast, Gtk::PACK_SHRINK, 2);    
+    vboxes[1]->pack_start (*localcontrast, Gtk::PACK_SHRINK, 2);
     vboxes[1]->pack_start (*sharpenedge, Gtk::PACK_SHRINK, 2);
     vboxes[1]->pack_start (*sharpenmicro, Gtk::PACK_SHRINK, 2);
     vboxes[1]->pack_start (*impden, Gtk::PACK_SHRINK, 2);
@@ -984,7 +984,7 @@ void PartialPasteDlg::applyPaste (rtengine::procparams::ProcParams* dstPP, Param
     if (!dehaze->get_active ()) {
         filterPE.dehaze = falsePE.dehaze;
     }
-    
+
     if (!rgbcurves->get_active ()) {
         filterPE.rgbCurves    = falsePE.rgbCurves;
     }
@@ -1234,6 +1234,9 @@ void PartialPasteDlg::applyPaste (rtengine::procparams::ProcParams* dstPP, Param
             if (!chosenSpots.at(i)) {
                 tmpPP.locallab.spots.erase(tmpPP.locallab.spots.begin() + i);
                 tmpPE.locallab.spots.erase(tmpPE.locallab.spots.begin() + i);
+
+                // Locallab Selspot param shall be kept in vector size limit
+                tmpPP.locallab.selspot = std::max(0, std::min(tmpPP.locallab.selspot, (int)tmpPP.locallab.spots.size() - 1));
             }
         }
 
@@ -1260,16 +1263,23 @@ void PartialPasteDlg::updateSpotWidget(const rtengine::procparams::ProcParams* p
 
 void PartialPasteDlg::partialSpotUpdated(const UpdateStatus status)
 {
+    locallabConn.block(true);
+
     switch (status) {
         case (AllSelection):
             locallab->set_active(true);
+            locallab->set_inconsistent(false);
             break;
 
         case (NoSelection):
             locallab->set_active(false);
+            locallab->set_inconsistent(false);
             break;
 
         case (PartialSelection):
+            locallab->set_active(false);
             locallab->set_inconsistent(true);
     }
+
+    locallabConn.block(false);
 }

--- a/rtgui/profilepanel.cc
+++ b/rtgui/profilepanel.cc
@@ -496,6 +496,12 @@ void ProfilePanel::load_clicked (GdkEventButton* event)
                 custom->pedited->locallab.spots.clear();
             }
 
+            // For each Locallab spot, loaded profile pp only contains activated tools params
+            // Missing tool params in pe shall be also set to true to avoid a "spot merge" issue
+            for (int i = 0; i < (int)pe.locallab.spots.size(); i++) {
+                pe.locallab.spots.at(i).set(true);
+            }
+
             custom->set(true);
 
             bool prevState = changeconn.block(true);


### PR DESCRIPTION
The Pull Request fixes the following issues:
- Fixes LA lost when applying partial profile (#6150)
- Fixes LA behavior when using apply/paste actions: spots are now totally replaced and not anymore merged (#6136, #6411)
- Fixes a crash in specific situations when saving/copying a partial number of spots
- Partial paste dialog: Fixes Locallab button remaining inconsistent if all the spots are deselected

@jade-nl @Lawrence37 @epadepa