### PR TITLE
Ubuntu 20.04 runner for AppImage workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -14,7 +14,7 @@ env:
   publish_pre_dev_labels: '[]'
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ubuntu 18.04 is no longer available in GitHub Actions and the OS standard support will end in about 2 months. This bumps up the OS to the next LTS version which is 20.04. Newly generated AppImages may break compatibility with some older operating systems.