### PR TITLE
Fix for white outlines and background in AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -101,7 +101,9 @@ jobs:
           echo "Downloading linuxdeploy."
           curl --location 'https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage' > linuxdeploy-x86_64.AppImage
           echo "Downloading GTK plugin for linuxdeploy."
-          curl --location 'https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh' > linuxdeploy-plugin-gtk.sh
+          curl --location 'https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh' \
+            | sed 's/^\(export GTK_THEME\)/#\1/' \
+            > linuxdeploy-plugin-gtk.sh
           echo "Setting execute bit on all AppImage tools."
           chmod u+x linuxdeploy-*
 


### PR DESCRIPTION
I managed to track down the difference between the AppImage and the other builds. It sets the `GTK_THEME` environment variable according to the GTK themes it can find with `gsettings`. On my computer, `gesettings` does not find all the themes, which causes the AppImage to default to `Adwaita:light`. I patched the GTK plugin for linuxdeploy to remove the `GTK_THEME` environment variable. It will now use the system theme, which I believe is the same behavior as the other builds including native ones. Uses can override the theme with the environment variable.
To avoid theme issues, the RawTherapee CSS themes should control all the colors instead leaving some to the default theme. We should consider fixing the RawTherapee theme. The TooWa* themes are unaffected.
Closes #6526.