### PR TITLE
Minor license path fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,7 +725,7 @@ add_custom_target(
 # End generating AboutThisBuild.txt
 
 install(FILES AUTHORS.txt DESTINATION "${CREDITSDIR}")
-install(FILES LICENSE.txt DESTINATION "${LICENCEDIR}")
+install(FILES LICENSE DESTINATION "${LICENCEDIR}")
 install(FILES "${CMAKE_BINARY_DIR}/AboutThisBuild.txt"
         DESTINATION "${CREDITSDIR}")
 install(

--- a/rtgui/splash.cc
+++ b/rtgui/splash.cc
@@ -178,7 +178,7 @@ Splash::Splash (Gtk::Window& parent) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, t
     }
 
     // Tab 4: the license
-    std::string licenseFileName = Glib::build_filename (licensePath, "LICENSE.txt");
+    std::string licenseFileName = Glib::build_filename (licensePath, "LICENSE");
 
     if ( Glib::file_test(licenseFileName, (Glib::FILE_TEST_EXISTS)) ) {
         FILE *f = g_fopen (licenseFileName.c_str (), "rt");


### PR DESCRIPTION
Two fixes in the code that directly references the `LICENSES.txt` file which was renamed in https://github.com/Beep6581/RawTherapee/commit/8566f06f4f2a06caeb24508da8b4cfc1d8bc5619