### PR TITLE
CIECAM - Changes such as symmetric works and temperature output makes sense - issue #6656

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2259,8 +2259,7 @@ TP_COLORAPP_TCMODE_LIGHTNESS;Lightness
 TP_COLORAPP_TCMODE_SATUR;Saturation
 TP_COLORAPP_TEMP2_TOOLTIP;Either symmetrical mode temp = White balance.\nEither select illuminant always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
 TP_COLORAPP_TEMP_TOOLTIP;To select an illuminant, always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
-TP_COLORAPP_TEMPOUT_TOOLTIP;Depending on the choices made previously, the selected temperature is:\nWhite balance\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504\nFree.
-
+TP_COLORAPP_TEMPOUT_TOOLTIP;Temperature and Tint.\nDepending on the choices made previously, the selected temperature is:\nWhite balance\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504\nFree.
 TP_COLORAPP_TONECIE;Use CIECAM for tone mapping
 TP_COLORAPP_TONECIE_TOOLTIP;If this option is disabled, tone mapping is done in L*a*b* space.\nIf this option is enabled, tone mapping is done using CIECAM02.\nThe Tone Mapping tool must be enabled for this setting to take effect.
 TP_COLORAPP_VIEWINGF_TOOLTIP;Takes into account the support on which the final image will be viewed (monitor, TV, projector, printer, etc.), as well as its environment. This process will take the data coming from process 'Image Adjustments' and 'bring' it to the support in such a way that the viewing conditions and its environment are taken into account.

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2259,6 +2259,8 @@ TP_COLORAPP_TCMODE_LIGHTNESS;Lightness
 TP_COLORAPP_TCMODE_SATUR;Saturation
 TP_COLORAPP_TEMP2_TOOLTIP;Either symmetrical mode temp = White balance.\nEither select illuminant always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
 TP_COLORAPP_TEMP_TOOLTIP;To select an illuminant, always set Tint=1.\n\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504
+TP_COLORAPP_TEMPOUT_TOOLTIP;Depending on the choices made previously, the selected temperature is:\nWhite balance\nA temp=2856\nD41 temp=4100\nD50 temp=5003\nD55 temp=5503\nD60 temp=6000\nD65 temp=6504\nD75 temp=7504\nFree.
+
 TP_COLORAPP_TONECIE;Use CIECAM for tone mapping
 TP_COLORAPP_TONECIE_TOOLTIP;If this option is disabled, tone mapping is done in L*a*b* space.\nIf this option is enabled, tone mapping is done using CIECAM02.\nThe Tone Mapping tool must be enabled for this setting to take effect.
 TP_COLORAPP_VIEWINGF_TOOLTIP;Takes into account the support on which the final image will be viewed (monitor, TV, projector, printer, etc.), as well as its environment. This process will take the data coming from process 'Image Adjustments' and 'bring' it to the support in such a way that the viewing conditions and its environment are taken into account.

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1913,7 +1913,9 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     adap = pow(2.0, E_V - 3.0);  // cd / m2
                     // end calculation adaptation scene luminosity
                 }
-
+				if(params->colorappearance.catmethod == "symg") {
+					adap = 400.;
+				}
                 float d, dj, yb;
                 bool execsharp = false;
 
@@ -1937,7 +1939,11 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 ipf.ciecam_02float(ncie, float (adap), pW, 2, nprevl, params.get(), customColCurve1, customColCurve2, customColCurve3, histLCAM, histCCAM, CAMBrightCurveJ, CAMBrightCurveQ, CAMMean, 0, scale, execsharp, d, dj, yb, 1);
 
                 if ((params->colorappearance.autodegree || params->colorappearance.autodegreeout) && acListener && params->colorappearance.enabled) {
-                    acListener->autoCamChanged(100.* (double)d, 100.* (double)dj);
+					if(params->colorappearance.catmethod == "symg") {
+						d = 0.9;
+						dj = 0.9;
+					}
+					acListener->autoCamChanged(100.* (double)d, 100.* (double)dj);
                 }
 
                 if (params->colorappearance.autoadapscen && acListener && params->colorappearance.enabled) {
@@ -1945,14 +1951,48 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 }
 
                 if (params->colorappearance.autoybscen && acListener && params->colorappearance.enabled) {
+					if(params->colorappearance.catmethod == "symg") {
+						yb = 18;
+					}
+
                     acListener->ybCamChanged((int) yb);    //real value Yb scene
                 }
