### PR TITLE
External editor fixes for Windows

### DIFF
--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -1278,6 +1278,11 @@ menuitem:hover > * {
     color: @text-hl-color;
 }
 
+menu menuitem > radio + * image:not(.dummy),
+#MyExpander menu menuitem > radio + * image:not(.dummy) {
+    margin-left: 1pt;
+}
+
 menu image:not(.dummy),
 #MyExpander menu image:not(.dummy) {
     min-height: 2em;

--- a/rtdata/themes/size - Legacy.css
+++ b/rtdata/themes/size - Legacy.css
@@ -383,6 +383,11 @@ menu arrow {
     margin: 0 -0.25em 0 0;
 }
 
+menu menuitem > radio + * image:not(.dummy),
+#MyExpander menu menuitem > radio + * image:not(.dummy) {
+    margin-left: 1pt;
+}
+
 menu image:not(.dummy),
 #MyExpander menu image:not(.dummy) {
     min-height: 2em;

--- a/rtdata/themes/size.css
+++ b/rtdata/themes/size.css
@@ -351,6 +351,11 @@ menu arrow {
     margin: 0 -0.25em 0 0;
 }
 
+menu menuitem > radio + * image:not(.dummy),
+#MyExpander menu menuitem > radio + * image:not(.dummy) {
+    margin-left: 1pt;
+}
+
 menu image:not(.dummy),
 #MyExpander menu image:not(.dummy) {
     min-height: 2em;

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -246,6 +246,7 @@ private:
     Gtk::Button* queueimg;
     Gtk::Button* saveimgas;
     PopUpButton* send_to_external;
+    Gtk::RadioButtonGroup send_to_external_radio_group;
     Gtk::Button* navSync;
     Gtk::Button* navNext;
     Gtk::Button* navPrev;

--- a/rtgui/externaleditorpreferences.cc
+++ b/rtgui/externaleditorpreferences.cc
@@ -274,7 +274,11 @@ void ExternalEditorPreferences::openFileChooserDialog()
     const auto exe_filter = Gtk::FileFilter::create();
     exe_filter->set_name(M("FILECHOOSER_FILTER_EXECUTABLE"));
     exe_filter->add_custom(Gtk::FILE_FILTER_MIME_TYPE, [](const Gtk::FileFilter::Info &info) {
+#ifdef WIN32
+        return info.mime_type == "application/x-msdownload";
+#else
         return Gio::content_type_can_be_executable(info.mime_type);
+#endif
     });
     const auto all_filter = Gtk::FileFilter::create();
     all_filter->set_name(M("FILECHOOSER_FILTER_ANY"));

--- a/rtgui/extprog.cc
+++ b/rtgui/extprog.cc
@@ -318,22 +318,26 @@ bool ExtProgStore::openInPhotoshop (const Glib::ustring& fileName)
     return spawnCommandAsync (cmdLine);
 }
 
