### PR TITLE
Try to fix bug when using CBDL main and Local Sharpening

### DIFF
--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -731,14 +731,14 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
         // Remove transformation if unneeded
         bool needstransform = ipf.needsTransform(fw, fh, imgsrc->getRotateDegree(), imgsrc->getMetaData());
 
-		int sharplablocal = 0;//detect if Locallab sharpening is active
+		bool sharplablocal = false;//detect if Locallab sharpening is active
         for (int sp = 0; sp < (int)params->locallab.spots.size(); sp++) {
 			if(params->locallab.spots.at(sp).expsharp) {
-				sharplablocal = 1;
+				sharplablocal = true;
 			}
 		}
 				
-		if (sharplablocal == 1) {
+		if (sharplablocal == true) {
 			params->dirpyrequalizer.cbdlMethod = "aft";
 		}
 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -731,16 +731,6 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
         // Remove transformation if unneeded
         bool needstransform = ipf.needsTransform(fw, fh, imgsrc->getRotateDegree(), imgsrc->getMetaData());
 
-		bool sharplablocal = false;//detect if Locallab sharpening is active
-        for (int sp = 0; sp < (int)params->locallab.spots.size(); sp++) {
-			if(params->locallab.spots.at(sp).expsharp) {
-				sharplablocal = true;
-			}
-		}
-				
-		if (sharplablocal == true) {
-			params->dirpyrequalizer.cbdlMethod = "aft";
-		}
 
         if ((needstransform || ((todo & (M_TRANSFORM | M_RGBCURVE))  && params->dirpyrequalizer.cbdlMethod == "bef" && params->dirpyrequalizer.enabled && !params->colorappearance.enabled))) {
             // Forking the image
@@ -755,6 +745,14 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 op->copyData(oprevi);
             }
         }
+
+        for (int sp = 0; sp < (int)params->locallab.spots.size(); sp++) {
+			if(params->locallab.spots.at(sp).expsharp  && params->dirpyrequalizer.cbdlMethod == "bef") {
+				if(params->locallab.spots.at(sp).shardamping < 1) {
+					params->locallab.spots.at(sp).shardamping = 1;
+				}				
+			}
+		}
 
         if ((todo & (M_TRANSFORM | M_RGBCURVE))  && params->dirpyrequalizer.cbdlMethod == "bef" && params->dirpyrequalizer.enabled && !params->colorappearance.enabled) {
             const int W = oprevi->getWidth();

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -731,6 +731,17 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
         // Remove transformation if unneeded
         bool needstransform = ipf.needsTransform(fw, fh, imgsrc->getRotateDegree(), imgsrc->getMetaData());
 
+		int sharplablocal = 0;//detect if Locallab sharpening is active
+        for (int sp = 0; sp < (int)params->locallab.spots.size(); sp++) {
+			if(params->locallab.spots.at(sp).expsharp) {
+				sharplablocal = 1;
+			}
+		}
+				
+		if (sharplablocal == 1) {
+			params->dirpyrequalizer.cbdlMethod = "aft";
+		}
+
         if ((needstransform || ((todo & (M_TRANSFORM | M_RGBCURVE))  && params->dirpyrequalizer.cbdlMethod == "bef" && params->dirpyrequalizer.enabled && !params->colorappearance.enabled))) {
             // Forking the image
             assert(oprevi);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -5299,7 +5299,7 @@ DirPyrEqualizerParams::DirPyrEqualizerParams() :
     threshold(0.2),
     skinprotect(0.0),
     hueskin(-5, 25, 170, 120, false),
-    cbdlMethod("aft")
+    cbdlMethod("bef")
 {
 }
 

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -5299,7 +5299,7 @@ DirPyrEqualizerParams::DirPyrEqualizerParams() :
     threshold(0.2),
     skinprotect(0.0),
     hueskin(-5, 25, 170, 120, false),
-    cbdlMethod("bef")
+    cbdlMethod("aft")
 {
 }
 

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -924,13 +924,13 @@ private:
         //ImProcFunctions ipf (&params, true);
         ImProcFunctions &ipf = * (ipf_p.get());
 
-		int sharplablocal = 0;
+		bool sharplablocal = false;
         for (int sp = 0; sp < (int)params.locallab.spots.size(); sp++) {
 			if(params.locallab.spots.at(sp).expsharp) {
-				sharplablocal = 1;
+				sharplablocal = true;
 			}
 		}
-		if (sharplablocal == 1) {
+		if (sharplablocal == true) {
 			params.dirpyrequalizer.cbdlMethod = "aft";
 		}
 

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -924,6 +924,16 @@ private:
         //ImProcFunctions ipf (&params, true);
         ImProcFunctions &ipf = * (ipf_p.get());
 
+		int sharplablocal = 0;
+        for (int sp = 0; sp < (int)params.locallab.spots.size(); sp++) {
+			if(params.locallab.spots.at(sp).expsharp) {
+				sharplablocal = 1;
+			}
+		}
+		if (sharplablocal == 1) {
+			params.dirpyrequalizer.cbdlMethod = "aft";
+		}
+
         if (params.dirpyrequalizer.cbdlMethod == "bef" && params.dirpyrequalizer.enabled && !params.colorappearance.enabled) {
             const int W = baseImg->getWidth();
             const int H = baseImg->getHeight();

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -924,14 +924,12 @@ private:
         //ImProcFunctions ipf (&params, true);
         ImProcFunctions &ipf = * (ipf_p.get());
 
-		bool sharplablocal = false;
         for (int sp = 0; sp < (int)params.locallab.spots.size(); sp++) {
-			if(params.locallab.spots.at(sp).expsharp) {
-				sharplablocal = true;
+			if(params.locallab.spots.at(sp).expsharp  && params.dirpyrequalizer.cbdlMethod == "bef") {
+				if(params.locallab.spots.at(sp).shardamping < 1) {
+					params.locallab.spots.at(sp).shardamping = 1;
+				}				
 			}
-		}
-		if (sharplablocal == true) {
-			params.dirpyrequalizer.cbdlMethod = "aft";
 		}
 
         if (params.dirpyrequalizer.cbdlMethod == "bef" && params.dirpyrequalizer.enabled && !params.colorappearance.enabled) {


### PR DESCRIPTION
This PR does not solve the bug itself, but avoids the bug.

For this by default "CDBL main" is set to "After black-and-white".

But if the user chooses "Before black-and-white" and chooses in "Local adjustments" - "sharpening", then the process is changed to "after".

This PR can be done before 5.9 or after...

jacques