-
-             //   if (params->colorappearance.enabled  && params->colorappearance.autotempout) {
+				double tempsym = 5003.;
+				int wmodel = 0;
+				if (params->colorappearance.wbmodel == "RawT") {
+					wmodel = 0;
+				} else if (params->colorappearance.wbmodel == "RawTCAT02") {
+					wmodel = 1;
+				} else if (params->colorappearance.wbmodel == "free") {
+					wmodel = 2;
+				}
+				
+				if(params->colorappearance.catmethod == "symg" && wmodel == 2) {
+					tempsym = params->wb.temperature;
+				} else {
+					if (params->colorappearance.illum == "iA") {
+						tempsym = 2856.;
+					} else if (params->colorappearance.illum == "i41") {
+						tempsym = 4100.;
+					} else if (params->colorappearance.illum == "i50") {
+						tempsym = 5003.;
+					} else if (params->colorappearance.illum == "i55") {
+						tempsym = 5503.;
+					} else if (params->colorappearance.illum == "i60") {
+						tempsym = 6000. ;
+					} else if (params->colorappearance.illum == "i65") {
+						tempsym = 6504.;
+					} else if (params->colorappearance.illum == "i75") {
+						tempsym = 7504.;
+					} else if (params->colorappearance.illum == "ifree") {
+						tempsym = params->wb.temperature;		
+					}
+				}
+                if (params->colorappearance.enabled  && params->colorappearance.autotempout) {
               //  if (params->colorappearance.enabled) {
               //      acListener->wbCamChanged(params->wb.temperature, params->wb.green);    //real temp and tint
-               //     acListener->wbCamChanged(params->wb.temperature, 1.f);    //real temp and tint = 1.
-               // }
+						acListener->wbCamChanged(tempsym, 1.f);    //real temp and tint = 1.
+                }
                 
             } else {
                 // CIECAM is disabled, we free up its image buffer to save some space

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1939,7 +1939,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 ipf.ciecam_02float(ncie, float (adap), pW, 2, nprevl, params.get(), customColCurve1, customColCurve2, customColCurve3, histLCAM, histCCAM, CAMBrightCurveJ, CAMBrightCurveQ, CAMMean, 0, scale, execsharp, d, dj, yb, 1);
 
                 if ((params->colorappearance.autodegree || params->colorappearance.autodegreeout) && acListener && params->colorappearance.enabled) {
-					if(params->colorappearance.catmethod == "symg") {
+					if(params->colorappearance.catmethod == "symg") {//force chromatic adaptation to 90 in symmetric
 						d = 0.9;
 						dj = 0.9;
 					}
@@ -1951,26 +1951,26 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 }
 
                 if (params->colorappearance.autoybscen && acListener && params->colorappearance.enabled) {
-					if(params->colorappearance.catmethod == "symg") {
+					if(params->colorappearance.catmethod == "symg") {//force yb scene to 18 in symmetric
 						yb = 18;
 					}
 
                     acListener->ybCamChanged((int) yb);    //real value Yb scene
                 }
 				double tempsym = 5003.;
-				int wmodel = 0;
+				int wmodel = 0;//allows - arbitrary - choice of illuminant and temp with choice
 				if (params->colorappearance.wbmodel == "RawT") {
 					wmodel = 0;
 				} else if (params->colorappearance.wbmodel == "RawTCAT02") {
 					wmodel = 1;
 				} else if (params->colorappearance.wbmodel == "free") {
-					wmodel = 2;
+					wmodel = 2;//force white balance in symmetric
 				}
 				
 				if(params->colorappearance.catmethod == "symg" && wmodel == 2) {
-					tempsym = params->wb.temperature;
+					tempsym = params->wb.temperature;//force white balance in symmetric
 				} else {
-					if (params->colorappearance.illum == "iA") {
+					if (params->colorappearance.illum == "iA") {//otherwise force illuminant source
 						tempsym = 2856.;
 					} else if (params->colorappearance.illum == "i41") {
 						tempsym = 4100.;
@@ -1985,12 +1985,10 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 					} else if (params->colorappearance.illum == "i75") {
 						tempsym = 7504.;
 					} else if (params->colorappearance.illum == "ifree") {
-						tempsym = params->wb.temperature;		
+						tempsym = params->wb.temperature;//force white balance in symmetric		
 					}
 				}
                 if (params->colorappearance.enabled  && params->colorappearance.autotempout) {
-              //  if (params->colorappearance.enabled) {
-              //      acListener->wbCamChanged(params->wb.temperature, params->wb.green);    //real temp and tint
 						acListener->wbCamChanged(tempsym, 1.f);    //real temp and tint = 1.
                 }
                 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1913,7 +1913,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     adap = pow(2.0, E_V - 3.0);  // cd / m2
                     // end calculation adaptation scene luminosity
                 }
-				if(params->colorappearance.catmethod == "symg") {
+				if(params->colorappearance.catmethod == "symg") {//force abolute luminance scenescene to 400 in symmetric
 					adap = 400.;
 				}
                 float d, dj, yb;
@@ -1937,7 +1937,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 CAMBrightCurveQ.dirty = true;
 
                 ipf.ciecam_02float(ncie, float (adap), pW, 2, nprevl, params.get(), customColCurve1, customColCurve2, customColCurve3, histLCAM, histCCAM, CAMBrightCurveJ, CAMBrightCurveQ, CAMMean, 0, scale, execsharp, d, dj, yb, 1);
-
+				//call listener
                 if ((params->colorappearance.autodegree || params->colorappearance.autodegreeout) && acListener && params->colorappearance.enabled) {
 					if(params->colorappearance.catmethod == "symg") {//force chromatic adaptation to 90 in symmetric
 						d = 0.9;
@@ -1947,7 +1947,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 }
 
                 if (params->colorappearance.autoadapscen && acListener && params->colorappearance.enabled) {
-                    acListener->adapCamChanged(adap);    //real value of adapt scene
+                    acListener->adapCamChanged(adap);    //real value of adapt scene, force to 400 in symmetric
                 }
 
                 if (params->colorappearance.autoybscen && acListener && params->colorappearance.enabled) {
@@ -1958,7 +1958,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     acListener->ybCamChanged((int) yb);    //real value Yb scene
                 }
 				double tempsym = 5003.;
-				int wmodel = 0;//allows - arbitrary - choice of illuminant and temp with choice
+				int wmodel = 0;//wmodel allows - arbitrary - choice of illuminant and temp with choice
 				if (params->colorappearance.wbmodel == "RawT") {
 					wmodel = 0;
 				} else if (params->colorappearance.wbmodel == "RawTCAT02") {

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -1870,7 +1870,7 @@ void ColorAppearance::wbCamChanged (double temp, double tin)
         {
             disableListener();
             tempout->setValue(temp);
-           // greenout->setValue(tin);
+			greenout->setValue(tin);
             enableListener();
             return false;
         }

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -683,7 +683,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
     tempout->set_tooltip_markup (M ("TP_COLORAPP_TEMP2_TOOLTIP"));
     tempout->throwOnButtonRelease();
     tempout->addAutoButton (M ("TP_COLORAPP_TEMPOUT_TOOLTIP"));
-
+	// I renable tempout with addautobutton to work properly (and all code disabled). There are certainly some redundancies, but it doesn't matter
     tempout->show();
     greenout->show();
     ybout->show();
@@ -1470,12 +1470,12 @@ void ColorAppearance::catmethodChanged()
         ybout->setValue(18);
         tempout->setValue (nexttemp);
     
-    if(tempout->getAutoValue()) {
-        tempout->resetValue (false);
-    } else {
-        tempout->setValue (nexttemp);
-        tempout->setAutoValue (true);
-    }
+		if(tempout->getAutoValue()) {
+			tempout->resetValue (false);
+		} else {
+			tempout->setValue (nexttemp);
+			tempout->setAutoValue (true);
+		}
 
         greenout->setValue (nextgreen);
         enableListener();
@@ -1863,7 +1863,7 @@ void ColorAppearance::adapCamChanged (double cadap)
 
 
 void ColorAppearance::wbCamChanged (double temp, double tin)
-{
+{//reactivate this function
     
     idle_register.add(
         [this, temp, tin]() -> bool

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -681,8 +681,8 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
     ybout->set_tooltip_markup (M ("TP_COLORAPP_YBOUT_TOOLTIP"));
 
     tempout->set_tooltip_markup (M ("TP_COLORAPP_TEMP2_TOOLTIP"));
- //   tempout->throwOnButtonRelease();
- //   tempout->addAutoButton (M ("TP_COLORAPP_TEMPOUT_TOOLTIP"));
+    tempout->throwOnButtonRelease();
+    tempout->addAutoButton (M ("TP_COLORAPP_TEMPOUT_TOOLTIP"));
 
     tempout->show();
     greenout->show();
@@ -822,7 +822,7 @@ void ColorAppearance::neutral_pressed ()
     qcontrast->resetValue (false);
     colorh->resetValue (false);
     tempout->resetValue (false);
-//   tempout->setAutoValue (true);
+	tempout->setAutoValue (true);
     greenout->resetValue (false);
     ybout->resetValue (false);
     tempsc->resetValue (false);
@@ -913,7 +913,7 @@ void ColorAppearance::read (const ProcParams* pp, const ParamsEdited* pedited)
         adapscen->setAutoInconsistent (multiImage && !pedited->colorappearance.autoadapscen);
         ybscen->setAutoInconsistent (multiImage && !pedited->colorappearance.autoybscen);
         set_inconsistent              (multiImage && !pedited->colorappearance.enabled);
-    //    tempout->setAutoInconsistent   (multiImage && !pedited->colorappearance.autotempout);
+        tempout->setAutoInconsistent   (multiImage && !pedited->colorappearance.autotempout);
 
         shape->setUnChanged (!pedited->colorappearance.curve);
         shape2->setUnChanged (!pedited->colorappearance.curve2);
@@ -1098,7 +1098,7 @@ void ColorAppearance::read (const ProcParams* pp, const ParamsEdited* pedited)
     lastAutoAdapscen = pp->colorappearance.autoadapscen;
     lastAutoDegreeout = pp->colorappearance.autodegreeout;
     lastAutoybscen = pp->colorappearance.autoybscen;
-//    lastAutotempout = pp->colorappearance.autotempout;
+    lastAutotempout = pp->colorappearance.autotempout;
 
     degree->setValue (pp->colorappearance.degree);
     degree->setAutoValue (pp->colorappearance.autodegree);
@@ -1121,7 +1121,7 @@ void ColorAppearance::read (const ProcParams* pp, const ParamsEdited* pedited)
     qcontrast->setValue (pp->colorappearance.qcontrast);
     colorh->setValue (pp->colorappearance.colorh);
     tempout->setValue (pp->colorappearance.tempout);
-//    tempout->setAutoValue (pp->colorappearance.autotempout);
+	tempout->setAutoValue (pp->colorappearance.autotempout);
     greenout->setValue (pp->colorappearance.greenout);
     ybout->setValue (pp->colorappearance.ybout);
     tempsc->setValue (pp->colorappearance.tempsc);
@@ -1185,7 +1185,7 @@ void ColorAppearance::write (ProcParams* pp, ParamsEdited* pedited)
     pp->colorappearance.curve2        = shape2->getCurve ();
     pp->colorappearance.curve3        = shape3->getCurve ();
     pp->colorappearance.tempout        = tempout->getValue ();
-//    pp->colorappearance.autotempout    = tempout->getAutoValue ();
+    pp->colorappearance.autotempout    = tempout->getAutoValue ();
     pp->colorappearance.greenout        = greenout->getValue ();
     pp->colorappearance.ybout        = ybout->getValue ();
     pp->colorappearance.tempsc        = tempsc->getValue ();
@@ -1263,7 +1263,7 @@ void ColorAppearance::write (ProcParams* pp, ParamsEdited* pedited)
         pedited->colorappearance.ybout        = ybout->getEditedState ();
         pedited->colorappearance.tempsc        = tempsc->getEditedState ();
         pedited->colorappearance.greensc        = greensc->getEditedState ();
-//        pedited->colorappearance.autotempout    = !tempout->getAutoInconsistent();
+        pedited->colorappearance.autotempout    = !tempout->getAutoInconsistent();
 
     }
 
@@ -1470,13 +1470,13 @@ void ColorAppearance::catmethodChanged()
         ybout->setValue(18);
         tempout->setValue (nexttemp);
     
-/*    if(tempout->getAutoValue()) {
+    if(tempout->getAutoValue()) {
         tempout->resetValue (false);
     } else {
         tempout->setValue (nexttemp);
         tempout->setAutoValue (true);
     }
-*/
+
         greenout->setValue (nextgreen);
         enableListener();
     
@@ -1525,7 +1525,7 @@ void ColorAppearance::catmethodChanged()
         adaplum->resetValue (false);
         degreeout->resetValue (false);
         ybout->resetValue (false);
-       // tempout->resetValue (false);
+        tempout->resetValue (false);
         tempout->setValue (nexttemp);
         greenout->resetValue (false);
         enableListener();
@@ -1870,7 +1870,7 @@ void ColorAppearance::wbCamChanged (double temp, double tin)
         {
             disableListener();
             tempout->setValue(temp);
-            greenout->setValue(tin);
+           // greenout->setValue(tin);
             enableListener();
             return false;
         }
@@ -1999,7 +1999,7 @@ void ColorAppearance::adjusterAutoToggled(Adjuster* a)
             ybscen->setAutoInconsistent (true);
         }
 
-/*        lastAutotempout = tempout->getAutoValue();
+        lastAutotempout = tempout->getAutoValue();
 
         if (tempout->getAutoInconsistent()) {
             tempout->setAutoInconsistent (false);
@@ -2009,7 +2009,7 @@ void ColorAppearance::adjusterAutoToggled(Adjuster* a)
         }
 
         lastAutotempout = tempout->getAutoValue();
-*/
+
     }
     if (listener && (multiImage || getEnabled()) ) {
 
@@ -2053,7 +2053,7 @@ void ColorAppearance::adjusterAutoToggled(Adjuster* a)
                 listener->panelChanged (EvCATAutoyb, M ("GENERAL_DISABLED"));
             }
         }
-/*
+
         if (a == tempout) {
             if (tempout->getAutoInconsistent()) {
                 listener->panelChanged (EvCATAutotempout, M ("GENERAL_UNCHANGED"));
@@ -2063,7 +2063,7 @@ void ColorAppearance::adjusterAutoToggled(Adjuster* a)
                 listener->panelChanged (EvCATAutotempout, M ("GENERAL_DISABLED"));
             }
         }
-*/
+
     }
 }
 void ColorAppearance::enabledChanged ()

--- a/rtgui/colorappearance.cc
+++ b/rtgui/colorappearance.cc
@@ -687,8 +687,16 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, "colorappearance"
     tempout->show();
     greenout->show();
     ybout->show();
-    p3VBox->pack_start (*tempout);
-    p3VBox->pack_start (*greenout);
+    Gtk::Frame *tempgreenFrame;
+    tempgreenFrame = Gtk::manage(new Gtk::Frame());
+    tempgreenFrame->set_label_align (0.025, 0.5);
+    Gtk::Box* tempgreenVBox;
+    tempgreenVBox = Gtk::manage ( new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
+    tempgreenVBox->set_spacing (2);
+    tempgreenVBox->pack_start (*tempout);
+	tempgreenVBox->pack_start (*greenout);
+	tempgreenFrame->add(*tempgreenVBox);
+    p3VBox->pack_start(*tempgreenFrame);
     p3VBox->pack_start (*ybout);
 
     Gtk::Box* surrHBox = Gtk::manage (new Gtk::Box ());
@@ -1355,7 +1363,9 @@ void ColorAppearance::updateGUIToMode(int mode)
         curveEditorG->hide();
         curveEditorG2->hide();
         curveEditorG3->hide();
-        greenout->hide();
+        //greenout->hide();
+        greenout->set_sensitive(false);
+		
         badpixsl->hide();
         datacie->hide();
     } else {
@@ -1364,7 +1374,8 @@ void ColorAppearance::updateGUIToMode(int mode)
         curveEditorG->show();
         curveEditorG2->show();
         curveEditorG3->show();
-        greenout->show();
+      //  greenout->show();
+        greenout->set_sensitive(true);
         badpixsl->show();
         datacie->show();
     }


### PR DESCRIPTION
See text in issue #6656 

With the modifications made, in "automatic symmectric" mode there may remain small differences. These are related to the precision of the algorithms (normal and inverse) and the change from "double" to "float" a few years ago (2015?) to save time and memory.

Admittedly, it's not "perfect", but very close to the objectives.
Reminder, it is more than normal that in "Classic" mode there are differences in colorimetry and contrast... this is the purpose of a CAM

jacques