### PR TITLE
Camconst entry for Canon EOS R8

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1259,10 +1259,10 @@ Camera constants:
     },
 
     { // Quality C
-        "make_model": "Canon EOS R6m2",
+        "make_model": ["Canon EOS R6m2", "Canon EOS R8"],
         "dcraw_matrix": [9539, -2795, -1224, -4175, 11998, 2458, -465, 1755, 6048],
         "raw_crop": [
-            {"frame": [6188, 4120], "crop": [154, 96, 6028, 4024]},
+            {"frame": [6188, 4120], "crop": [154, 96, 6024, 4024]},
             {"frame": [3936, 2612], "crop": [156, 96, 3780, 2516]}
         ],
         "masked_areas": [


### PR DESCRIPTION
The R8 images look identical to the R6m2, so they share the same `camconst` entry. The [RPU](raw.pixls.us) does not have 1.6x crop samples if that even exists, so the values for the crop are assumed to be the same as the R6m2. There are Dual Pixel samples for the R8. They need an additional 4 pixel crop from the right. There are also Dual Pixel samples for the R6m2. Those require an extra 3 pixel crop (no extra crop required for images taken in the 1.6 crop mode). The 4 pixel extra crop in this pull request handles both.