### PR TITLE
Fix for L*a*b* curves histogram scaling and pipette values

### DIFF
--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -4176,9 +4176,6 @@ void ImProcFunctions::chromiLuminanceCurve(PipetteBuffer *pipetteBuffer, int pW,
     }
 
 
-    const float histLFactor = pW != 1 ? histLCurve.getSize() / 100.f : 1.f;
-    const float histCFactor = pW != 1 ? histCCurve.getSize() / 48000.f : 1.f;
-
     float adjustr = 1.0f;
 
 //  if(params->labCurve.avoidclip ){
@@ -4199,6 +4196,9 @@ void ImProcFunctions::chromiLuminanceCurve(PipetteBuffer *pipetteBuffer, int pW,
     } else if (params->icm.workingProfile == "BruceRGB")   {
         adjustr = 1.8f;
     }
+
+    const float histLFactor = pW != 1 ? histLCurve.getSize() / 100.f : 1.f;
+    const float histCFactor = pW != 1 ? histCCurve.getSize() * adjustr / 65536.f : 1.f;
 
     // reference to the params structure has to be done outside of the parallelization to avoid CPU cache problem
     const bool highlight = params->toneCurve.hrenabled; //Get the value if "highlight reconstruction" is activated
@@ -4359,11 +4359,11 @@ void ImProcFunctions::chromiLuminanceCurve(PipetteBuffer *pipetteBuffer, int pW,
 
                 if (editPipette) {
                     if (editID == EUID_Lab_aCurve) { // Lab a pipette
-                        float chromapipa = lold->a[i][j] + (32768.f * 1.28f);
-                        editWhatever->v(i, j) = LIM01<float> ((chromapipa) / (65536.f * 1.28f));
+                        float chromapipa = lold->a[i][j] + 32768.f;
+                        editWhatever->v(i, j) = LIM01<float> ((chromapipa) / (65536.f));
                     } else if (editID == EUID_Lab_bCurve) { //Lab b pipette
-                        float chromapipb = lold->b[i][j] + (32768.f * 1.28f);
-                        editWhatever->v(i, j) = LIM01<float> ((chromapipb) / (65536.f * 1.28f));
+                        float chromapipb = lold->b[i][j] + 32768.f;
+                        editWhatever->v(i, j) = LIM01<float> ((chromapipb) / (65536.f));
                     }
                 }
 
@@ -4602,7 +4602,7 @@ void ImProcFunctions::chromiLuminanceCurve(PipetteBuffer *pipetteBuffer, int pW,
                     // I have placed C=f(C) after all C treatments to assure maximum amplitude of "C"
                     if (editPipette && editID == EUID_Lab_CCurve) {
                         float chromapip = sqrt(SQR(atmp) + SQR(btmp) + 0.001f);
-                        editWhatever->v(i, j) = LIM01<float> ((chromapip) / (48000.f));
+                        editWhatever->v(i, j) = LIM01<float> ((chromapip) / (65536.f / adjustr));
                     }//Lab C=f(C) pipette
 
                     if (ccut) {
@@ -4669,7 +4669,7 @@ void ImProcFunctions::chromiLuminanceCurve(PipetteBuffer *pipetteBuffer, int pW,
 
                 if (editPipette && editID == EUID_Lab_LCCurve) {
                     float chromapiplc = sqrt(SQR(atmp) + SQR(btmp) + 0.001f);
-                    editWhatever->v(i, j) = LIM01<float> ((chromapiplc) / (48000.f));
+                    editWhatever->v(i, j) = LIM01<float> ((chromapiplc) / (65536.f / adjustr));
                 }//Lab L=f(C) pipette
 
 


### PR DESCRIPTION
Fixes the x-axis alignment between the chroma histogram and curves of the CC and LC curves. Also fixes the pipette sampling values for the a*, b*, CC, and LC curves.

Closes #6519.