### PR TITLE
Fix for Auto-matched camera profile detection when using the English (US) language

### DIFF
--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -430,6 +430,16 @@ std::map<std::string, std::string> getAliases(const Glib::ustring& profile_dir)
     return res;
 }
 
+/**
+ * Returns a locale-independent case-insensitive collate key. Differs from
+ * Glib::ustring::casefold_collate_key() in that the Glib method may return
+ * different results depending on the current locale.
+ */
+std::string casefold_collate_key(const Glib::ustring &str)
+{
+    return str.casefold().raw();
+}
+
 }
 
 struct DCPProfileApplyState::Data {
@@ -1831,7 +1841,7 @@ void DCPStore::init(const Glib::ustring& rt_profile_dir, bool loadAll)
                     && lastdot <= sname.size() - 4
                     && !sname.casefold().compare(lastdot, 4, ".dcp")
                     ) {
-                    file_std_profiles[sname.substr(0, lastdot).casefold_collate_key()] = fname; // They will be loaded and cached on demand
+                    file_std_profiles[casefold_collate_key(sname.substr(0, lastdot))] = fname; // They will be loaded and cached on demand
                 }
             } else {
                 // Directory
@@ -1842,10 +1852,10 @@ void DCPStore::init(const Glib::ustring& rt_profile_dir, bool loadAll)
 
         for (const auto& alias : getAliases(rt_profile_dir)) {
             const Glib::ustring alias_name = Glib::ustring(alias.first).uppercase();
-            const std::map<std::string, Glib::ustring>::const_iterator real = file_std_profiles.find(Glib::ustring(alias.second).casefold_collate_key());
+            const std::map<std::string, Glib::ustring>::const_iterator real = file_std_profiles.find(casefold_collate_key(alias.second));
 
             if (real != file_std_profiles.end()) {
-                file_std_profiles[alias_name.casefold_collate_key()] = real->second;
+                file_std_profiles[casefold_collate_key(alias_name)] = real->second;
         }
     }
 }
@@ -1892,7 +1902,7 @@ DCPProfile* DCPStore::getProfile(const Glib::ustring& filename) const
 
 DCPProfile* DCPStore::getStdProfile(const Glib::ustring& requested_cam_short_name) const
 {
-    const std::map<std::string, Glib::ustring>::const_iterator iter = file_std_profiles.find(requested_cam_short_name.casefold_collate_key());
+    const std::map<std::string, Glib::ustring>::const_iterator iter = file_std_profiles.find(casefold_collate_key(requested_cam_short_name));
     if (iter != file_std_profiles.end()) {
         return getProfile(iter->second);
     }


### PR DESCRIPTION
I was able to reproduce #5511 by setting the language to "English (US)" and launching RawTherapee with the environment variables `LANG=es_ES.UTF-8` and `LANGUAGE=es`. The issue is caused by using a locale-dependent function to refer to the DCP files. When RawTherapee starts, it finds the DCPs and uses the locale in the environment variable. Later in the program initialization, it sets the language and also updates the `LANG` environment variable. As a result, opening an image will cause RawTherapee to look up the DCP using a different locale which is problematic for certain locales.

This pull request makes the DCP lookup use a locale-independent function.

Closes #5511.