### PR TITLE
Fix various typos

### DIFF
--- a/rtdata/themes/TooWaBlue-GTK3-20_.css
+++ b/rtdata/themes/TooWaBlue-GTK3-20_.css
@@ -946,7 +946,7 @@ dialog notebook stack {
 }
 
 
-/* Adds a line on top of the notebook as a separtor for the titlebar (only on CSD) */
+/* Adds a line on top of the notebook as a separator for the titlebar (only on CSD) */
 dialog.csd #PrefNotebook > header,
 dialog.csd #AboutNotebook > header,
 window.csd:not(.fullscreen) #MainNotebook > header.top {

--- a/rtdata/themes/size - Legacy.css
+++ b/rtdata/themes/size - Legacy.css
@@ -102,7 +102,7 @@ notebook > header.left > tabs > arrow {
 }
 
 
-/* Adds a line on top of the notebook as a separtor for the titlebar (only on CSD) */
+/* Adds a line on top of the notebook as a separator for the titlebar (only on CSD) */
 dialog.csd #PrefNotebook > header,
 dialog.csd #AboutNotebook > header,
 window.csd:not(.fullscreen) #MainNotebook > header.top {

--- a/rtdata/themes/size.css
+++ b/rtdata/themes/size.css
@@ -102,7 +102,7 @@ notebook > header.left > tabs > arrow {
 }
 
 
-/* Adds a line on top of the notebook as a separtor for the titlebar (only on CSD) */
+/* Adds a line on top of the notebook as a separator for the titlebar (only on CSD) */
 dialog.csd #PrefNotebook > header,
 dialog.csd #AboutNotebook > header,
 window.csd:not(.fullscreen) #MainNotebook > header.top {

--- a/rtengine/cJSON.c
+++ b/rtengine/cJSON.c
@@ -126,7 +126,7 @@ typedef struct internal_hooks
 } internal_hooks;
 
 #if defined(_MSC_VER)
