### PR TITLE
Use `_WIN32` instead of `WIN32` to detect Windows

### DIFF
--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -51,7 +51,7 @@
 #ifdef __CYGWIN__
 #include <io.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <sys/utime.h>
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")
@@ -3846,7 +3846,7 @@ void CLASS bad_pixels (const char *cfname)
       free (fname);
       if (errno != ERANGE) return;
     }
-#if defined(WIN32) || defined(DJGPP)
+#if defined(_WIN32) || defined(DJGPP)
     if (fname[1] == ':')
       memmove (fname, fname+2, len-2);
     for (cp=fname; *cp; cp++)
@@ -9979,7 +9979,7 @@ int CLASS main (int argc, const char **argv)
       fprintf (stderr,_("Will not write an image to the terminal!\n"));
       return 1;
     }
-#if defined(WIN32) || defined(DJGPP) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(DJGPP) || defined(__CYGWIN__)
     if (setmode(1,O_BINARY) < 0) {
       perror ("setmode()");
       return 1;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -86,7 +86,7 @@
 #ifdef __CYGWIN__
 #include <io.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #include <sys/utime.h>
 #include <winsock2.h>
 #ifndef strcasecmp
@@ -4516,7 +4516,7 @@ mask_set:
 //      free (fname);
 //      if (errno != ERANGE) return;
 //    }
-//#if defined(WIN32) || defined(DJGPP)
+//#if defined(_WIN32) || defined(DJGPP)
 //    if (fname[1] == ':')
 //      memmove (fname, fname+2, len-2);
 //    for (cp=fname; *cp; cp++)

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -33,7 +33,7 @@ public:
 	typedef unsigned short ushort;
 	typedef unsigned char uchar;
 	typedef unsigned short (*dcrawImage_t)[4];
-#ifdef WIN32
+#ifdef _WIN32
 	typedef __int64 INT64;
 	typedef unsigned __int64 UINT64;
 #else

--- a/rtengine/dynamicprofile.cc
+++ b/rtengine/dynamicprofile.cc
@@ -221,7 +221,7 @@ bool DynamicProfileRules::loadRules()
 
         try {
             rule.profilepath = kf.get_string (group, "profilepath");
-			#if defined (WIN32)
+			#if defined (_WIN32)
 			// if this is Windows, replace any "/" in the path with "\\"
 			size_t pos = rule.profilepath.find("/");
 			while (pos != Glib::ustring::npos) {
@@ -229,7 +229,7 @@ bool DynamicProfileRules::loadRules()
 				pos = rule.profilepath.find("/", pos);
 			}
 			#endif
-			#if !defined (WIN32)
+			#if !defined (_WIN32)
 			// if this is not Windows, replace any "\\" in the path with "/"
 			size_t pos = rule.profilepath.find("\\");
 			while (pos != Glib::ustring::npos) {

--- a/rtengine/iccstore.cc
+++ b/rtengine/iccstore.cc
@@ -24,7 +24,7 @@
 #include <glibmm/miscutils.h>
 #include <glib/gstdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <netinet/in.h>

--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -78,7 +78,7 @@ FramesMetaData* FramesMetaData::fromFile(const Glib::ustring& fname)
 
 static struct tm timeFromTS(const time_t ts)
 {
-#if !defined(WIN32)
+#if !defined(_WIN32)
         struct tm tm;
         return *gmtime_r(&ts, &tm);
 #else

--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -31,7 +31,7 @@
 #include <tiff.h>
 #include <tiffio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <netinet/in.h>
@@ -64,7 +64,7 @@ namespace
 FILE* g_fopen_withBinaryAndLock(const Glib::ustring& fname)
 {
 
-#ifdef WIN32
+#ifdef _WIN32
 
     // Use native function to disallow sharing, i.e. lock the file for exclusive access.
     // This is important to e.g. prevent Windows Explorer from crashing RT due to concurrently scanning an image file.
@@ -382,7 +382,7 @@ void my_error_exit (j_common_ptr cinfo)
     (*cinfo->err->output_message) (cinfo);
 
     /* Return control to the setjmp point */
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
     __builtin_longjmp(myerr->setjmp_buffer, 1);
 #else
     longjmp(myerr->setjmp_buffer, 1);
@@ -406,7 +406,7 @@ int ImageIO::loadJPEGFromMemory (const char* buffer, int bufsize)
     jerr.pub.error_exit = my_error_exit;
 
     /* Establish the setjmp return context for my_error_exit to use. */
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
 
     if (__builtin_setjmp(jerr.setjmp_buffer)) {
 #else
@@ -492,7 +492,7 @@ int ImageIO::loadJPEG (const Glib::ustring &fname)
 
     my_jpeg_stdio_src (&cinfo, file);
 
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
     if ( __builtin_setjmp((reinterpret_cast<rt_jpeg_error_mgr*>(cinfo.src))->error_jmp_buf) == 0 ) {
 #else
     if ( setjmp((reinterpret_cast<rt_jpeg_error_mgr*>(cinfo.src))->error_jmp_buf) == 0 ) {
@@ -568,7 +568,7 @@ int ImageIO::loadJPEG (const Glib::ustring &fname)
 
 int ImageIO::getTIFFSampleFormat (const Glib::ustring &fname, IIOSampleFormat &sFormat, IIOSampleArrangement &sArrangement)
 {
-#ifdef WIN32
+#ifdef _WIN32
     wchar_t *wfilename = (wchar_t*)g_utf8_to_utf16 (fname.c_str(), -1, NULL, NULL, NULL);
     TIFF* in = TIFFOpenW (wfilename, "r");
     g_free (wfilename);
@@ -681,7 +681,7 @@ int ImageIO::loadTIFF (const Glib::ustring &fname)
         lock.release();
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     wchar_t *wfilename = (wchar_t*)g_utf8_to_utf16 (fname.c_str(), -1, NULL, NULL, NULL);
     TIFF* in = TIFFOpenW (wfilename, "r");
     g_free (wfilename);
@@ -988,7 +988,7 @@ int ImageIO::saveJPEG (const Glib::ustring &fname, int quality, int subSamp) con
     jerr.pub.error_exit = my_error_exit;
 
     /* Establish the setjmp return context for my_error_exit to use. */
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
 
     if (__builtin_setjmp(jerr.setjmp_buffer)) {
 #else
@@ -1063,7 +1063,7 @@ int ImageIO::saveJPEG (const Glib::ustring &fname, int quality, int subSamp) con
     unsigned char *row = new unsigned char [rowlen];
 
     /* To avoid memory leaks we establish a new setjmp return context for my_error_exit to use. */
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
 
     if (__builtin_setjmp(jerr.setjmp_buffer)) {
 #else
@@ -1147,7 +1147,7 @@ int ImageIO::saveTIFF (
         mode += '8';
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     FILE *file = g_fopen_withBinaryAndLock (fname);
     int fileno = _fileno(file);
     int osfileno = _get_osfhandle(fileno);
@@ -1245,7 +1245,7 @@ int ImageIO::saveTIFF (
     }
 
     TIFFClose (out);
-#ifdef WIN32
+#ifdef _WIN32
     fclose (file);
 #endif
 

--- a/rtengine/jdatasrc.cc
+++ b/rtengine/jdatasrc.cc
@@ -240,7 +240,7 @@ my_error_exit (j_common_ptr cinfo)
 
     j_decompress_ptr dinfo = (j_decompress_ptr)cinfo;
 //  longjmp (((rt_jpeg_error_mgr*)(dinfo->src))->error_jmp_buf, 1);
-#if defined( WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
+#if defined( _WIN32 ) && defined( __x86_64__ ) && !defined(__clang__)
     __builtin_longjmp ((reinterpret_cast<rt_jpeg_error_mgr*>(dinfo->src))  ->error_jmp_buf, 1);
 #else
     longjmp ((reinterpret_cast<rt_jpeg_error_mgr*>(dinfo->src))  ->error_jmp_buf, 1);
@@ -248,7 +248,7 @@ my_error_exit (j_common_ptr cinfo)
 }
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #define JVERSION	"6b  27-Mar-1998"
 #define JCOPYRIGHT_SHORT	"(C) 1998, Thomas G. Lane"
 #define JMESSAGE(code,string)	string ,

--- a/rtengine/lcp.cc
+++ b/rtengine/lcp.cc
@@ -25,7 +25,7 @@
 #include <glibmm/fileutils.h>
 #include <glib/gstdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <shlobj.h>
 #endif
 
@@ -906,7 +906,7 @@ Glib::ustring rtengine::LCPStore::getDefaultCommonDirectory() const
 {
     Glib::ustring dir;
 
-#ifdef WIN32
+#ifdef _WIN32
     WCHAR pathW[MAX_PATH] = {0};
 
     if (SHGetSpecialFolderPathW(NULL, pathW, CSIDL_COMMON_APPDATA, false)) {

--- a/rtengine/myfile.cc
+++ b/rtengine/myfile.cc
@@ -22,7 +22,7 @@
 // get mmap() sorted out
 #ifdef MYFILE_MMAP
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include <fcntl.h>
 #include <windows.h>
@@ -59,13 +59,13 @@ int munmap(void *start, size_t length)
 #pragma GCC diagnostic pop
 #endif
 
-#else // WIN32
+#else // _WIN32
 
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#endif // WIN32
+#endif // _WIN32
 #endif // MYFILE_MMAP
 
 #ifdef MYFILE_MMAP
@@ -74,7 +74,7 @@ rtengine::IMFILE* rtengine::fopen (const char* fname)
 {
     int fd;
 
-#ifdef WIN32
+#ifdef _WIN32
 
     fd = -1;
     // First convert UTF8 to UTF16, then use Windows function to open the file and convert back to file descriptor.

--- a/rtengine/mytime.h
+++ b/rtengine/mytime.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <profileapi.h>
 #elif defined __APPLE__
 #include <sys/time.h>
@@ -30,7 +30,7 @@ class MyTime
 {
 
 public:
-#ifndef WIN32
+#ifndef _WIN32
     timespec t;
 #else
     LONGLONG t;
@@ -47,7 +47,7 @@ public:
 
     void set ()
     {
-#ifdef WIN32
+#ifdef _WIN32
         LARGE_INTEGER ulf;
         QueryPerformanceCounter(&ulf);
         t = ulf.QuadPart;
@@ -63,7 +63,7 @@ public:
 
     int etime (const MyTime &a) const
     {
-#ifndef WIN32
+#ifndef _WIN32
         return (t.tv_sec - a.t.tv_sec) * 1000000 + (t.tv_nsec - a.t.tv_nsec) / 1000;
 #else
         return (t - a.t) * 1000 / (baseFrequency / 1000);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -67,7 +67,7 @@ Glib::ustring expandRelativePath(const Glib::ustring &procparams_fname, const Gl
 
 Glib::ustring expandRelativePath2(const Glib::ustring &procparams_fname, const Glib::ustring &procparams_fname2, const Glib::ustring &prefix, Glib::ustring embedded_fname)
 {
-	#if defined (WIN32)
+	#if defined (_WIN32)
 	// if this is Windows, replace any "/" in the filename with "\\"
 	size_t pos = embedded_fname.find("/");
 	while (pos != string::npos) {
@@ -75,7 +75,7 @@ Glib::ustring expandRelativePath2(const Glib::ustring &procparams_fname, const G
 		pos = embedded_fname.find("/", pos);
 	}
 	#endif
-	#if !defined (WIN32)
+	#if !defined (_WIN32)
 	// if this is not Windows, replace any "\\" in the filename with "/"
 	size_t pos = embedded_fname.find("\\");
 	while (pos != string::npos) {
@@ -10244,7 +10244,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
         if (keyFile.has_group("Film Simulation")) {
             assignFromKeyfile(keyFile, "Film Simulation", "Enabled", pedited, filmSimulation.enabled, pedited->filmSimulation.enabled);
 			assignFromKeyfile(keyFile, "Film Simulation", "ClutFilename", pedited, filmSimulation.clutFilename, pedited->filmSimulation.clutFilename);
-			#if defined (WIN32)
+			#if defined (_WIN32)
 			// if this is Windows, replace any "/" in the filename with "\\"
 			size_t pos = filmSimulation.clutFilename.find("/");
 			while (pos != string::npos) {
@@ -10252,7 +10252,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
 				pos = filmSimulation.clutFilename.find("/", pos);
 			}
 			#endif
-			#if !defined (WIN32)
+			#if !defined (_WIN32)
 			// if this is not Windows, replace any "\\" in the filename with "/"
 			size_t pos = filmSimulation.clutFilename.find("\\");
 			while (pos != string::npos) {

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -5,7 +5,7 @@
  */
 
 #include <strings.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <netinet/in.h>

--- a/rtengine/winutils.h
+++ b/rtengine/winutils.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include <aclapi.h>
 #include <windows.h>

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -253,7 +253,7 @@ bool BatchQueue::saveBatchQueue ()
             const auto& saveFormat = entry->saveFormat;
 
             // Warning: for code's simplicity in loadBatchQueue, each field must end by the '|' character, safer than ';' or ',' since it can't be used in paths
-#ifdef WIN32
+#ifdef _WIN32
             // on windows it crashes if we don't use c_str() and filename etc. contain special (e.g. chinese) characters, see issue 3387
             file << entry->filename.c_str() << '|' << entry->savedParamsFile.c_str() << '|' << entry->outFileName.c_str() << '|' << saveFormat.format << '|'
 #else

--- a/rtgui/batchqueueentry.cc
+++ b/rtgui/batchqueueentry.cc
@@ -50,7 +50,7 @@ BatchQueueEntry::BatchQueueEntry (rtengine::ProcessingJob* pjob, const rtengine:
 
     thumbnail = thm;
 
-#if 1 //ndef WIN32
+#if 1 //ndef _WIN32
     // The BatchQueueEntryIdleHelper tracks if an entry has been deleted while it was sitting waiting for "idle"
     bqih = new BatchQueueEntryIdleHelper;
     bqih->bqentry = this;

--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -24,7 +24,7 @@
 #include <giomm.h>
 #include <glib/gstdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <fileapi.h>
 #endif
 
@@ -310,7 +310,7 @@ void CacheManager::deleteFiles (const Glib::ustring& fname, const std::string& m
 std::string CacheManager::getMD5 (const Glib::ustring& fname)
 {
 
-#ifdef WIN32
+#ifdef _WIN32
 
     std::unique_ptr<wchar_t, GFreeFunc> wfname(reinterpret_cast<wchar_t*>(g_utf8_to_utf16 (fname.c_str (), -1, NULL, NULL, NULL)), g_free);
 

--- a/rtgui/cropwindow.cc
+++ b/rtgui/cropwindow.cc
@@ -17,7 +17,7 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <iomanip>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -1496,7 +1496,7 @@ void CropWindow::expose (Cairo::RefPtr<Cairo::Context> cr)
 
             // While the Right-side ALT is pressed, auto-enable highlight and shadow clipping indicators
             // TODO: Add linux/MacOS specific functions for alternative
-#ifdef WIN32
+#ifdef _WIN32
 
             if (GetKeyState(VK_RMENU) < 0) {
                 showcs = true;

--- a/rtgui/dirbrowser.cc
+++ b/rtgui/dirbrowser.cc
@@ -87,7 +87,7 @@ DirBrowser::DirBrowser () : dirTreeModel(),
     dtColumns(),
     tvc(M("DIRBROWSER_FOLDERS")),
     expandSuccess(false)
-#ifdef WIN32
+#ifdef _WIN32
     , volumes(0)
 #endif
 {
@@ -160,7 +160,7 @@ void DirBrowser::fillDirTree ()
     dirTreeModel->signal_sort_column_changed().connect(sigc::mem_fun(*this, &DirBrowser::on_sort_column_changed));
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 void DirBrowser::addRoot (char letter)
 {
 
@@ -251,7 +251,7 @@ int updateVolumesUI (void* br)
 void DirBrowser::fillRoot ()
 {
 
-#ifdef WIN32
+#ifdef _WIN32
     volumes = GetLogicalDrives ();
 
     for (int i = 0; i < 32; i++)
@@ -396,7 +396,7 @@ Gtk::TreePath DirBrowser::expandToDir (const Glib::ustring& absDirPath)
     int count = 0;
     expandSuccess = true;
 
-#ifndef WIN32
+#ifndef _WIN32
     Gtk::TreeModel::iterator j = dirTreeModel->get_iter (path);
     path.up ();
     path.push_back (0);
@@ -406,7 +406,7 @@ Gtk::TreePath DirBrowser::expandToDir (const Glib::ustring& absDirPath)
 
     while (dir) {
         Glib::ustring dirstr = dir;
-#ifdef WIN32
+#ifdef _WIN32
 
         if (count == 0) {
             dirstr = dirstr + "\\";
@@ -419,7 +419,7 @@ Gtk::TreePath DirBrowser::expandToDir (const Glib::ustring& absDirPath)
         while (i && expandSuccess) {
             Gtk::TreeModel::Row crow = *i;
             Glib::ustring str = crow[dtColumns.filename];
-#ifdef WIN32
+#ifdef _WIN32
 
             if (str.casefold() == dirstr.casefold()) {
 #else

--- a/rtgui/dirbrowser.h
+++ b/rtgui/dirbrowser.h
@@ -72,7 +72,7 @@ private:
 
     bool expandSuccess;
 
-#ifdef WIN32
+#ifdef _WIN32
     unsigned int volumes;
 public:
     void updateVolumes ();

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -43,7 +43,7 @@
 #include "thumbnail.h"
 #include "toolpanelcoord.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "windows.h"
 
 #include "../rtengine/winutils.h"
@@ -70,7 +70,7 @@ void setprogressStrUI(double val, const Glib::ustring str, MyProgressBar* pProgr
 #if !defined(__APPLE__) // monitor profile not supported on apple
 bool find_default_monitor_profile (GdkWindow *rootwin, Glib::ustring &defprof, Glib::ustring &defprofname)
 {
-#ifdef WIN32
+#ifdef _WIN32
     HDC hDC = GetDC (nullptr);
 
     if (hDC != nullptr) {
@@ -151,7 +151,7 @@ bool hasUserOnlyPermission(const Glib::ustring &dirname)
     const guint32 mode = file_info->get_attribute_uint32("unix::mode");
 
     return (mode & 0777) == 0700 && owner == Glib::get_user_name();
-#elif defined(WIN32)
+#elif defined(_WIN32)
     const Glib::RefPtr<Gio::File> file = Gio::File::create_for_path(dirname);
     const Glib::RefPtr<Gio::FileInfo> file_info = file->query_info("owner::user");
     if (!file_info) {
@@ -254,7 +254,7 @@ void setUserOnlyPermission(const Glib::RefPtr<Gio::File> file, bool execute)
         file->set_attribute_uint32("unix::mode", mode, Gio::FILE_QUERY_INFO_NONE);
     } catch (Gio::Error &) {
     }
-#elif defined(WIN32)
+#elif defined(_WIN32)
     // Get the current user's SID.
     HANDLE process_token_raw;
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_READ, &process_token_raw)) {
@@ -324,7 +324,7 @@ void setUserOnlyPermission(const Glib::RefPtr<Gio::File> file, bool execute)
  */
 Glib::ustring getTmpDirectory()
 {
-#if defined(__linux__) || defined(__APPLE__) || defined(WIN32)
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
     static Glib::ustring recent_dir = "";
     const Glib::ustring tmp_dir_root = Glib::get_tmp_dir();
     const Glib::ustring subdir_base =
@@ -1545,7 +1545,7 @@ void EditorPanel::refreshProcessingState (bool inProcessingP)
         val = 0.0;
         str = "PROGRESSBAR_READY";
 
-#ifdef WIN32
+#ifdef _WIN32
 
         // Maybe accessing "parent", which is a Gtk object, can justify to get the Gtk lock...
         if (!firstProcessingDone && static_cast<RTWindow*> (parent)->getIsFullscreen()) {

--- a/rtgui/externaleditorpreferences.cc
+++ b/rtgui/externaleditorpreferences.cc
@@ -265,7 +265,7 @@ void ExternalEditorPreferences::onFileChooserDialogResponse(
                     false;
 #endif
                 row[model_columns.command] =
-#ifdef WIN32
+#ifdef _WIN32
                     '"' + dialog->get_filename() + '"';
 #else
                     Glib::shell_quote(dialog->get_filename());
@@ -314,7 +314,7 @@ void ExternalEditorPreferences::openFileChooserDialog()
     const auto exe_filter = Gtk::FileFilter::create();
     exe_filter->set_name(M("FILECHOOSER_FILTER_EXECUTABLE"));
     exe_filter->add_custom(Gtk::FILE_FILTER_MIME_TYPE, [](const Gtk::FileFilter::Info &info) {
-#ifdef WIN32
+#ifdef _WIN32
         return info.mime_type == "application/x-msdownload";
 #else
         return Gio::content_type_can_be_executable(info.mime_type);

--- a/rtgui/extprog.cc
+++ b/rtgui/extprog.cc
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <shlobj.h>
 #include <shellapi.h>
 #endif
@@ -79,7 +79,7 @@ void ExtProgStore::init ()
 
     actions.clear ();
 
-#ifdef WIN32
+#ifdef _WIN32
 
     // Please do not add obscure little tools here, only widely used programs.
     // They should also have a proper setup program and therefore a standard path.
@@ -104,7 +104,7 @@ void ExtProgStore::init ()
 #endif
 
 }
-#ifdef WIN32
+#ifdef _WIN32
 bool ExtProgStore::searchProgram (const Glib::ustring& name,
                                   const Glib::ustring& exePath,
                                   const Glib::ustring& exePath86,
@@ -240,7 +240,7 @@ bool ExtProgStore::spawnCommandSync (const Glib::ustring& cmd)
 
 bool ExtProgStore::openInGimp (const Glib::ustring& fileName)
 {
-#if defined WIN32
+#if defined _WIN32
 
     auto executable = Glib::build_filename (options.gimpDir, "bin", "gimp-win-remote");
     auto success = ShellExecute( NULL, "open", executable.c_str(), fileName.c_str(), NULL, SW_SHOWNORMAL );
@@ -260,7 +260,7 @@ bool ExtProgStore::openInGimp (const Glib::ustring& fileName)
 
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
     if (reinterpret_cast<uintptr_t>(success) > 32) {
         return true;
     }
@@ -271,7 +271,7 @@ bool ExtProgStore::openInGimp (const Glib::ustring& fileName)
 
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 
     for (auto ver = 12; ver >= 0; --ver) {
 
@@ -300,7 +300,7 @@ bool ExtProgStore::openInGimp (const Glib::ustring& fileName)
 
 bool ExtProgStore::openInPhotoshop (const Glib::ustring& fileName)
 {
-#if defined WIN32
+#if defined _WIN32
 
     const auto executable = Glib::build_filename(options.psDir, "Photoshop.exe");
     const auto cmdLine = Glib::ustring("\"") + executable + Glib::ustring("\" \"") + fileName + Glib::ustring("\"");
@@ -324,7 +324,7 @@ bool ExtProgStore::openInCustomEditor (const Glib::ustring& fileName, const Glib
         command = &(options.customEditorProg);
     }
 
-#if defined WIN32
+#if defined _WIN32
 
     const auto cmdLine = Glib::ustring("\"") + *command + Glib::ustring("\"");
     auto success = ShellExecute( NULL, "open", cmdLine.c_str(), ('"' + fileName + '"').c_str(), NULL, SW_SHOWNORMAL );
@@ -381,7 +381,7 @@ bool ExtProgStore::openInExternalEditor(const Glib::ustring &fileName, const Edi
         std::cout << "Unable to launch external editor with Gio. Trying custom launcher." << std::endl;
     }
     Glib::ustring command = editorInfo.commandline;
-#if defined WIN32
+#if defined _WIN32
     if (command.length() > 2 && command[0] == '"' && command[command.length() - 1] == '"') {
         command = command.substr(1, command.length() - 2);
     }

--- a/rtgui/extprog.h
+++ b/rtgui/extprog.h
@@ -55,7 +55,7 @@ class ExtProgStore
     MyMutex mtx;  // covers actions
     std::vector<ExtProgAction> actions;
 
-#ifdef WIN32
+#ifdef _WIN32
     bool searchProgram (const Glib::ustring& name,
                         const Glib::ustring& exePath,
                         const Glib::ustring& exePath86,

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -272,7 +272,7 @@ FileBrowser::FileBrowser () :
     /***********************
      * external programs
      * *********************/
-#if defined(WIN32)
+#if defined(_WIN32)
     Gtk::manage(miOpenDefaultViewer = new Gtk::MenuItem (M("FILEBROWSER_OPENDEFAULTVIEWER")));
 #endif
 
@@ -296,7 +296,7 @@ FileBrowser::FileBrowser () :
             p++;
             Gtk::Menu* submenuExtProg = Gtk::manage (new Gtk::Menu());
 
-#ifdef WIN32
+#ifdef _WIN32
             if (miOpenDefaultViewer) {
                 submenuExtProg->attach (*miOpenDefaultViewer, 0, 1, p, p + 1);
                 p++;
@@ -310,7 +310,7 @@ FileBrowser::FileBrowser () :
             submenuExtProg->show_all ();
             menuExtProg->set_submenu (*submenuExtProg);
         } else {
-#ifdef WIN32
+#ifdef _WIN32
             if (miOpenDefaultViewer) {
                 pmenu->attach (*miOpenDefaultViewer, 0, 1, p, p + 1);
                 p++;
@@ -482,7 +482,7 @@ FileBrowser::FileBrowser () :
         amiExtProg[i]->signal_activate().connect (sigc::bind(sigc::mem_fun(*this, &FileBrowser::menuItemActivated), amiExtProg[i]));
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     if (miOpenDefaultViewer) {
         miOpenDefaultViewer->signal_activate().connect (sigc::bind(sigc::mem_fun(*this, &FileBrowser::menuItemActivated), miOpenDefaultViewer));
     }
@@ -1046,7 +1046,7 @@ void FileBrowser::menuItemActivated (Gtk::MenuItem* m)
         tbl->clearFromCacheRequested (mselected, true);
 
         //queue_draw ();
-#ifdef WIN32
+#ifdef _WIN32
     } else if (miOpenDefaultViewer && m == miOpenDefaultViewer) {
         openDefaultViewer(1);
 #endif
@@ -1157,7 +1157,7 @@ void FileBrowser::partPasteProfile ()
     }
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 void FileBrowser::openDefaultViewer (int destination)
 {
     bool success = true;
@@ -1254,7 +1254,7 @@ bool FileBrowser::keyPressed (GdkEventKey* event)
         }
 
         openRequested(mselected);
-#ifdef WIN32
+#ifdef _WIN32
     } else if (event->keyval == GDK_KEY_F5) {
         int dest = 1;
 

--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -203,7 +203,7 @@ public:
     void partPasteProfile ();
     void openNextPreviousEditorImage(const Glib::ustring& fname, eRTNav eNextPrevious);
 
-#ifdef WIN32
+#ifdef _WIN32
     void openDefaultViewer (int destination);
 #endif
 

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -26,7 +26,7 @@
 #include "placesbrowser.h"
 #include "thumbnail.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "windows.h"
 #endif
 
@@ -302,7 +302,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
             if (options.tabbedUI) {
                 EditorPanel* epanel;
                 {
-#ifdef WIN32
+#ifdef _WIN32
                     int winGdiHandles = GetGuiResources( GetCurrentProcess(), GR_GDIOBJECTS);
                     if(winGdiHandles > 0 && winGdiHandles <= 6500) //(old settings 8500) 0 means we don't have the rights to access the function, 8500 because the limit is 10000 and we need about 1500 free handles
                     //J.Desmis october 2021 I change 8500 to 6500..Why ? because without while increasing size GUI system crash in multieditor
@@ -312,7 +312,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
                     epanel = Gtk::manage (new EditorPanel ());
                     parent->addEditorPanel (epanel, pl->thm->getFileName());
                     }
-#ifdef WIN32
+#ifdef _WIN32
                     else {
                         Glib::ustring msg_ = Glib::ustring("<b>") + M("MAIN_MSG_CANNOTLOAD") + " \"" + escapeHtmlChars(thm->getFileName()) + "\" .\n" + M("MAIN_MSG_TOOMANYOPENEDITORS") + "</b>";
                         Gtk::MessageDialog msgd (*parent, msg_, true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
@@ -339,7 +339,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
             Gtk::MessageDialog msgd (*parent, msg_, true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
             msgd.run ();
         }
-#ifdef WIN32
+#ifdef _WIN32
 MAXGDIHANDLESREACHED:
 #endif
         delete pl->pc;

--- a/rtgui/icmpanel.cc
+++ b/rtgui/icmpanel.cc
@@ -467,7 +467,7 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     ipDialog->add_filter(filter_icc);
     ipDialog->add_filter(filter_iccdng);
     ipDialog->add_filter(filter_any);
-#ifdef WIN32
+#ifdef _WIN32
     ipDialog->set_show_hidden(true);  // ProgramData is hidden on Windows
 #endif
 

--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -129,7 +129,7 @@ LensProfilePanel::LensProfilePanel() :
     const Glib::ustring defDir = LCPStore::getInstance()->getDefaultCommonDirectory();
 
     if (!defDir.empty()) {
-#ifdef WIN32
+#ifdef _WIN32
         corrLcpFileChooser->set_show_hidden(true);  // ProgramData is hidden on Windows
 #endif
         corrLcpFileChooser->set_current_folder(defDir);

--- a/rtgui/main-cli.cc
+++ b/rtgui/main-cli.cc
@@ -41,7 +41,7 @@
 #include "extprog.h"
 #include "pathutils.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <glibmm/fileutils.h>
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -96,7 +96,7 @@ int main (int argc, char **argv)
     char exname[512] = {0};
     Glib::ustring exePath;
     // get the path where the rawtherapee executable is stored
-#ifdef WIN32
+#ifdef _WIN32
     WCHAR exnameU[512] = {0};
     GetModuleFileNameW (NULL, exnameU, 511);
     WideCharToMultiByte (CP_UTF8, 0, exnameU, -1, exname, 511, 0, 0 );
@@ -182,7 +182,7 @@ int main (int argc, char **argv)
 
     TIFFSetWarningHandler (nullptr);   // avoid annoying message boxes
 
-#ifndef WIN32
+#ifndef _WIN32
 
     // Move the old path to the new one if the new does not exist
     if (Glib::file_test (Glib::build_filename (options.rtdir, "cache"), Glib::FILE_TEST_IS_DIR) && !Glib::file_test (options.cacheBaseDir, Glib::FILE_TEST_IS_DIR)) {

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -46,7 +46,7 @@
 #include "../rtengine/procparams.h"
 #include "pathutils.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <glibmm/fileutils.h>
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -121,7 +121,7 @@ int processLineParams ( int argc, char **argv )
                     // GTK --argument, we're skipping it
                     break;
 
-#ifdef WIN32
+#ifdef _WIN32
 
                 case 'w': // This case is handled outside this function
                     break;
@@ -167,7 +167,7 @@ int processLineParams ( int argc, char **argv )
                     printf("  %s <file>             Start Image Editor with file.\n\n",Glib::path_get_basename (argv[0]).c_str());
                     std::cout << std::endl;
                     printf("Options:\n");
-#ifdef WIN32
+#ifdef _WIN32
                     printf("  -w Do not open the Windows console\n");
 #endif
                     printf("  -v Print RawTherapee version number and exit\n");
@@ -210,7 +210,7 @@ bool init_rt()
         TIFFSetWarningHandler (nullptr);   // avoid annoying message boxes
     }
 
-#ifndef WIN32
+#ifndef _WIN32
 
     // Move the old path to the new one if the new does not exist
     if (Glib::file_test (Glib::build_filename (options.rtdir, "cache"), Glib::FILE_TEST_IS_DIR) && !Glib::file_test (options.cacheBaseDir, Glib::FILE_TEST_IS_DIR)) {
@@ -362,7 +362,7 @@ int main (int argc, char **argv)
     Glib::init();  // called by Gtk::Main, but this may be important for thread handling, so we call it ourselves now
     Gio::init ();
 
-#ifdef WIN32
+#ifdef _WIN32
     if (GetFileType (GetStdHandle (STD_OUTPUT_HANDLE)) == 0x0003) {
         // started from msys2 console => do not buffer stdout
         setbuf(stdout, NULL);
@@ -373,7 +373,7 @@ int main (int argc, char **argv)
     char exname[512] = {0};
     Glib::ustring exePath;
     // get the path where the rawtherapee executable is stored
-#ifdef WIN32
+#ifdef _WIN32
     WCHAR exnameU[512] = {0};
     GetModuleFileNameW (NULL, exnameU, 511);
     WideCharToMultiByte (CP_UTF8, 0, exnameU, -1, exname, 511, 0, 0 );
@@ -416,7 +416,7 @@ int main (int argc, char **argv)
     options.rtSettings.lensfunDbBundleDirectory = LENSFUN_DB_PATH;
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
     bool consoleOpened = false;
 
     // suppression of annoying error boxes
@@ -567,7 +567,7 @@ int main (int argc, char **argv)
         }
     }
 
-#ifdef WIN32
+#ifdef _WIN32
 
     if (consoleOpened) {
         printf ("Press any key to exit RawTherapee\n");

--- a/rtgui/md5helper.h
+++ b/rtgui/md5helper.h
@@ -23,7 +23,7 @@
 #include <glib/gstdio.h>
 #include <giomm.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -35,7 +35,7 @@ std::string getMD5 (const Glib::ustring& fname)
 
     if (file && file->query_exists ())   {
 
-#ifdef WIN32
+#ifdef _WIN32
 
         std::unique_ptr<wchar_t, GFreeFunc> wfname (reinterpret_cast<wchar_t*> (g_utf8_to_utf16 (fname.c_str (), -1, NULL, NULL, NULL)), g_free);
 

--- a/rtgui/multilangmgr.cc
+++ b/rtgui/multilangmgr.cc
@@ -22,7 +22,7 @@
 #include <glib.h>
 #include <iostream>
 #include <utility>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <winnls.h>
 #endif
@@ -315,7 +315,7 @@ const TranslationMetadata *MultiLangMgr::getMetadata(const Glib::ustring &fname)
 
 bool MultiLangMgr::isOSLanguageDetectSupported ()
 {
-#if defined (WIN32) || defined (__linux__) || defined (__APPLE__)
+#if defined (_WIN32) || defined (__linux__) || defined (__APPLE__)
     return true;
 #else
     return false;
@@ -326,7 +326,7 @@ Glib::ustring MultiLangMgr::getOSUserLanguage ()
 {
     Glib::ustring langName ("default");
 
-#if defined (WIN32)
+#if defined (_WIN32)
 
     const LCID localeID = GetUserDefaultLCID ();
     TCHAR localeName[18];

--- a/rtgui/navigator.cc
+++ b/rtgui/navigator.cc
@@ -157,7 +157,7 @@ Navigator::Navigator() :
     /*
     Glib::ustring fontname;
 
-#ifdef WIN32
+#ifdef _WIN32
     fontname = "Droid Sans Mono Slashed"; // font file is provided in the source tree in rtdata/fonts to be installed by the windows installer
 #endif
 

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -42,7 +42,7 @@
 
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 // for GCC32
 #ifndef _WIN32_IE
@@ -368,7 +368,7 @@ void Options::setDefaults()
     fbShowDateTime = true;
     fbShowBasicExif = true;
     fbShowExpComp = false;
-#ifdef WIN32
+#ifdef _WIN32
     // use windows setting for visibility of hidden files/folders
     SHELLFLAGSTATE sft = { 0 };
     SHGetSettings(&sft, SSF_SHOWALLOBJECTS);
@@ -577,7 +577,7 @@ void Options::setDefaults()
 	rtSettings.cameraProfilesPath = "";
 	rtSettings.lensProfilesPath = "";
 	
-#ifdef WIN32
+#ifdef _WIN32
     const gchar* sysRoot = g_getenv("SystemRoot");  // Returns e.g. "c:\Windows"
 
     if (sysRoot != NULL) {
@@ -933,7 +933,7 @@ void Options::readFromFile(Glib::ustring fname)
                     // GIMP == 1, Photoshop == 2, Custom == 3.
                     editorToSendTo = keyFile.get_integer("External Editor", "EditorKind");
 
-#ifdef WIN32
+#ifdef _WIN32
                     auto getIconSerialized = [](const Glib::ustring &executable) {
                         // Backslashes and quotes must be escaped in the text representation of GVariant strings.
                         // See https://www.freedesktop.org/software/gstreamer-sdk/data/docs/2012.5/glib/gvariant-text.html#gvariant-text-strings
@@ -1228,7 +1228,7 @@ void Options::readFromFile(Glib::ustring fname)
                     fbShowExpComp = keyFile.get_boolean("File Browser", "BrowserShowsExpComp");
                 }
 
-#ifndef WIN32
+#ifndef _WIN32
                 if (keyFile.has_key("File Browser", "BrowserShowsHidden")) {
                     fbShowHidden = keyFile.get_boolean("File Browser", "BrowserShowsHidden");
                 }
@@ -2399,7 +2399,7 @@ void Options::saveToFile(Glib::ustring fname)
         keyFile.set_boolean("File Browser", "BrowserShowsDate", fbShowDateTime);
         keyFile.set_boolean("File Browser", "BrowserShowsExif", fbShowBasicExif);
         keyFile.set_boolean("File Browser", "BrowserShowsExpComp", fbShowExpComp);
-#ifndef WIN32
+#ifndef _WIN32
         keyFile.set_boolean("File Browser", "BrowserShowsHidden", fbShowHidden);
 #endif
         keyFile.set_integer("File Browser", "ThumbnailSize", thumbSize);
@@ -2788,7 +2788,7 @@ void Options::load(bool lightweight)
         }
     } else {
 
-#ifdef WIN32
+#ifdef _WIN32
         WCHAR pathW[MAX_PATH] = {0};
 
         if (SHGetSpecialFolderPathW(NULL, pathW, CSIDL_LOCAL_APPDATA, false)) {
@@ -2838,7 +2838,7 @@ void Options::load(bool lightweight)
 
     // No environment variable provided, so falling back to the multi user mode, if enabled
     else if (options.multiUser) {
-#ifdef WIN32
+#ifdef _WIN32
         cacheBaseDir = Glib::build_filename(rtdir, "cache");
 #else
     #ifdef __APPLE__

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -40,7 +40,7 @@
 #define THEMEREGEXSTR      "^(.+)-GTK3-(\\d{1,2})?_(\\d{1,2})?\\.css$"
 
 // Default bundled profile name to use for Raw images
-#ifdef WIN32
+#ifdef _WIN32
 #define DEFPROFILE_RAW      "${G}\\Auto-Matched Curve - ISO Low"
 #else
 #define DEFPROFILE_RAW      "${G}/Auto-Matched Curve - ISO Low"

--- a/rtgui/pathutils.cc
+++ b/rtgui/pathutils.cc
@@ -55,7 +55,7 @@ Glib::ustring getExtension (const Glib::ustring& filename)
 // so we're using Glib::filename_to_utf8 for Linux/Apple and Glib::locale_to_utf8 for Windows.
 Glib::ustring fname_to_utf8(const std::string &fname)
 {
-#ifdef WIN32
+#ifdef _WIN32
 
     try {
         return Glib::locale_to_utf8(fname);

--- a/rtgui/placesbrowser.cc
+++ b/rtgui/placesbrowser.cc
@@ -18,7 +18,7 @@
  */
 #include "placesbrowser.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <shlobj.h>
 #include <Shlwapi.h>
@@ -231,7 +231,7 @@ void PlacesBrowser::refreshPlacesList ()
     // (Drives in Windows)
     std::vector<Glib::RefPtr<Gio::Mount> > mounts = vm->get_mounts ();
 
-#ifdef WIN32
+#ifdef _WIN32
     // on Windows, it's usual to sort by drive letter, not by name
     std::sort (mounts.begin(), mounts.end(), compareMountByRoot);
 #endif
@@ -353,7 +353,7 @@ void PlacesBrowser::delPressed ()
 
 Glib::ustring PlacesBrowser::userHomeDir ()
 {
-#ifdef WIN32
+#ifdef _WIN32
 
     // get_home_dir crashes on some Windows configurations,
     // so we rather use the safe native functions here.
@@ -378,7 +378,7 @@ Glib::ustring PlacesBrowser::userHomeDir ()
 
 Glib::ustring PlacesBrowser::userPicturesDir ()
 {
-#ifdef WIN32
+#ifdef _WIN32
 
     // get_user_special_dir crashes on some Windows configurations,
     // so we rather use the safe native functions here.

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -119,7 +119,7 @@ Preferences::Preferences(RTWindow *rtwindow)
     nb->append_page(*getBatchProcPanel(), M("PREFERENCES_BATCH_PROCESSING"));
     nb->append_page(*getPerformancePanel(), M("PREFERENCES_TAB_PERFORMANCE"));
     // Sounds only on Windows and Linux
-#if defined(WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(__linux__)
     nb->append_page(*getSoundsPanel(), M("PREFERENCES_TAB_SOUND"));
 #endif
     nb->set_current_page(0);
@@ -1985,7 +1985,7 @@ void Preferences::storePreferences()
     moptions.rtSettings.thumbnail_inspector_mode = static_cast<rtengine::Settings::ThumbnailInspectorMode>(thumbnailInspectorMode->get_active_row_number());
 
 // Sounds only on Windows and Linux
-#if defined(WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(__linux__)
     moptions.sndEnable = ckbSndEnable->get_active();
     moptions.sndBatchQueueDone = txtSndBatchQueueDone->get_text();
     moptions.sndLngEditProcDone = txtSndLngEditProcDone->get_text();
@@ -2244,7 +2244,7 @@ void Preferences::fillPreferences()
     chOverwriteOutputFile->set_active(moptions.overwriteOutputFile);
 
     // Sounds only on Windows and Linux
-#if defined(WIN32) || defined(__linux__)
+#if defined(_WIN32) || defined(__linux__)
     ckbSndEnable->set_active(moptions.sndEnable);
     txtSndBatchQueueDone->set_text(moptions.sndBatchQueueDone);
     txtSndLngEditProcDone->set_text(moptions.sndLngEditProcDone);

--- a/rtgui/rtappchooserdialog.cc
+++ b/rtgui/rtappchooserdialog.cc
@@ -18,7 +18,7 @@
  */
 #include "rtappchooserdialog.h"
 
-#if !(defined WIN32 || defined __APPLE__)
+#if !(defined _WIN32 || defined __APPLE__)
 #define GTKMM_APPCHOOSERDIALOG
 #endif
 

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -243,7 +243,7 @@ RTWindow::RTWindow ()
     MyExpander::init();
     FileBrowserEntry::init();
 
-#ifndef WIN32
+#ifndef _WIN32
     const std::vector<Glib::RefPtr<Gdk::Pixbuf>> appIcons = {
         RTImage::createPixbufFromFile("rawtherapee-logo-16.png"),
         RTImage::createPixbufFromFile("rawtherapee-logo-24.png"),

--- a/rtgui/soundman.cc
+++ b/rtgui/soundman.cc
@@ -21,7 +21,7 @@
 #include "soundman.h"
 #include "options.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <mmsystem.h>
 #endif
@@ -33,7 +33,7 @@
 
 void SoundManager::init()
 {
-#ifdef WIN32
+#ifdef _WIN32
 // TODO: On Windows Vista/7 RT should register with the OS sound system, so it can enjoy application specific
 // volume, safed, process independent etc. from the start.
 // Function call is IAudioClient::Initialize
@@ -53,7 +53,7 @@ void SoundManager::playSoundAsync(const Glib::ustring &sound)
         return;
     }
 
-#ifdef WIN32
+#ifdef _WIN32
     DWORD sndParam = SND_ASYNC | SND_NODEFAULT;
 
     if (sound.find('.') != Glib::ustring::npos) {

--- a/rtgui/threadutils.cc
+++ b/rtgui/threadutils.cc
@@ -21,7 +21,7 @@
 #include <csignal>
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -34,7 +34,7 @@ void MyMutex::checkLock ()
     if (locked) {
         std::cerr << "MyMutex already locked!" << std::endl;
 
-#ifdef WIN32
+#ifdef _WIN32
         DebugBreak ();
 #else
         raise (SIGTRAP);
@@ -49,7 +49,7 @@ void MyMutex::checkUnlock ()
     if (!locked) {
         std::cerr << "MyMutex already unlocked!" << std::endl;
 
-#ifdef WIN32
+#ifdef _WIN32
         DebugBreak ();
 #else
         raise (SIGTRAP);

--- a/rtgui/thumbnail.cc
+++ b/rtgui/thumbnail.cc
@@ -15,7 +15,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -1142,7 +1142,7 @@ void Thumbnail::removeThumbnailListener (ThumbnailListener* tnl)
 bool Thumbnail::openDefaultViewer(int destination)
 {
 
-#ifdef WIN32
+#ifdef _WIN32
     Glib::ustring openFName;
 
     if (destination == 1) {


### PR DESCRIPTION
`WIN32` is not defined when building a 64-bit executable on Windows with Clang. `_WIN32` is the more appropriate option here.

http://web.archive.org/web/20191012035921/http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system contains a handy table/matrix of the options and why this is best.