### PR TITLE
Update libtiff DLL version for Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,7 +159,7 @@ jobs:
             "libstdc++-6.dll" \
             "libsystre-0.dll" \
             "libthai-0.dll" \
-            "libtiff-5.dll" \
+            "libtiff-6.dll" \
             "libtre-5.dll" \
             "libwebp-7.dll" \
             "libwinpthread-1.dll" \


### PR DESCRIPTION
The libtiff DLL name has changed. See https://packages.msys2.org/package/mingw-w64-x86_64-libtiff for the current name.