### PR TITLE
Fix for Treeview's editable entries incorrectly displayed

### DIFF
--- a/rtdata/themes/RawTherapee-GTK3-20_.css
+++ b/rtdata/themes/RawTherapee-GTK3-20_.css
@@ -44,7 +44,7 @@ textview.view, treeview.view {
     padding: 0;
     margin: 0;
 }
-.view, .textview, textview, textview.view {
+.view, .textview, textview, textview.view, treeview > entry {
     background-color: #262626;
 }
 /* The headers of these panels */


### PR DESCRIPTION
When editing a text in a Treeview, the current value is still displayed in the cell, below the new text. The problem was a transparent background, given that the edition is done with an Entry widget painted above the cell (which doesn't scroll with the Treeview, but that seem to be the correct behavior.

If no one objects, I'll merge tomorrow, it's a simple fix.