### PR TITLE
Fix the buffer-size computation flow of exif marker of JPEG

### DIFF
--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -1027,7 +1027,7 @@ int ImageIO::savePNG  (const Glib::ustring &fname, int bps) const
 #if defined(PNG_SKIP_sRGB_CHECK_PROFILE) && defined(PNG_SET_OPTION_SUPPORTED)
     png_set_option(png, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
 #endif
-    
+
     png_infop info = png_create_info_struct(png);
 
     if (!info) {
@@ -1227,12 +1227,12 @@ int ImageIO::saveJPEG (const Glib::ustring &fname, int quality, int subSamp) con
     jpeg_start_compress(&cinfo, TRUE);
 
     // buffer for exif and iptc markers
-    unsigned char* buffer = new unsigned char[165535]; //FIXME: no buffer size check so it can be overflowed in createJPEGMarker() for large tags, and then software will crash
+    unsigned char* buffer;
     unsigned int size;
 
     // assemble and write exif marker
     if (exifRoot) {
-        int size = rtexif::ExifManager::createJPEGMarker (exifRoot, *exifChange, cinfo.image_width, cinfo.image_height, buffer);
+        rtexif::ExifManager::createJPEGMarker (exifRoot, *exifChange, cinfo.image_width, cinfo.image_height, buffer, size);
 
         if (size > 0 && size < 65530) {
             jpeg_write_marker(&cinfo, JPEG_APP0 + 1, buffer, size);

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -1250,9 +1250,10 @@ int ImageIO::saveJPEG (const Glib::ustring &fname, int quality, int subSamp) con
     // assemble and write iptc marker
     if (iptc) {
         unsigned char* iptcdata;
+        unsigned int iptcSize;
         bool error = false;
 
-        if (iptc_data_save (iptc, &iptcdata, &size)) {
+        if (iptc_data_save (iptc, &iptcdata, &iptcSize)) {
             if (iptcdata) {
                 iptc_data_free_buf (iptc, iptcdata);
             }
@@ -1262,7 +1263,7 @@ int ImageIO::saveJPEG (const Glib::ustring &fname, int quality, int subSamp) con
 
         int bytes = 0;
 
-        if (!error && (bytes = iptc_jpeg_ps3_save_iptc (nullptr, 0, iptcdata, size, iptcBuffer, 65532)) < 0) {
+        if (!error && (bytes = iptc_jpeg_ps3_save_iptc (nullptr, 0, iptcdata, iptcSize, iptcBuffer, 65532)) < 0) {
             error = true;
         }
 

--- a/rtexif/rtexif.cc
+++ b/rtexif/rtexif.cc
@@ -3243,7 +3243,7 @@ std::vector<Tag*> ExifManager::getDefaultTIFFTags (TagDirectory* forthis)
 
 
 
-int ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize)
+void ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize)
 {
 
     // write tiff header
@@ -3324,11 +3324,9 @@ int ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::pro
     offs += 2;
     sset4 (8, buffer + offs, order);
 
-    int endOffs = cl->write (8, buffer + 6);
+    cl->write (8, buffer + 6);
 
     delete cl;
-
-    return endOffs;
 }
 
 int ExifManager::createPNGMarker(const TagDirectory* root, const rtengine::procparams::ExifPairs &changeList, int W, int H, int bps, const char* iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize)

--- a/rtexif/rtexif.cc
+++ b/rtexif/rtexif.cc
@@ -3243,23 +3243,16 @@ std::vector<Tag*> ExifManager::getDefaultTIFFTags (TagDirectory* forthis)
 
 
 
-int ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char* buffer)
+int ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize)
 {
 
     // write tiff header
-    int offs = 6;
-    memcpy (buffer, "Exif\0\0", 6);
+    int offs = 6; // "Exif\0\0"
     ByteOrder order = INTEL;
 
     if (root) {
         order = root->getOrder ();
     }
-
-    sset2 ((unsigned short)order, buffer + offs, order);
-    offs += 2;
-    sset2 (42, buffer + offs, order);
-    offs += 2;
-    sset4 (8, buffer + offs, order);
 
     TagDirectory* cl;
 
@@ -3322,11 +3315,20 @@ int ExifManager::createJPEGMarker (const TagDirectory* root, const rtengine::pro
     }
 
     cl->sort ();
-    int size = cl->write (8, buffer + 6);
+    bufferSize = cl->calculateSize() + 8 + 6;
+    buffer = new unsigned char[bufferSize]; // this has to be deleted in caller
+    memcpy (buffer, "Exif\0\0", 6);
+    sset2 ((unsigned short)order, buffer + offs, order);
+    offs += 2;
+    sset2 (42, buffer + offs, order);
+    offs += 2;
+    sset4 (8, buffer + offs, order);
+
+    int endOffs = cl->write (8, buffer + 6);
 
     delete cl;
 
-    return size + 6;
+    return endOffs;
 }
 
 int ExifManager::createPNGMarker(const TagDirectory* root, const rtengine::procparams::ExifPairs &changeList, int W, int H, int bps, const char* iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize)

--- a/rtexif/rtexif.h
+++ b/rtexif/rtexif.h
@@ -379,7 +379,7 @@ public:
     /// @param forthis The byte order will be taken from the given directory.
     /// @return The ownership of the return tags is passed to the caller.
     static std::vector<Tag*> getDefaultTIFFTags (TagDirectory* forthis);
-    static int    createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize);
+    static void   createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize);
     static int    createTIFFHeader (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, int bps, const char* profiledata, int profilelen, const char* iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize);
     static int createPNGMarker(const TagDirectory *root, const rtengine::procparams::ExifPairs &changeList, int W, int H, int bps, const char *iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize);
 };

--- a/rtexif/rtexif.h
+++ b/rtexif/rtexif.h
@@ -379,7 +379,7 @@ public:
     /// @param forthis The byte order will be taken from the given directory.
     /// @return The ownership of the return tags is passed to the caller.
     static std::vector<Tag*> getDefaultTIFFTags (TagDirectory* forthis);
-    static int    createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char* buffer);
+    static int    createJPEGMarker (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, unsigned char *&buffer, unsigned &bufferSize);
     static int    createTIFFHeader (const TagDirectory* root, const rtengine::procparams::ExifPairs& changeList, int W, int H, int bps, const char* profiledata, int profilelen, const char* iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize);
     static int createPNGMarker(const TagDirectory *root, const rtengine::procparams::ExifPairs &changeList, int W, int H, int bps, const char *iptcdata, int iptclen, unsigned char *&buffer, unsigned &bufferSize);
 };


