### PR TITLE
Lensfun DB directory fallback

### DIFF
--- a/rtengine/init.cc
+++ b/rtengine/init.cc
@@ -58,10 +58,20 @@ int init (const Settings* s, const Glib::ustring& baseDir, const Glib::ustring& 
 #pragma omp section
 #endif
 {
+    bool ok;
+
     if (s->lensfunDbDirectory.empty() || Glib::path_is_absolute(s->lensfunDbDirectory)) {
-        LFDatabase::init(s->lensfunDbDirectory);
+        ok = LFDatabase::init(s->lensfunDbDirectory);
     } else {
-        LFDatabase::init(Glib::build_filename(baseDir, s->lensfunDbDirectory));
+        ok = LFDatabase::init(Glib::build_filename(baseDir, s->lensfunDbDirectory));
+    }
+
+    if (!ok && !s->lensfunDbBundleDirectory.empty() && s->lensfunDbBundleDirectory != s->lensfunDbDirectory) {
+        if (Glib::path_is_absolute(s->lensfunDbBundleDirectory)) {
+            LFDatabase::init(s->lensfunDbBundleDirectory);
+        } else {
+            LFDatabase::init(Glib::build_filename(baseDir, s->lensfunDbBundleDirectory));
+        }
     }
 }
 #ifdef _OPENMP

--- a/rtengine/settings.h
+++ b/rtengine/settings.h
@@ -83,6 +83,7 @@ public:
     double          level0_cbdl;
     double          level123_cbdl;
     Glib::ustring   lensfunDbDirectory; // The directory containing the lensfun database. If empty, the system defaults will be used, as described in https://lensfun.github.io/manual/latest/dbsearch.html
+    Glib::ustring   lensfunDbBundleDirectory;
     int             cropsleep;
     double          reduchigh;
     double          reduclow;

--- a/rtgui/main-cli.cc
+++ b/rtgui/main-cli.cc
@@ -148,12 +148,14 @@ int main (int argc, char **argv)
     }
 
     options.rtSettings.lensfunDbDirectory = LENSFUN_DB_PATH;
+    options.rtSettings.lensfunDbBundleDirectory = LENSFUN_DB_PATH;
 
 #else
     argv0 = DATA_SEARCH_PATH;
     creditsPath = CREDITS_SEARCH_PATH;
     licensePath = LICENCE_SEARCH_PATH;
     options.rtSettings.lensfunDbDirectory = LENSFUN_DB_PATH;
+    options.rtSettings.lensfunDbBundleDirectory = LENSFUN_DB_PATH;
 #endif
 
     bool quickstart = dontLoadCache (argc, argv);

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -425,12 +425,14 @@ int main (int argc, char **argv)
     }
 
     options.rtSettings.lensfunDbDirectory = LENSFUN_DB_PATH;
+    options.rtSettings.lensfunDbBundleDirectory = LENSFUN_DB_PATH;
 
 #else
     argv0 = DATA_SEARCH_PATH;
     creditsPath = CREDITS_SEARCH_PATH;
     licensePath = LICENCE_SEARCH_PATH;
     options.rtSettings.lensfunDbDirectory = LENSFUN_DB_PATH;
+    options.rtSettings.lensfunDbBundleDirectory = LENSFUN_DB_PATH;
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
If the Lensfun database fails to load using the path set in the `options` file, this will try to load the database bundled with the application (the path set with the CMake option `LENSFUNDBDIR`). No fallback occurs if the bundled location is not set or is the same as the path in `options`.

This PR should fix the [issue some 5.9-rc1 testers found](https://discuss.pixls.us/t/rawtherapee-5-9-rc1-ready-for-testing/33631/66) in which a [blank database directory in `options`](https://discuss.pixls.us/t/rawtherapee-5-9-rc1-ready-for-testing/33631/76) causes the profiled lens corrections to have no lenses available.