### PR TITLE
Dynamic Profile Rules application when picture is selected in File Browser

### DIFF
--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -24,6 +24,7 @@
 #include "rtscalable.h"
 #include "thumbbrowserbase.h"
 #include "thumbbrowserentrybase.h"
+#include "procparamchangers.h"
 
 #include "../rtengine/rt_math.h"
 
@@ -174,6 +175,10 @@ inline void addToSelection (ThumbBrowserEntryBase* entry, ThumbVector& selected)
         return;
 
     entry->selected = true;
+	// load parameters (includes applying Dynamic Profile Rules)
+    entry->thumbnail->createProcParamsForUpdate(true, false); 
+    // update thumbnail
+    entry->thumbnail->notifylisterners_procParamsChanged(FILEBROWSER);
     selected.push_back (entry);
 }
 

--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -174,11 +174,11 @@ inline void addToSelection (ThumbBrowserEntryBase* entry, ThumbVector& selected)
     if (entry->selected || entry->filtered)
         return;
 
-    entry->selected = true;
+	entry->selected = true;
 	// load parameters (includes applying Dynamic Profile Rules)
-    entry->thumbnail->createProcParamsForUpdate(true, false); 
-    // update thumbnail
-    entry->thumbnail->notifylisterners_procParamsChanged(FILEBROWSER);
+	entry->thumbnail->createProcParamsForUpdate(true, false); 
+	// update thumbnail
+	entry->thumbnail->notifylisterners_procParamsChanged(FILEBROWSER);
     selected.push_back (entry);
 }
 


### PR DESCRIPTION
This proposal refers to my question in the forum [https://discuss.pixls.us/t/dynamic-profile-rules-application-in-file-browser/38529](url).

The idea is to evaluate Dynamic Profile Rules whenever a picture is selected in File Browser for the first time.

Code is motivated by function "rankingRequested" in rtgui/filebrowser.cc because I noticed that this evaluation is done whenever I change the star rating of a picture.

What I'm unsure about: Function "rankingRequested" contains calls to  "beginBatchPParamsChange" and "endBatchPParamsChange". It's not clear to me what exactly these calls do, and if something similar might be needed here. It seems to work without, but ...

As always with my unsolicited potential contributions, feel free to reject if this is not something you'd like to have in general RawTherapee.