### PR DESCRIPTION
Hello, 

This pull-request aims to fix the computation flow of the size of JPEG marker buffer. The "buffer" is at line 1230 of `rtengine/imageio.cc`( `ImageIO::saveJPEG` ). 

https://github.com/Beep6581/RawTherapee/blob/23408bfcb3117404af376d24bad07e011e8f0fb2/rtengine/imageio.cc#L1230

In previously, it initialized as fixed length array that length is `165535` so RawTherapee will crash when that render a jpeg image with large exif data (Actually, I encountered this bug). This PR will fix this bug.

The crash bug had caused by the (fixed-size) buffer overflowed by large exif data. so I modified three files as follows:

* `rtexif/rtexif.cc`: Fix `ExifManager::createJPEGMarker` as like as `ExifManager::createPNGMarker`. 
  - `ExifManager::createJPEGMarker` assumed the given buffer has been initialized as an array that have sufficient size. 
  - In `ExifManager::createPNGMarker`, It'll initialize the given buffer by computed buffer size. 
  - After this PR, `ExifManager::createJPEGMarker` will not trust the given buffer. It compute the size of buffer needs, then initialize the buffer. 
* `rtexif/rtexif.h`: Follows the change of the signature of `ExifManager::createJPEGMarker`.
* `rtengine/imageio.cc`: Follows the change of the signature, and separate buffer variable.
  - Previously, the buffer uses as marker buffer of exif and iptc.
  - After this PR, "the buffer for exif" and "the buffer for iptc" will separate. 

Thanks and sorry for the bad English.
Shiho