### PR TITLE
Show favorite places at the top of the list

### DIFF
--- a/rtdata/themes/RawTherapee - Legacy-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee - Legacy-GTK3-20_.css
@@ -227,6 +227,8 @@ menu separator {
 }
 
 #PlacesPaned .view.separator {
+    min-height: 0.16666666666666666em;
+    color: #363636;
 }
 
 #MetaPanelNotebook separator {

--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -207,6 +207,8 @@ menu separator {
 }
 
 #PlacesPaned .view.separator {
+    min-height: 0.16666666666666666em;
+    color: #363636;
 }
 
 #MetaPanelNotebook separator {


### PR DESCRIPTION
Moves the user's favorite directories list to the top of the list in the file browser Places section. Also fixes the hidden separator between the Places sub-lists when using the RawTherapee theme.