### PR TITLE
Automated builds: Patch lensfun-update-data script

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Include Lensfun
         run: |
+          echo "Patching lensfun-update-data script."
+          sudo sed -i 's/HTTPError\(, ValueError\)/URLError\1/' $(which lensfun-update-data)
           echo "Updating Lensfun database."
           lensfun-update-data
           echo "Creating Lensfun directory in the build directory."

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,7 +117,7 @@ jobs:
             "libdeflate.dll" \
             "libepoxy-0.dll" \
             "libexpat-1.dll" \
-            "libffi-7.dll" \
+            libffi-*.dll \
             "libfftw3f-3.dll" \
             "libfontconfig-1.dll" \
             "libfreetype-6.dll" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Include Lensfun
         run: |
+          echo "Patching lensfun-update-data script."
+          sed -i 's/HTTPError\(, ValueError\)/URLError\1/' $(which lensfun-update-data)
           echo "Updating Lensfun database."
           lensfun-update-data
           echo "Creating Lensfun directory in the build directory."


### PR DESCRIPTION
The Windows and AppImage builds are failing at the Lensfun step due to a bug in the `lensfun-update-data` script which causes an error if a connection to a URL times out. The script can pull data from http://lensfun.sourceforge.net/db/ or http://wilson.bronger.org/lensfun-db/, but the latter is down at the moment. Only one of the two are actually required to retrieve the latest database. The bug has been fixed in [this commit](https://github.com/lensfun/lensfun/commit/71cf3c9febcaa2c2dd81a43058488d4326d11f4e). I have modified our build scripts to patch `lensfun-update-data` before using it.
Note that the upstream fix adds `URLError` to the list of exceptions to catch, but my patch replaces `HTTPError` with `URLError`. This is because `URLError` is a superclass of `HTTPError` (so it will catch `HTTPError`s anyway) and replacing the error results in a smaller patch :).

`libffi-7.dll` has been updated to `libffi-8.dll`. Because it was upgraded from `libffi-6.dll` not long ago, I am now using `libffi-*.dll` to avoid having to change the build script again when there is another upgrade. No other files match the `libffi-*.dll` pattern.