### PR TITLE
Show "unchanged" in batch profiled lens correction

### DIFF
--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -441,6 +441,7 @@ void LensProfilePanel::setBatchMode(bool yes)
     modesGrid->attach_next_to(*corrUnchangedRB, Gtk::POS_TOP, 3, 1);
     corrUnchangedRB->signal_toggled().connect(sigc::bind(sigc::mem_fun(*this, &LensProfilePanel::onCorrModeChanged), corrUnchangedRB));
     corrUnchangedRB->set_active(true);
+    corrUnchangedRB->show();
 }
 
 void LensProfilePanel::onLensfunCameraChanged()


### PR DESCRIPTION
Fixes #6828.

It's a small fix, but I'm opening a pull request so it's easier to track everything on GitHub.