### PR TITLE
Add missing fftw libraries for Windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,7 +123,6 @@ jobs:
             libffi-*.dll \
             "libfftw3f-3.dll" \
             "libfftw3f_omp-3.dll" \
-            "libfftw3f_threads-3.dll" \
             "libfontconfig-1.dll" \
             "libfreetype-6.dll" \
             "libfribidi-0.dll" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Bundle dependencies
         run: |
+          echo "Listing shared library dependencies."
+          ldd "./build/${{matrix.build_type}}/rawtherapee.exe"
           echo "Getting workspace path."
           export BUILD_DIR="$(pwd)/build/${{matrix.build_type}}"
           echo "Build directory is '$BUILD_DIR'."
@@ -120,6 +122,8 @@ jobs:
             "libexpat-1.dll" \
             libffi-*.dll \
             "libfftw3f-3.dll" \
+            "libfftw3f_omp-3.dll" \
+            "libfftw3f_threads-3.dll" \
             "libfontconfig-1.dll" \
             "libfreetype-6.dll" \
             "libfribidi-0.dll" \


### PR DESCRIPTION
Attempt to fix the missing DLL error. In the future, we should use something like ldd to include all the required libraries.

Closes #6701.