### PR TITLE
Publish pre-dev builds with workflows

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - dev
   workflow_dispatch:
+env:
+  publish_pre_dev_labels: '[]'
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -167,3 +169,33 @@ jobs:
           files: |
             ${{env.PUBLISH_NAME}}.AppImage
             ${{env.PUBLISH_NAME}}-AboutThisBuild.txt
+
+      - name: Prepare for publishing pre-dev
+        id: prepare-publish-pre-dev
+        if: ${{github.event_name == 'pull_request' && contains(fromJSON(env.publish_pre_dev_labels), github.event.pull_request.head.label)}}
+        run: |
+          echo "Making ref name."
+          REF_NAME_FILTERED="$(echo '${{github.event.pull_request.head.label}}' | tr ':' '_' | sed 's/[^A-z0-9_.-]//g')"
+          echo "Ref name is '$REF_NAME_FILTERED'."
+
+          echo "Setting publish name."
+          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_${{matrix.build_type}}"
+          echo "Publish name is '$PUBLISH_NAME'."
+
+          echo "Renaming AppImage."
+          cp "build/$ARTIFACT_NAME.AppImage" "$PUBLISH_NAME.AppImage"
+
+          echo "Creating version file."
+          cp "build/AboutThisBuild.txt" "$PUBLISH_NAME-AppImage-AboutThisBuild.txt"
+
+          echo "Recording publish name."
+          echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
+
+      - name: Publish pre-dev artifacts
+        uses: softprops/action-gh-release@v1
+        if: ${{steps.prepare-publish-pre-dev.outcome == 'success'}}
+        with:
+          tag_name: pre-dev-github-actions
+          files: |
+            ${{env.PUBLISH_NAME}}.AppImage
+            ${{env.PUBLISH_NAME}}-AppImage-AboutThisBuild.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - dev
   workflow_dispatch:
+env:
+  publish_pre_dev_labels: '[]'
 jobs:
   build:
     runs-on: windows-2022
@@ -299,4 +301,45 @@ jobs:
         if: ${{matrix.build_type == 'release' && (github.ref_type == 'tag' || github.ref_name == 'dev')}}
         with:
           tag_name: nightly-github-actions
+          files: build/${{env.PUBLISH_NAME}}.exe
+
+      - name: Prepare for publishing pre-dev
+        id: prepare-publish-pre-dev
+        if: ${{github.event_name == 'pull_request' && contains(fromJSON(env.publish_pre_dev_labels), github.event.pull_request.head.label)}}
+        run: |
+          echo "Making ref name."
+          REF_NAME_FILTERED="$(echo '${{github.event.pull_request.head.label}}' | tr ':' '_' | sed 's/[^A-z0-9_.-]//g')"
+          echo "Ref name is '$REF_NAME_FILTERED'."
+
+          echo "Setting publish name."
+          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.build_type}}"
+          echo "Publish name is '$PUBLISH_NAME'."
+          if [ "$ARTIFACT_NAME" != "$PUBLISH_NAME" ]; then
+            echo "Renaming ZIP file."
+            cp "build/$ARTIFACT_NAME.zip" "build/$PUBLISH_NAME.zip"
+            if [ -e "./build/$ARTIFACT_NAME.exe" ]; then
+              echo "Renaming installer."
+              mv "./build/$ARTIFACT_NAME.exe" "./build/$PUBLISH_NAME.exe"
+            fi
+          fi
+          echo "Creating version file."
+          cp "build/$ARTIFACT_NAME/AboutThisBuild.txt" "build/$PUBLISH_NAME-AboutThisBuild.txt"
+
+          echo "Recording publish name."
+          echo "PUBLISH_NAME=$PUBLISH_NAME" >> "$(cygpath -u $GITHUB_ENV)"
+
+      - name: Publish pre-dev artifacts
+        uses: softprops/action-gh-release@v1
+        if: ${{steps.prepare-publish-pre-dev.outcome == 'success'}}
+        with:
+          tag_name: pre-dev-github-actions
+          files: |
+            build/${{env.PUBLISH_NAME}}.zip
+            build/${{env.PUBLISH_NAME}}-AboutThisBuild.txt
+
+      - name: Publish pre-dev installer
+        uses: softprops/action-gh-release@v1
+        if: ${{steps.prepare-publish-pre-dev.outcome == 'success' && matrix.build_type == 'release'}}
+        with:
+          tag_name: pre-dev-github-actions
           files: build/${{env.PUBLISH_NAME}}.exe


### PR DESCRIPTION
The automated workflows generate artifacts that are accessible from each builds' summary page. `dev` and releases are published to the Automated Builds release/tag here on GitHub. Anyone can download these builds, but only signed-in GitHub users can access the ones on the build summary pages. Some may wish to test pre-dev builds but do not want to create a GitHub account. This pull request augments the current workflows (currently for Windows and AppImage) so additional artifacts can be automatically published to a pre-dev release so that anyone can download them.

To activate the publishing, one must add the source branch label to the workflows in the `publish_pre_dev_labels` environment variable. This variable is a stringified JSON array containing all the source branches that will be published. An example:
This pull request's source branch is from my fork at Lawrence37/RawTherapee in branch `pre-dev-releases`. In the `.github/workflows/appimage.yml` and `.github/workflows/windows.yml` files, you will see the following.
```yml
env:
  publish_pre_dev_labels: '[]'
```
If I wanted to publish the builds from this pull request, I can add the branch label to **BOTH** `appimage.yml` and `windows.yml` like this.
```yml
env:
  publish_pre_dev_labels: '["Lawrence37:pre-dev-releases"]'
```
Notice the label has the format `owner_name:branch_name`. Multiple branches can be added.
```yml
env:
  publish_pre_dev_labels: '["Lawrence37:pre-dev-releases", "Beep6581:whitebalanceopt", "Beep6581:metadata-exiv2"]'
```
Builds will be published to [this release](https://github.com/Beep6581/RawTherapee/releases/tag/pre-dev-github-actions). Files will show the repository owner and branch name to help distinguish between them. For example, a Windows zip file could be called `RawTherapee_Beep6581_metadata-exiv2_win64_release.zip`, indicating it is from the `metadata-exiv2` branch of this (Beep6581) repository.

The primary goal is to allow more people to test features and bug-fixes in active development. Current examples include #6643, which requires feedback from many users to determine the best parameters, and #5889, which will be a major update.