### PR TITLE
Fix Windows build libpcre DLL error

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -150,7 +150,7 @@ jobs:
             "libpangoft2-1.0-0.dll" \
             "libpangomm-1.4-1.dll" \
             "libpangowin32-1.0-0.dll" \
-            "libpcre-1.dll" \
+            "libpcre2-8-0.dll" \
             "libpixman-1-0.dll" \
             "libpng16-16.dll" \
             "librsvg-2-2.dll" \


### PR DESCRIPTION
Updates the PCRE DLL file name that need to be bundled with the executable.