### PR TITLE
Fix PDAF lines pattern for Sony ILCE-7RM2

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -2993,8 +2993,8 @@ Camera constants:
         "dcraw_matrix": [ 6629,-1900,-483,-4618,12349,2550,-622,1381,6514 ], // DNG_v9.1.1 D65
         "raw_crop": [ 0, 0, -36, 0 ], // full raw frame 8000x5320 - 36 rightmost columns are garbage
         "ranges": { "black": 512, "white": 16300 },
-        // PDAF info provided by Horshack with the rawshack tool (http://testcams.com/rawshack/)
-        "pdaf_pattern" : [ 0,24,36,60,84,120,132,156,192,204,240,252,276,300,324,360,372,396,420 ],
+        // PDAF lines pattern detected from image provided by elite4jonny at https://github.com/Beep6581/RawTherapee/issues/6801.
+        "pdaf_pattern" : [ 0,24,36,60,84,120,132,156,192,204,240,252,276,300,324,360,372,396,420,444,480,492,504,540,564,576,612,636,660,696,720,732,756,780,804,840 ],
         "pdaf_offset" : 31
     },
 


### PR DESCRIPTION
The current PDAF lines pattern values incorrectly assume the pattern repeats every 420 rows. It actually repeats after 840 rows. The procedure for obtaining the corrected PDAF lines from https://github.com/Beep6581/RawTherapee/issues/6801#issuecomment-1653086379 is as follows.

1. Export the raw data from RawTherapee
    - Start with the Neutral profile
    - Demosaicing method: none
    - Border: 0
    - White balance: disabled
    - Input color profile: no profile
2. Find zero values from blue pixels
    - Import raw data into GIMP
    - Take the blue channel and discard the other channels
    - Apply a grid to make the red and green color filter locations non-zero
    - Threshold the image so that any non-zero pixels become white
3. Find likely PDAF rows
    - Use G'MIC to sort the pixels horizontally
    - Rows with longer black bars are more likely to be PDAF lines
4. Identify the pattern
    - Duplicate the result from the previous step
    - Move the duplicate downward pixel by pixel and compare with the original until the lines match
    - The total movement downward is the pattern repetition size
    - Identify the row indices of the PDAF pixels for the first instance of the pattern.

The first half of the PDAF row numbers match the current values in `camconst.json`. All new values are spaced 12, 24, or 36 pixels apart just like the old values. I also double-checked the new values by comparing the value spacing with the spacing I observed with the result of step 3.