### PR TITLE
Automatically detect DLLs for Windows packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,6 +98,10 @@ jobs:
         run: |
           echo "Listing shared library dependencies."
           ldd "./build/${{matrix.build_type}}/rawtherapee.exe"
+          echo "Finding DLLs to include."
+          DLLS=($(ldd "./build/${{matrix.build_type}}/rawtherapee.exe" | grep '/mingw64/bin/' | awk '{print($1)'}))
+          echo "Required DLLs are: ${DLLS[*]}"
+
           echo "Getting workspace path."
           export BUILD_DIR="$(pwd)/build/${{matrix.build_type}}"
           echo "Build directory is '$BUILD_DIR'."
@@ -110,68 +114,7 @@ jobs:
             "gdbus.exe" \
             "gspawn-win64-helper.exe" \
             "gspawn-win64-helper-console.exe" \
-            "libatk-1.0-0.dll" \
-            "libatkmm-1.6-1.dll" \
-            "libbrotlicommon.dll" \
-            "libbrotlidec.dll" \
-            "libbz2-1.dll" \
-            "libcairo-2.dll" \
-            "libcairo-gobject-2.dll" \
-            "libcairomm-1.0-1.dll" \
-            "libdatrie-1.dll" \
-            "libdeflate.dll" \
-            "libepoxy-0.dll" \
-            "libexpat-1.dll" \
-            libffi-*.dll \
-            "libfftw3f-3.dll" \
-            "libfftw3f_omp-3.dll" \
-            "libfontconfig-1.dll" \
-            "libfreetype-6.dll" \
-            "libfribidi-0.dll" \
-            "libgcc_s_seh-1.dll" \
-            "libgdk_pixbuf-2.0-0.dll" \
-            "libgdk-3-0.dll" \
-            "libgdkmm-3.0-1.dll" \
-            "libgio-2.0-0.dll" \
-            "libgiomm-2.4-1.dll" \
-            "libglib-2.0-0.dll" \
-            "libglibmm-2.4-1.dll" \
-            "libgmodule-2.0-0.dll" \
-            "libgobject-2.0-0.dll" \
-            "libgomp-1.dll" \
-            "libgraphite2.dll" \
-            "libgtk-3-0.dll" \
-            "libgtkmm-3.0-1.dll" \
-            "libharfbuzz-0.dll" \
-            "libiconv-2.dll" \
-            "libintl-8.dll" \
-            "libjbig-0.dll" \
-            "libjpeg-8.dll" \
-            "liblcms2-2.dll" \
-            "liblensfun.dll" \
-            "libLerc.dll" \
-            "liblzma-5.dll" \
-            "libpango-1.0-0.dll" \
-            "libpangocairo-1.0-0.dll" \
-            "libpangoft2-1.0-0.dll" \
-            "libpangomm-1.4-1.dll" \
-            "libpangowin32-1.0-0.dll" \
-            "libpcre2-8-0.dll" \
-            "libpixman-1-0.dll" \
-            "libpng16-16.dll" \
-            "librsvg-2-2.dll" \
-            "libsharpyuv-0.dll" \
-            "libsigc-2.0-0.dll" \
-            "libstdc++-6.dll" \
-            "libsystre-0.dll" \
-            "libthai-0.dll" \
-            "libtiff-6.dll" \
-            "libtre-5.dll" \
-            "libwebp-7.dll" \
-            "libwinpthread-1.dll" \
-            "libxml2-2.dll" \
-            "libzstd.dll" \
-            "zlib1.dll" \
+            ${DLLS[*]} \
             "$BUILD_DIR"
           cd -
 


### PR DESCRIPTION
Uses `ldd` to get all the DLLs that need to be included in the Windows packages instead of hard-coding the DLLs in the workflow file.