### PR TITLE
Add missing include for GCC13 compatibility

### DIFF
--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 #include "myfile.h"


### PR DESCRIPTION
This #include is needed for correct build on Fedora 38 with GCC 13, see https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Mattia Verga <mattia.verga@tiscali.it>