### PR TITLE
Add raw_crop and masked_areas for Canon EOS R7 and R10

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1231,7 +1231,9 @@ Camera constants:
 
     { // Quality C
         "make_model": "Canon EOS R7",
-        "dcraw_matrix" : [10424, -3138, -1300, -4221, 11938,  2584,  -547,  1658,  6183]
+        "dcraw_matrix" : [10424, -3138, -1300, -4221, 11938,  2584,  -547,  1658,  6183],
+        "raw_crop": [ 144, 72, 6984, 4660 ],
+        "masked_areas" : [ 70, 20, 4724, 138 ]
     },
 
     { // Quality C

--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1238,7 +1238,9 @@ Camera constants:
 
     { // Quality C
         "make_model": "Canon EOS R10",
-        "dcraw_matrix" : [9269, -2012, -1107, -3990, 11762,  2527,  -569,  2093,  4913]
+        "dcraw_matrix" : [9269, -2012, -1107, -3990, 11762,  2527,  -569,  2093,  4913],
+        "raw_crop": [ 144, 40, 6048, 4020 ],
+        "masked_areas" : [ 38, 20, 4052, 138 ]
     },
 
     { // Quality C, CHDK DNGs, raw frame correction


### PR DESCRIPTION
Add raw_crop and masked_areas settings to camconst.json for Canon EOS R7 and R10.  raw_crop settings determined from R7 and R10 raw files. masked_areas uses the same relative offsets as the R5.