### PR TITLE
External editor button: synchronize in multiple editors layout

### DIFF
--- a/rtgui/editwindow.cc
+++ b/rtgui/editwindow.cc
@@ -488,6 +488,13 @@ void EditWindow::set_title_decorated(Glib::ustring fname)
     set_title("RawTherapee " + M("EDITWINDOW_TITLE") + subtitle);
 }
 
+void EditWindow::updateExternalEditorWidget(int selectedIndex, const std::vector<ExternalEditor> &editors)
+{
+    for (const auto& panel : epanels) {
+        panel.second->updateExternalEditorWidget(selectedIndex, editors);
+    }
+}
+
 void EditWindow::updateToolPanelToolLocations(
         const std::vector<Glib::ustring> &favorites, bool cloneFavoriteTools)
 {

--- a/rtgui/editwindow.h
+++ b/rtgui/editwindow.h
@@ -24,6 +24,7 @@
 #include "guiutils.h"
 
 class EditorPanel;
+class ExternalEditor;
 class RTWindow;
 
 class EditWindow :
@@ -66,6 +67,7 @@ public:
     bool selectEditorPanel(const std::string &name);
     bool closeOpenEditors();
     bool isProcessing();
+    void updateExternalEditorWidget(int selectedIndex, const std::vector<ExternalEditor> &editors);
     void updateToolPanelToolLocations(
         const std::vector<Glib::ustring> &favorites, bool cloneFavoriteTools);
 

--- a/rtgui/popupcommon.cc
+++ b/rtgui/popupcommon.cc
@@ -20,10 +20,12 @@
  */
 
 #include <gtkmm.h>
+
+#include "guiutils.h"
 #include "multilangmgr.h"
 #include "popupcommon.h"
 #include "rtimage.h"
-#include "guiutils.h"
+#include "threadutils.h"
 
 PopUpCommon::PopUpCommon (Gtk::Button* thisButton, const Glib::ustring& label)
     : buttonImage (nullptr)
@@ -203,6 +205,15 @@ void PopUpCommon::changeImage(const Glib::ustring& fileName, const Glib::RefPtr<
 
 void PopUpCommon::entrySelected(Gtk::Widget* widget)
 {
+    if (widget != menu->get_active()) { // Not actually selected.
+        return;
+    }
+
+    if (!entrySelectionMutex.trylock()) { // Already being updated.
+        return;
+    }
+    entrySelectionMutex.unlock();
+
     int i = 0;
     for (const auto & child : menu->get_children()) {
         if (widget == child) {
@@ -249,7 +260,8 @@ bool PopUpCommon::setSelected (int entryNum)
         setButtonHint();
 
         auto radioMenuItem = dynamic_cast<Gtk::RadioMenuItem*>(menu->get_children()[entryNum]);
-        if (radioMenuItem && menu->get_active() != radioMenuItem) {
+        if (radioMenuItem && !radioMenuItem->get_active()) {
+            MyMutex::MyLock updateLock(entrySelectionMutex);
             radioMenuItem->set_active();
         }
 

--- a/rtgui/popupcommon.h
+++ b/rtgui/popupcommon.h
@@ -20,12 +20,13 @@
  */
 #pragma once
 
-#include "glibmm/refptr.h"
+#include "threadutils.h"
+
 #include <memory>
 #include <vector>
 
+#include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-
 #include <sigc++/signal.h>
 
 namespace Gio
@@ -91,6 +92,7 @@ private:
     Gtk::Button* arrowButton;
     int selected;
     bool hasMenu;
+    MyMutex entrySelectionMutex;
 
     void changeImage(int position);
     void changeImage(const Glib::ustring& fileName, const Glib::RefPtr<const Gio::Icon>& gIcon);

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -589,6 +589,7 @@ void RTWindow::addEditorPanel (EditorPanel* ep, const std::string &name)
     } else {
         ep->setParent (this);
         ep->setParentWindow (this);
+        ep->setExternalEditorChangedSignal(&externalEditorChangedSignal);
 
         // construct closeable tab for the image
         Gtk::Grid* titleGrid = Gtk::manage (new Gtk::Grid ());
@@ -637,6 +638,7 @@ void RTWindow::remEditorPanel (EditorPanel* ep)
         wndEdit->remEditorPanel (ep);
     } else {
         bool queueHadFocus = (mainNB->get_current_page() == mainNB->page_num (*bpanel));
+        ep->setExternalEditorChangedSignal(nullptr);
         epanels.erase (ep->getFileName());
         filesEdited.erase (ep->getFileName ());
         fpanel->refreshEditedState (filesEdited);
@@ -1059,6 +1061,15 @@ void RTWindow::updateExternalEditorWidget(int selectedIndex, const std::vector<E
 {
     if (epanel) {
         epanel->updateExternalEditorWidget(selectedIndex, editors);
+    }
+
+    for (auto panel : epanels) {
+        panel.second->updateExternalEditorWidget(selectedIndex, editors);
+    }
+
+    if (options.multiDisplayMode > 0) {
+        EditWindow::getInstance(this)
+            ->updateExternalEditorWidget(selectedIndex, editors);
     }
 }
 

--- a/rtgui/rtwindow.h
+++ b/rtgui/rtwindow.h
@@ -20,6 +20,7 @@
 #include <set>
 
 #include <gtkmm.h>
+#include <sigc++/signal.h>
 
 #if defined(__APPLE__)
 #include <gtkosxapplication.h>
@@ -47,6 +48,8 @@ private:
     BatchQueuePanel* bpanel;
     std::set<Glib::ustring> filesEdited;
     std::map<Glib::ustring, EditorPanel*> epanels;
+
+    sigc::signal<void> externalEditorChangedSignal;
 
     Splash* splash;
     Gtk::ProgressBar prProgBar;


### PR DESCRIPTION
This makes sure that after updating the external editors in preferences, the external editor button updates to reflect the new settings even when using one of the multiple editors layouts (Multiple Editor Tabs or Multiple Editor Tabs In Own Window).