-/* work around MSVC error C2322: '...' address of dillimport '...' is not static */
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
 static void *internal_malloc(size_t size)
 {
     return malloc(size);

--- a/rtengine/calc_distort.cc
+++ b/rtengine/calc_distort.cc
@@ -84,7 +84,7 @@ int calcDistortion(unsigned char* img1, unsigned char* img2, int ncols, int nrow
 
             r0[n] = sqrt((x0 - wc) * (x0 - wc) + (y0 - hc) * (y0 - hc)) / radius;
 
-            // dots too close to the center tends to have big diviation and create noise, extract them
+            // dots too close to the center tends to have big deviation and create noise, extract them
             if (r0[n] < CENTER_R) {
                 continue;
             }

--- a/rtengine/color.cc
+++ b/rtengine/color.cc
@@ -2895,7 +2895,7 @@ void Color::SkinSat (float lum, float hue, float chrom, float &satreduc)
  *
  * data (Munsell ==> Lab) obtained with WallKillcolor and http://www.cis.rit.edu/research/mcsl2/online/munsell.php
  * each LUT give Hue in function of C, for each color Munsell and Luminance
- * eg: _6PB20 : color Munsell 6PB for L=20 c=5 c=45 c=85 c=125..139 when possible: interpolation betwwen values
+ * eg: _6PB20 : color Munsell 6PB for L=20 c=5 c=45 c=85 c=125..139 when possible: interpolation between values
  * no value for C<5  (gray)
  * low memory footprint -- maximum: 195 LUTf * 140 values
  * errors due to small number of samples in LUT and linearization are very low (1 to 2%)

--- a/rtengine/iimage.h
+++ b/rtengine/iimage.h
@@ -1858,7 +1858,7 @@ class IImage : virtual public ImageDimensions
 public:
 
     virtual ~IImage() {}
-    /** @brief Returns a mutex that can is useful in many situations. No image operations shuold be performed without locking this mutex.
+    /** @brief Returns a mutex that can is useful in many situations. No image operations should be performed without locking this mutex.
       * @return The mutex */
     virtual MyMutex& getMutex () = 0;
     virtual cmsHPROFILE getProfile () const = 0;

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1889,7 +1889,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
 
             if (params->colorappearance.enabled) {
                 // L histo  and Chroma histo for ciecam
-                // histogram well be for Lab (Lch) values, because very difficult to do with J,Q, M, s, C
+                // histogram will be for Lab (Lch) values, because very difficult to do with J,Q, M, s, C
                 int x1, y1, x2, y2;
                 params->crop.mapToResized(pW, pH, scale, x1, x2,  y1, y2);
                 lhist16CAM.clear();
@@ -1936,7 +1936,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     adap = pow(2.0, E_V - 3.0);  // cd / m2
                     // end calculation adaptation scene luminosity
                 }
-				if(params->colorappearance.catmethod == "symg") {//force abolute luminance scenescene to 400 in symmetric
+				if(params->colorappearance.catmethod == "symg") {//force absolute luminance scene to 400 in symmetric
 					adap = 400.;
 				}
                 float d, dj, yb;

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -2270,7 +2270,7 @@ void ImProcFunctions::Aver(const float* RESTRICT DataList, int datalen, float &a
     int countP = 0, countN = 0;
     double averaP = 0.0, averaN = 0.0; // use double precision for large summations
 
-    constexpr float thres = 32.7f;//different fom zero to take into account only data large enough 32.7 = 0.1 in range 0..100 very low value
+    constexpr float thres = 32.7f;//different from zero to take into account only data large enough 32.7 = 0.1 in range 0..100 very low value
     max = 0.f;
     min = RT_INFINITY_F;
 #ifdef _OPENMP
@@ -2322,7 +2322,7 @@ void ImProcFunctions::Sigma(const float* RESTRICT DataList, int datalen, float a
 {
     int countP = 0, countN = 0;
     double variP = 0.0, variN = 0.0; // use double precision for large summations
-    float thres = 32.7f;//different fom zero to take into account only data large enough 32.7 = 0.1 in range 0..100
+    float thres = 32.7f;//different from zero to take into account only data large enough 32.7 = 0.1 in range 0..100
 
 #ifdef _OPENMP
     #pragma omp parallel for reduction(+:variP,variN,countP,countN) num_threads(numThreads) if (numThreads>1)

--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -847,7 +847,7 @@ void RawImageSource::getImage (const ColorTemp &ctemp, int tran, Imagefloat* ima
     const bool doClip = (chmax[0] >= clmax[0] || chmax[1] >= clmax[1] || chmax[2] >= clmax[2]) && !hrp.hrenabled && hrp.clampOOG;
     bool doHr = (hrp.hrenabled && !iscolor);
     if (hrp.hrenabled && iscolor) {
-        if(hrp.method == "Coloropp" && opposed == 1) {//force Inpaint opposed if WB change, and opposed limited tne number to 1
+        if(hrp.method == "Coloropp" && opposed == 1) {//force Inpaint opposed if WB change, and opposed limited the number to 1
             rgbSourceModified  = false;
         }
         if (!rgbSourceModified) {
@@ -5526,7 +5526,7 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
     float gmm[N_t];
     float bmm[N_t];
 
-    int siza = 237; //192 untill 01/2023 size of histogram
+    int siza = 237; //192 until 01/2023 size of histogram
     if(wbpar.itcwb_sampling == true) {
         siza = 192;//old sampling 5.9 and before...
     }
@@ -5671,11 +5671,11 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
             purp = false;
         }
         if(wbpar.itcwb_sampling == false) {
-            //printf("Use high smapling\n");
+            //printf("Use high sampling\n");
             histoxyY(bfhitc, bfwitc, xc, yc, Yc, xxx,  yyy, YYY, histxy, purp);//purp enable,  enable purple color in WB
             //return histogram x and y for each temp and in a range of 235 colors (siza)
         } else {
-            //printf("Use low smapling - 5.9\n");
+            //printf("Use low sampling - 5.9\n");
             histoxyY_low(bfhitc, bfwitc, xc, yc, Yc, xxx,  yyy, YYY, histxy);//low scaling 
         }
     }
@@ -5818,7 +5818,7 @@ void RawImageSource::ItcWB(bool extra, double &tempref, double &greenref, double
    // int maxnb = rtengine::LIM(settings->itcwb_sizereference, 1, 5);
    // int maxnb = rtengine::LIM(wbpar.itcwb_size, 1, 5);
     int maxnb = 3;
-    //wbpar.itcwb_size to verify if this setting is usefull...diificulties with High gamut and limited patch spectral colors.
+    //wbpar.itcwb_size to verify if this setting is useful...diificulties with High gamut and limited patch spectral colors.
 
     if (wbpar.itcwb_thres > 55) {//normally never used
         maxnb = 201 / wbpar.itcwb_thres;

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -327,7 +327,7 @@ public:
     bool internalThumbIfUntouched;
     bool overwriteOutputFile;
     int complexity;
-    bool inspectorWindow; // open inspector in spearate window
+    bool inspectorWindow; // open inspector in separate window
     bool zoomOnScroll;    // translate scroll events to zoom
 
     std::vector<double> thumbnailZoomRatios;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./rtdata/languages -L activ,alph,ba,bloc,bord,chang,childs,currentry,dof,dum,fo,hist,inout,invers,lonly,makro,ois,pres,preserv,portugues,rady,reall,redy,struc,tbe,thre,trough,vart,vekto`