### PR TITLE
iccstore: Allow loading profiles from user-writable configuration directory

### DIFF
--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -454,6 +454,8 @@ public:
         if (loadAll) {
             loadProfiles(profilesDir, &fileProfiles, &fileProfileContents, nullptr, false);
             loadProfiles(userICCDir, &fileProfiles, &fileProfileContents, nullptr, false);
+            Glib::ustring user_output_icc_dir = Glib::build_filename(options.rtdir, "iccprofiles", "output");
+            loadProfiles(user_output_icc_dir, &fileProfiles, &fileProfileContents, nullptr, false);
         }
 
         // Input profiles


### PR DESCRIPTION

In addition to bundled profiles and the system ICC profile store, load profiles from a user-writable/user-specific directory

On Linux, this is $HOME/.config/RawTherapee/iccprofiles/output - corresponding to "input" being already supported

Partial fix for part of #6644