### PR TITLE
Issue #6721 - Fix memory leak in Crop

### DIFF
--- a/rtengine/dcrop.cc
+++ b/rtengine/dcrop.cc
@@ -1735,6 +1735,11 @@ void Crop::freeAll()
             shbuffer = nullptr;
         }
 
+        if (shbuf_real) {
+            delete [] shbuf_real;
+            shbuf_real = nullptr;
+        }
+
         PipetteBuffer::flush();
     }
 


### PR DESCRIPTION
- Crop::freeAll() didn't free the memory