-bool ExtProgStore::openInCustomEditor (const Glib::ustring& fileName)
+bool ExtProgStore::openInCustomEditor (const Glib::ustring& fileName, const Glib::ustring* command)
 {
+    if (!command) {
+        command = &(options.customEditorProg);
+    }
+
 #if defined WIN32
 
-    const auto cmdLine = Glib::ustring("\"") + options.customEditorProg + Glib::ustring("\"");
+    const auto cmdLine = Glib::ustring("\"") + *command + Glib::ustring("\"");
     auto success = ShellExecute( NULL, "open", cmdLine.c_str(), ('"' + fileName + '"').c_str(), NULL, SW_SHOWNORMAL );
     return (uintptr_t)success > 32;
 
 #elif defined __APPLE__
 
-    const auto cmdLine = options.customEditorProg + Glib::ustring(" \"") + fileName + Glib::ustring("\"");
+    const auto cmdLine = *command + Glib::ustring(" \"") + fileName + Glib::ustring("\"");
     return spawnCommandAsync (cmdLine);
 
 #else
 
-    const auto cmdLine = options.customEditorProg + Glib::ustring(" ") + Glib::shell_quote(fileName);
+    const auto cmdLine = *command + Glib::ustring(" ") + Glib::shell_quote(fileName);
     return spawnCommandAsync (cmdLine);
 
 #endif
@@ -342,13 +346,30 @@ bool ExtProgStore::openInCustomEditor (const Glib::ustring& fileName)
 
 bool ExtProgStore::openInExternalEditor(const Glib::ustring &fileName, const Glib::RefPtr<Gio::AppInfo> &editorInfo)
 {
+    bool success = false;
+
     try {
-        return editorInfo->launch(Gio::File::create_for_path(fileName));
+        success = editorInfo->launch(Gio::File::create_for_path(fileName));
     } catch (const Glib::Error &e) {
         std::cerr
             << "Error launching external editor.\n"
             << "Error code #" << e.code() << ": " << e.what()
             << std::endl;
-        return false;
+        success = false;
     }
+
+    if (success) {
+        return true;
+    }
+
+    if (rtengine::settings->verbose) {
+        std::cout << "Unable to launch external editor with Gio. Trying custom launcher." << std::endl;
+    }
+    Glib::ustring command = editorInfo->get_commandline();
+#if defined WIN32
+    if (command.length() > 2 && command[0] == '"' && command[command.length() - 1] == '"') {
+        command = command.substr(1, command.length() - 2);
+    }
+#endif
+    return openInCustomEditor(fileName, &command);
 }

--- a/rtgui/extprog.h
+++ b/rtgui/extprog.h
@@ -69,7 +69,7 @@ public:
 
     static bool openInGimp (const Glib::ustring& fileName);
     static bool openInPhotoshop (const Glib::ustring& fileName);
-    static bool openInCustomEditor (const Glib::ustring& fileName);
+    static bool openInCustomEditor (const Glib::ustring& fileName, const Glib::ustring* command = nullptr);
     static bool openInExternalEditor(const Glib::ustring &fileName, const Glib::RefPtr<Gio::AppInfo> &editorInfo);
 };
 

--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -1506,48 +1506,110 @@ TextOrIcon::TextOrIcon (const Glib::ustring &fname, const Glib::ustring &labelTx
 
 }
 
