### PR TITLE
Mac: add CR3 defalut handling

### DIFF
--- a/tools/osx/Info.plist.in
+++ b/tools/osx/Info.plist.in
@@ -73,6 +73,8 @@
                     <string>arw</string>
                     <string>CR2</string>
                     <string>cr2</string>
+                    <string>CR3</string>
+                    <string>cr3</string>
                     <string>CRF</string>
                     <string>crf</string>
                     <string>CRW</string>


### PR DESCRIPTION
App lets system know it can open CR3 files.