### PR TITLE
Fix missing explicit include

### DIFF
--- a/rtengine/alpha.h
+++ b/rtengine/alpha.h
@@ -19,7 +19,7 @@
 #ifndef _ALPHA_H_
 #define _ALPHA_H_
 
-#include <gtkmm.h>
+#include <cairomm/cairomm.h>
 #include <assert.h>
 
 #define CHECK_BOUNDS 0

--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -18,6 +18,9 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <glibmm/ustring.h>
+#include <glibmm/timer.h>
+
 #include "cieimage.h"
 #include "color.h"
 #include "curves.h"

--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -17,6 +17,7 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cstring>
+#include <map>
 
 #include <glibmm/ustring.h>
 #include <glibmm/fileutils.h>

--- a/rtengine/init.cc
+++ b/rtengine/init.cc
@@ -17,7 +17,8 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <fftw3.h>
-#include "../rtgui/profilestorecombobox.h"
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
 #include "color.h"
 #include "rtengine.h"
 #include "iccstore.h"

--- a/rtengine/profilestore.cc
+++ b/rtengine/profilestore.cc
@@ -17,6 +17,9 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
+#include <map>
+
 #include <glibmm/fileutils.h>
 #include <glibmm/miscutils.h>
 

--- a/rtengine/profilestore.h
+++ b/rtengine/profilestore.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <list>
 #include <map>
 #include <vector>
 

--- a/rtgui/editcallbacks.h
+++ b/rtgui/editcallbacks.h
@@ -18,6 +18,8 @@
  */
 #pragma once
 
+#include <vector>
+
 #include "editid.h"
 #include "cursormanager.h"
 #include "../rtengine/coord.h"

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -19,7 +19,11 @@
 #include "options.h"
 #include <cstdio>
 #include <glib/gstdio.h>
+#include <glibmm/date.h>
+#include <glibmm/fileutils.h>
 #include <glibmm/keyfile.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/regex.h>
 #include <iostream>
 #include <sstream>
 #include "multilangmgr.h"


### PR DESCRIPTION
- Also avoid rtgui include

For the context, I'm trying to build rtengine without depending on gtkmm, and with glibmm-2.68, and these are the "trivial" changes that don't impact the current code.

Let me know if you have further questions.