### PR TITLE
Fix crash with Fujifilm sports finder mode

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1565,7 +1565,10 @@ Camera constants:
     { // Quality B
         "make_model": [ "FUJIFILM X-T30", "FUJIFILM X-T30 II", "FUJIFILM X100V", "FUJIFILM X-T4", "FUJIFILM X-S10" ],
         "dcraw_matrix": [ 13426,-6334,-1177,-4244,12136,2371,-580,1303,5980 ], // DNG_v11, standard_v2 d65
-        "raw_crop": [ 0, 5, 6252, 4176]
+        "raw_crop": [
+            {"frame": [6384, 3348], "crop": [624, 0, 5004, 3347]}, // Sports finder mode.
+            {"frame": [0, 0], "crop": [0, 5, 6252, 4176]}
+        ]
     },
 
     { // Quality B

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -4422,10 +4422,10 @@ void CLASS crop_masked_pixels()
     }
   } else {
     if (height + top_margin > raw_height) {
-      top_margin = raw_height - height;
+      top_margin = raw_height - MIN(height, raw_height);
     }
     if (width + left_margin > raw_width) {
-      left_margin = raw_width - width;
+      left_margin = raw_width - MIN(width, raw_width);
     }
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -10138,8 +10138,8 @@ canon_a5:
         width = raw_width = 5504;
         height = raw_height = 3856;
     }
-    top_margin = (raw_height - height) >> 2 << 1;
-    left_margin = (raw_width - width ) >> 2 << 1;
+    top_margin = (raw_height - MIN(height, raw_height)) >> 2 << 1;
+    left_margin = (raw_width - MIN(width, raw_width) ) >> 2 << 1;
     if (width == 2848 || width == 3664) filters = 0x16161616;
     if (width == 4032 || width == 4952 || width == 6032 || width == 8280) left_margin = 0;
     if (width == 3328 && (width -= 66)) left_margin = 34;


### PR DESCRIPTION
Raw images taken with Fujifilm cameras with sports finder mode enabled cause crashes due to bad `top_margin` calculation resulting from `height` exceeding `raw_height`. Letting the margin be zero fixes the crash and allows the images to be decoded correctly. I also added the `camconst` `raw_crop` entry for sports finder mode images.

Closes #6748.