### PR TITLE
Add libsharpyuv-0.dll to Windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -155,6 +155,7 @@ jobs:
             "libpixman-1-0.dll" \
             "libpng16-16.dll" \
             "librsvg-2-2.dll" \
+            "libsharpyuv-0.dll" \
             "libsigc-2.0-0.dll" \
             "libstdc++-6.dll" \
             "libsystre-0.dll" \


### PR DESCRIPTION
libwebp-7.dll now depends on libsharpyuv-0.dll. Adding the DLL to the Windows package makes it runnable in Wine again and I assume it will work on Windows too.

Closes #6671.