### PR TITLE
PDAF lines filter crashes with RAWs from Nikon Z 50

### DIFF
--- a/rtengine/pdaflinesfilter.cc
+++ b/rtengine/pdaflinesfilter.cc
@@ -275,7 +275,11 @@ int PDAFLinesFilter::mark(const array2D<float> &rawData, PixelsMap &bpMap)
     for (int y = 1; y < H_-1; ++y) {
         int yy = pattern_[idx] + off;
         if (y == yy) {
-            int n = markLine(rawData, bpMap, y) + markLine(rawData, bpMap, y-1) + markLine(rawData, bpMap, y+1);
+            int n = 0;
+            n += markLine(rawData, bpMap, y);
+            n += (y-1 <= 0   ) ? 0 : markLine(rawData, bpMap, y-1);
+            n += (y+1 >= H_-1) ? 0 : markLine(rawData, bpMap, y+1);
+            
             if (n) {
                 found += n;
                 if (settings->verbose) {


### PR DESCRIPTION
Hey, 

Link to the original issue #6630 . I tested it and it was crashing in windows 10 as well. 

There seems to be a problem in the logic of the pdfa filter, `PDAFLinesFilter::markLine` might get out of the bounds of the image as `PDAFLinesFilter::mark` will try to mark the adjacent lines as well for a specific row and  `PDAFLinesFilter::markLine` it's looking at the adjacent lines as well. So, this will give an effective offset of 2 lines ... 

The crash was happening on the last row but it should have happened for the first row as well. I think this was not the case because the pattern in `PDAFLinesFilter::mark` might have prevented that. I saw that this pattern in static and loaded from some file ... so maybe we could make an update on that pattern to exclude the second to last line as well ? 

For the moment, I added some extra checks for boundaries in `PDAFLinesFilter::mark`. This solved the crash and I belief it's side effect free. I tough that maybe changing the logic in `PDAFLinesFilter::markLine` to do some bound check might be better, but then we should give `g2` and `g4` some dummy values when they get out of image's bounds. For example, trying `0` would result in the line not being marked, same if the dummy value is some big negative float. So I thought it might be better to skip the call to `markLine` altogether. 

On the [Rawpedia ](https://rawpedia.rawtherapee.com/Preprocessing) I found this in the documentation: 
```
RawTherapee 5.5 can fix Nikon PDAF banding artifacts for the following cameras:
- Nikon Z 6
- Nikon Z 7
```
So maybe the Nikon Z 5 is not supported and it's expected not to work ?

Please let me know your opinion about what would be the best course of action.

Thank you,
Daniel 