### PR TITLE
Replace Inpaint-opposed by Blend - hlrecovery in all pp3 profiles and default

### DIFF
--- a/rtdata/profiles/Auto-Matched Curve - ISO High.pp3
+++ b/rtdata/profiles/Auto-Matched Curve - ISO High.pp3
@@ -4,7 +4,7 @@ HistogramMatching=true
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Directional Pyramid Denoising]
 Enabled=true

--- a/rtdata/profiles/Auto-Matched Curve - ISO Low.pp3
+++ b/rtdata/profiles/Auto-Matched Curve - ISO Low.pp3
@@ -4,7 +4,7 @@ HistogramMatching=true
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [LensProfile]
 LcMode=lfauto

--- a/rtdata/profiles/Auto-Matched Curve - ISO Medium.pp3
+++ b/rtdata/profiles/Auto-Matched Curve - ISO Medium.pp3
@@ -4,7 +4,7 @@ HistogramMatching=true
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Directional Pyramid Denoising]
 Enabled=true

--- a/rtdata/profiles/Film Negative - Black and White.pp3
+++ b/rtdata/profiles/Film Negative - Black and White.pp3
@@ -11,7 +11,7 @@ Curve2=1;0;0;0.0397505754145333;0.020171771436200074;0.54669745433149319;0.69419
 
 [HLRecovery]
 Enabled=false
-Method=Coloropp
+Method=Blend
 
 [Black & White]
 Enabled=true

--- a/rtdata/profiles/Film Negative.pp3
+++ b/rtdata/profiles/Film Negative.pp3
@@ -11,7 +11,7 @@ Curve2=1;0;0;0.0397505754145333;0.020171771436200074;0.54669745433149319;0.69419
 
 [HLRecovery]
 Enabled=false
-Method=Coloropp
+Method=Blend
 
 [Crop]
 FixedRatio=false

--- a/rtdata/profiles/Pop/Pop 1.pp3
+++ b/rtdata/profiles/Pop/Pop 1.pp3
@@ -19,7 +19,7 @@ Curve2=0;
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Luminance Curve]
 Enabled=true

--- a/rtdata/profiles/Pop/Pop 2 Lab.pp3
+++ b/rtdata/profiles/Pop/Pop 2 Lab.pp3
@@ -19,7 +19,7 @@ Curve2=0;
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Luminance Curve]
 Enabled=true

--- a/rtdata/profiles/Pop/Pop 3 Skin.pp3
+++ b/rtdata/profiles/Pop/Pop 3 Skin.pp3
@@ -19,7 +19,7 @@ Curve2=0;
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Luminance Curve]
 Enabled=true

--- a/rtdata/profiles/Pop/Pop 4 Black-and-White.pp3
+++ b/rtdata/profiles/Pop/Pop 4 Black-and-White.pp3
@@ -19,7 +19,7 @@ Curve2=0;
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Black & White]
 Enabled=true

--- a/rtdata/profiles/Standard Film Curve - ISO High.pp3
+++ b/rtdata/profiles/Standard Film Curve - ISO High.pp3
@@ -6,7 +6,7 @@ Curve=1;0;0;0.11;0.089999999999999997;0.32000000000000001;0.42999999999999999;0.
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Directional Pyramid Denoising]
 Enabled=true

--- a/rtdata/profiles/Standard Film Curve - ISO Low.pp3
+++ b/rtdata/profiles/Standard Film Curve - ISO Low.pp3
@@ -6,7 +6,7 @@ Curve=1;0;0;0.11;0.089999999999999997;0.32000000000000001;0.42999999999999999;0.
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [LensProfile]
 LcMode=lfauto

--- a/rtdata/profiles/Standard Film Curve - ISO Medium.pp3
+++ b/rtdata/profiles/Standard Film Curve - ISO Medium.pp3
@@ -6,7 +6,7 @@ Curve=1;0;0;0.11;0.089999999999999997;0.32000000000000001;0.42999999999999999;0.
 
 [HLRecovery]
 Enabled=true
-Method=Coloropp
+Method=Blend
 
 [Directional Pyramid Denoising]
 Enabled=true

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -427,7 +427,7 @@ ToneCurveParams::ToneCurveParams() :
     autoexp(false),
     clip(0.02),
     hrenabled(false),
-    method("Coloropp"),
+    method("Blend"),
     expcomp(0),
     curve{
         DCT_Linear


### PR DESCRIPTION
To ensure a faster refresh, I replace "Inpaint opposed" by "Blend" in "Highlight reconstruction".

Of course this is accompanied by a less good treatment of highlights