-MyImageMenuItem::MyImageMenuItem(Glib::ustring label, Glib::ustring imageFileName)
+class ImageAndLabel::Impl
 {
-    RTImage* itemImage = nullptr;
+public:
+    RTImage* image;
+    Gtk::Label* label;
 
-    if (!imageFileName.empty()) {
-        itemImage = Gtk::manage(new RTImage(imageFileName));
+    Impl(RTImage* image, Gtk::Label* label) : image(image), label(label) {}
+    static std::unique_ptr<RTImage> createImage(const Glib::ustring& fileName);
+};
+
+std::unique_ptr<RTImage> ImageAndLabel::Impl::createImage(const Glib::ustring& fileName)
+{
+    if (fileName.empty()) {
+        return nullptr;
     }
-
-    construct(label, itemImage);
+    return std::unique_ptr<RTImage>(new RTImage(fileName));
 }
 
-MyImageMenuItem::MyImageMenuItem(Glib::ustring label, RTImage* itemImage) {
-    construct(label, itemImage);
+ImageAndLabel::ImageAndLabel(const Glib::ustring& label, const Glib::ustring& imageFileName) :
+    ImageAndLabel(label, Gtk::manage(Impl::createImage(imageFileName).release()))
+{
 }
 
-void MyImageMenuItem::construct(Glib::ustring label, RTImage* itemImage)
+ImageAndLabel::ImageAndLabel(const Glib::ustring& label, RTImage *image) :
+    pimpl(new Impl(image, Gtk::manage(new Gtk::Label(label))))
 {
-    box = Gtk::manage (new Gtk::Grid());
-    this->label = Gtk::manage( new Gtk::Label(label));
-    box->set_orientation(Gtk::ORIENTATION_HORIZONTAL);
+    Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
+    grid->set_orientation(Gtk::ORIENTATION_HORIZONTAL);
 
-    if (itemImage) {
-        image = itemImage;
-        box->attach_next_to(*image, Gtk::POS_LEFT, 1, 1);
-    } else {
-        image = nullptr;
+    if (image) {
+        grid->attach_next_to(*image, Gtk::POS_LEFT, 1, 1);
     }
 
-    box->attach_next_to(*this->label, Gtk::POS_RIGHT, 1, 1);
-    box->set_column_spacing(4);
-    box->set_row_spacing(0);
-    add(*box);
+    grid->attach_next_to(*(pimpl->label), Gtk::POS_RIGHT, 1, 1);
+    grid->set_column_spacing(4);
+    grid->set_row_spacing(0);
+    pack_start(*grid, Gtk::PACK_SHRINK, 0);
+}
+
+const RTImage* ImageAndLabel::getImage() const
+{
+    return pimpl->image;
+}
+
+const Gtk::Label* ImageAndLabel::getLabel() const
+{
+    return pimpl->label;
+}
+
+class MyImageMenuItem::Impl
+{
+private:
+    std::unique_ptr<ImageAndLabel> widget;
+
+public:
+    Impl(const Glib::ustring &label, const Glib::ustring &imageFileName) :
+        widget(new ImageAndLabel(label, imageFileName)) {}
+    Impl(const Glib::ustring &label, RTImage *itemImage) :
+        widget(new ImageAndLabel(label, itemImage)) {}
+    ImageAndLabel* getWidget() const { return widget.get(); }
+};
+
+MyImageMenuItem::MyImageMenuItem(const Glib::ustring& label, const Glib::ustring& imageFileName) :
+    pimpl(new Impl(label, imageFileName))
+{
+    add(*(pimpl->getWidget()));
+}
+
+MyImageMenuItem::MyImageMenuItem(const Glib::ustring& label, RTImage* itemImage) :
+    pimpl(new Impl(label, itemImage))
+{
+    add(*(pimpl->getWidget()));
 }
 
 const RTImage *MyImageMenuItem::getImage () const
 {
-    return image;
+    return pimpl->getWidget()->getImage();
 }
 
 const Gtk::Label* MyImageMenuItem::getLabel () const
 {
-    return label;
+    return pimpl->getWidget()->getLabel();
+}
+
+class MyRadioImageMenuItem::Impl
+{
+    std::unique_ptr<ImageAndLabel> widget;
+
+public:
+    Impl(const Glib::ustring &label, RTImage *image) :
+        widget(new ImageAndLabel(label, image)) {}
+    ImageAndLabel* getWidget() const { return widget.get(); }
+};
+
+MyRadioImageMenuItem::MyRadioImageMenuItem(const Glib::ustring& label, RTImage *image, Gtk::RadioButton::Group& group) :
+    Gtk::RadioMenuItem(group),
+    pimpl(new Impl(label, image))
+{
+    add(*(pimpl->getWidget()));
+}
+
+const Gtk::Label* MyRadioImageMenuItem::getLabel() const
+{
+    return pimpl->getWidget()->getLabel();
 }
 
 MyProgressBar::MyProgressBar(int width) : w(rtengine::max(width, 10 * RTScalable::getScale())) {}

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -482,20 +482,56 @@ public:
     TextOrIcon (const Glib::ustring &filename, const Glib::ustring &labelTx, const Glib::ustring &tooltipTx);
 };
 
-class MyImageMenuItem final : public Gtk::MenuItem
+/**
+ * Widget with image and label placed horizontally.
+ */
+class ImageAndLabel final : public Gtk::Box
 {
-private:
-    Gtk::Grid *box;
-    RTImage *image;
-    Gtk::Label *label;
-
-    void construct(Glib::ustring label, RTImage* image);
+    class Impl;
+    std::unique_ptr<Impl> pimpl;
 
 public:
-    MyImageMenuItem (Glib::ustring label, Glib::ustring imageFileName);
-    MyImageMenuItem (Glib::ustring label, RTImage* image);
+    ImageAndLabel(const Glib::ustring& label, const Glib::ustring& imageFileName);
+    ImageAndLabel(const Glib::ustring& label, RTImage* image);
+    const RTImage* getImage() const;
+    const Gtk::Label* getLabel() const;
+};
+
+/**
+ * Menu item with an image and label.
+ */
+class MyImageMenuItemInterface
+{
+public:
+    virtual const Gtk::Label* getLabel() const = 0;
+};
+
+/**
+ * Basic image menu item.
+ */
+class MyImageMenuItem final : public Gtk::MenuItem, public MyImageMenuItemInterface
+{
+    class Impl;
+    std::unique_ptr<Impl> pimpl;
+
+public:
+    MyImageMenuItem (const Glib::ustring& label, const Glib::ustring& imageFileName);
+    MyImageMenuItem (const Glib::ustring& label, RTImage* image);
     const RTImage *getImage () const;
-    const Gtk::Label* getLabel () const;
+    const Gtk::Label* getLabel() const override;
+};
+
+/**
+ * Image menu item with radio selector.
+ */
+class MyRadioImageMenuItem final : public Gtk::RadioMenuItem, public MyImageMenuItemInterface
+{
+    class Impl;
+    std::unique_ptr<Impl> pimpl;
+
+public:
+    MyRadioImageMenuItem(const Glib::ustring& label, RTImage* image, Gtk::RadioButton::Group& group);
+    const Gtk::Label* getLabel() const override;
 };
 
 class MyProgressBar final : public Gtk::ProgressBar

--- a/rtgui/popupcommon.h
+++ b/rtgui/popupcommon.h
@@ -40,6 +40,7 @@ class Grid;
 class Menu;
 class Button;
 class ImageMenuItem;
+class RadioButtonGroup;
 class Widget;
 
 }
@@ -60,9 +61,9 @@ public:
 
     explicit PopUpCommon (Gtk::Button* button, const Glib::ustring& label = "");
     virtual ~PopUpCommon ();
-    bool addEntry (const Glib::ustring& fileName, const Glib::ustring& label);
-    bool insertEntry(int position, const Glib::ustring& fileName, const Glib::ustring& label);
-    bool insertEntry(int position, const Glib::RefPtr<const Gio::Icon>& gIcon, const Glib::ustring& label);
+    bool addEntry (const Glib::ustring& fileName, const Glib::ustring& label, Gtk::RadioButtonGroup* radioGroup = nullptr);
+    bool insertEntry(int position, const Glib::ustring& fileName, const Glib::ustring& label, Gtk::RadioButtonGroup* radioGroup = nullptr);
+    bool insertEntry(int position, const Glib::RefPtr<const Gio::Icon>& gIcon, const Glib::ustring& label, Gtk::RadioButtonGroup* radioGroup = nullptr);
     int getEntryCount () const;
     bool setSelected (int entryNum);
     int  getSelected () const;
@@ -91,7 +92,7 @@ private:
     void changeImage(int position);
     void changeImage(const Glib::ustring& fileName, const Glib::RefPtr<const Gio::Icon>& gIcon);
     void entrySelected(Gtk::Widget* menuItem);
-    bool insertEntryImpl(int position, const Glib::ustring& fileName, const Glib::RefPtr<const Gio::Icon>& gIcon, RTImage* image, const Glib::ustring& label);
+    bool insertEntryImpl(int position, const Glib::ustring& fileName, const Glib::RefPtr<const Gio::Icon>& gIcon, RTImage* image, const Glib::ustring& label, Gtk::RadioButtonGroup* radioGroup);
     void showMenu(GdkEventButton* event);
 
 protected:

--- a/rtgui/rtwindow.h
+++ b/rtgui/rtwindow.h
@@ -33,7 +33,7 @@
 class BatchQueueEntry;
 class BatchQueuePanel;
 class EditorPanel;
-class ExternalEditor;
+struct ExternalEditor;
 class FilePanel;
 class PLDBridge;
 class RTWindow final :


### PR DESCRIPTION
See https://discuss.pixls.us/t/5-9-can-not-launch-external-editor/34606. For some reason, certain applications do not launch properly when using the improved external editor feature.

This introduces a fallback to the previous application launcher and fixes the executable file picker filter so that `.exe`s are shown by default.