### PR TITLE
Add Canon EOS R3, R7 and R10 support

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1209,11 +1209,16 @@ Camera constants:
     },
 
     { // Quality C
+        "make_model": "Canon EOS R3",
+        "dcraw_matrix" : [9423,-2839,-1195,-4532,12377,2415,-483,1374,5276]
+    },
+
+    { // Quality C
         "make_model": "Canon EOS R5",
         "dcraw_matrix" : [9766, -2953, -1254, -4276, 12116, 2433, -437, 1336, 5131],
         "raw_crop" : [ 128, 96, 8224, 5490 ],
         "masked_areas" : [ 94, 20, 5578, 122 ],
-        "ranges" : { "white" : 16382 } 
+        "ranges" : { "white" : 16382 }
     },
 
     { // Quality C
@@ -1222,6 +1227,16 @@ Camera constants:
         "raw_crop": [ 72, 38, 5496, 3670 ],
         "masked_areas" : [ 40, 10, 5534, 70 ],
         "ranges" : { "white" : 16382 }
+    },
+
+    { // Quality C
+        "make_model": "Canon EOS R7",
+        "dcraw_matrix" : [10424, -3138, -1300, -4221, 11938,  2584,  -547,  1658,  6183]
+    },
+
+    { // Quality C
+        "make_model": "Canon EOS R10",
+        "dcraw_matrix" : [9269, -2012, -1107, -3990, 11762,  2527,  -569,  2093,  4913]
     },
 
     { // Quality C, CHDK DNGs, raw frame correction
@@ -1702,7 +1717,7 @@ Camera constants:
     { // Quality A, samples provided by dimonoid (#5842)
         "make_model": "NIKON COOLPIX P1000",
         "dcraw_matrix": [ 14294, -6116, -1333, -1628, 10219, 1637, -14, 1158, 5022 ], // ColorMatrix2 from Adobe DNG Converter 11.4
-        "ranges": { 
+        "ranges": {
             "black": 200,
             "white": [ 4000, 4050, 3950 ] // Typical values without LENR: 4009, 4093, 3963
         } // No significant influence of ISO

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6091,6 +6091,18 @@ get2_256:
       offsetChannelBlackLevel2 = save1 + (0x157 << 1);
       offsetWhiteLevels = save1 + (0x32a << 1);
       break;
+    case 3973: // R3; ColorDataSubVer: 34
+    case 3778: // R7, R10; ColorDataSubVer: 48
+      // imCanon.ColorDataVer = 11;
+      imCanon.ColorDataSubVer = get2();
+
+      fseek(ifp, save1 + ((0x0069+0x0064) << 1), SEEK_SET);
+      FORC4 cam_mul[c ^ (c >> 1)] = (float)get2();
+
+      offsetChannelBlackLevel2 = save1 + ((0x0069+0x0102) << 1);
+      offsetChannelBlackLevel  = save1 + ((0x0069+0x0213) << 1);
+      offsetWhiteLevels        = save1 + ((0x0069+0x0217) << 1);
+      break;
     }
 
     if (offsetChannelBlackLevel)


### PR DESCRIPTION
I've added support for these camera in RawTherapee. This is all taken from LibRaw.

I don't know what to set for raw_crop, masked_areas and ranges, I couldn't find these values in LibRaw.

For some reason, EXIF data isn't extracted by RawTherapee.