### PR TITLE
RT crush when using before/after + abstruct Profile #6663

### DIFF
--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -163,6 +163,7 @@ ImProcCoordinator::ImProcCoordinator() :
     imageTypeListener(nullptr),
     filmNegListener(nullptr),
     actListener(nullptr),
+    primListener(nullptr),
     adnListener(nullptr),
     awavListener(nullptr),
     dehaListener(nullptr),


### PR DESCRIPTION
Hey, 

As described in the bug, there was a crash when using the before and after function after doing some adjustments to the photo. 
I managed to track the problem to a bad pointer in `rtengine/improccoordinator.cc:1865 ` (`rtengine::ImProcCoordinator::updatePreviewImage`). What was happening was that is that when using the before/after function a new `ImProcCoordinator` object is created. The problem was that `primListener` was never initialized  with `NULL` and it contained garbage and the member wasn't set by `ToolPanelCoordinator`. The logic inside `updatePreviewImage` seems good as the member was checked for `NULL` before using it. 

As for the fix, just initializing the member with `NULL` seems to have solved the problem. If you think any other changes or analysis is needed please let me know but it's clear that we should initialize the variable with `NULL`. 

Thank you,
Daniel  