### PR TITLE
Segfault fixed when opening Fuji cropped raw. Fixes #6312

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1571,7 +1571,10 @@ Camera constants:
     { // Quality A, samples provided by Daniel Catalina (#5839) and pi99y (#5860)
         "make_model": [ "FUJIFILM X-T3", "FUJIFILM X-PRO3" ],
         "dcraw_matrix": [ 13426,-6334,-1177,-4244,12136,2371,-580,1303,5980 ], // DNG_v11, standard_v2 d65
-        "raw_crop": [ 0, 5, 6252, 4176],
+        "raw_crop" : [
+           { "frame" : [6384, 4182], "crop": [ 0, 5, 6252, 4176] },
+           { "frame" : [6384, 3348], "crop": [624, 0, 5004, 3348] }
+        ],
         "white": [ 16170, 16275, 16170 ] // typical safe-margins with LENR
         // negligible aperture scaling effect
     },

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -5775,6 +5775,8 @@ nf: order = 0x4949;
       cam_mul[0] = get2() / 256.0;
     if (tag == 0x1018 || tag == 0x20400100)
       cam_mul[2] = get2() / 256.0;
+    if (tag == 0x104D)
+        read_crop.crop_mode = (CropMode)get2();
     if (tag == 0x2011 && len == 2) {
 get2_256:
       order = 0x4d4d;
@@ -7697,7 +7699,6 @@ void CLASS parse_fuji (int offset)
   }
   height <<= fuji_layout;
   width  >>= fuji_layout;
-  read_crop.complete = read_crop_c == 4;                                // RT
 }
 
 int CLASS parse_jpeg (int offset)
@@ -10153,12 +10154,12 @@ canon_a5:
         width = raw_width = 6016;
         height = raw_height = 4014;
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
-        constexpr std::uint_fast16_t x_width = 6384, x_height = 4182;                                                               // RT
-        is_cropped = read_crop.complete && (x_width - raw_width > is_cropped_margin || x_height - raw_height > is_cropped_margin);  // RT
-        if (!is_cropped) {                                                                                                          // RT
-            width = raw_width = x_width;                                                                                            // RT
-            height = raw_height = x_height;                                                                                         // RT
-        }                                                                                                                           // RT
+        raw_width = 6384;           // RT
+        raw_height = 4182;          // RT
+        if (!read_crop.crop_mode) { // RT
+            width = 6384;           // RT
+            height = 4182;          // RT
+        }                           // RT
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;
         height = raw_height = 3856;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7658,6 +7658,15 @@ void CLASS parse_fuji (int offset)
     if (tag == 0x100) {
       raw_height = get2();
       raw_width  = get2();
+    // RawImageCroppedSize 0x111 = 273 	(including borders)                RT
+    } else if (tag == 0x111) {                                          // RT
+      read_crop.height = get2();                                        // RT
+      read_crop.width = get2();                                         // RT
+      // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)  RT
+    } else if (tag == 0x110){                                           // RT
+      read_crop.top_margin = get2();                                    // RT
+      read_crop.left_margin = get2();                                   // RT
+    // 0x115 = 277 RawImageAspectRatio                                     RT
     } else if (tag == 0x121) {
       height = get2();
       if ((width = get2()) == 4284) width += 3;
@@ -7678,16 +7687,7 @@ void CLASS parse_fuji (int offset)
       width = tag;
       height = get4();
       order = c;
-    // RawImageCroppedSize 0x111 = 273 	(including borders)                RT
-    } else if (tag == 0x111) {                                          // RT
-      read_crop.height = get2();                                        // RT
-      read_crop.width = get2();                                         // RT
-      // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)  RT
-    } else if (tag == 0x110){                                           // RT
-      read_crop.top_margin = get2();                                    // RT
-      read_crop.left_margin = get2();                                   // RT
-    }                                                                   // RT
-    // 0x115 = 277 RawImageAspectRatio                                     RT
+    }
     // 0x9650 = 38480 RawExposureBias                                      RT
 
     fseek (ifp, save+len, SEEK_SET);

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7113,8 +7113,8 @@ void CLASS apply_tiff()
     (unsigned)tiff_ifd[i].bps < 33 && (unsigned)tiff_ifd[i].samples < 13 && // RT
 	 ns && ((ns > os && (ties = 1)) ||
 		(ns == os && shot_select == ties++))) {
-      raw_width     = read_crop.complete ? read_crop.width : tiff_ifd[i].width;
-      raw_height    = read_crop.complete ? read_crop.height : tiff_ifd[i].height;
+      raw_width     = read_crop.complete ? read_crop.width : tiff_ifd[i].width;   // RT
+      raw_height    = read_crop.complete ? read_crop.height : tiff_ifd[i].height; // RT
       tiff_bps      = tiff_ifd[i].bps;
       tiff_compress = tiff_ifd[i].comp;
       data_offset   = tiff_ifd[i].offset;
@@ -7647,57 +7647,57 @@ void CLASS parse_fuji (int offset)
 
   fseek (ifp, offset, SEEK_SET);
   entries = get4();
-  int read_crop_c = 0;
-  bool read_crop_dimensions = false;
+  int read_crop_c = 0;                                                  // RT
+  bool read_crop_dimensions = false;                                    // RT
   if (entries > 255) return;
   while (entries--) {
     tag = get2();
     len = get2();
     save = ftell(ifp);
-    // tag 0x100 = 256 RawImageFullSize
+    // tag 0x100 = 256 RawImageFullSize                                    RT
     if (tag == 0x100) {
       raw_height = get2();
       raw_width  = get2();
     } else if (tag == 0x121) {
       height = get2();
       if ((width = get2()) == 4284) width += 3;
-      // tag 0x130 = 304 FujiLayout
+      // tag 0x130 = 304 FujiLayout                                        RT
     } else if (tag == 0x130) {
       fuji_layout = fgetc(ifp) >> 7;
       fuji_width = !(fgetc(ifp) & 8);
-      // tag 0x131 = 305 XTransLayout
+      // tag 0x131 = 305 XTransLayout                                      RT
     } else if (tag == 0x131) {
       filters = 9;
       FORC(36) xtrans_abs[0][35-c] = fgetc(ifp) & 3;
     } else if (tag == 0x2ff0) {
       FORC4 cam_mul[c ^ 1] = get2();
-    } else if (tag == 0xc000 && len > 20000 && !read_crop_dimensions) {
+    } else if (tag == 0xc000 && len > 20000 && !read_crop_dimensions) { // RT
       c = order;
       order = 0x4949;
       while ((tag = get4()) > raw_width);
       width = tag;
       height = get4();
       order = c;
-    // RawImageCroppedSize 0x111 = 273 	(including borders)
-    } else if (tag == 0x111) {
-      height = raw_height = read_crop.height = get2();
-      width = raw_width = read_crop.width = get2();
-      read_crop_dimensions = true;
-      read_crop_c += 2;
-      // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)
-    } else if (tag == 0x110){
-      read_crop.top_margin = get2();
-      read_crop.left_margin = get2();
-      read_crop_c += 2;
-    }
-    // 0x115 = 277 RawImageAspectRatio
-    // 0x9650 = 38480 RawExposureBias
+    // RawImageCroppedSize 0x111 = 273 	(including borders)                RT
+    } else if (tag == 0x111) {                                          // RT
+      height = raw_height = read_crop.height = get2();                  // RT
+      width = raw_width = read_crop.width = get2();                     // RT
+      read_crop_dimensions = true;                                      // RT
+      read_crop_c += 2;                                                 // RT
+      // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)  RT
+    } else if (tag == 0x110){                                           // RT
+      read_crop.top_margin = get2();                                    // RT
+      read_crop.left_margin = get2();                                   // RT
+      read_crop_c += 2;                                                 // RT
+    }                                                                   // RT
+    // 0x115 = 277 RawImageAspectRatio                                     RT
+    // 0x9650 = 38480 RawExposureBias                                      RT
 
     fseek (ifp, save+len, SEEK_SET);
   }
   height <<= fuji_layout;
   width  >>= fuji_layout;
-  read_crop.complete = read_crop_c == 4;
+  read_crop.complete = read_crop_c == 4;                                // RT
 }
 
 int CLASS parse_jpeg (int offset)
@@ -10153,12 +10153,12 @@ canon_a5:
         width = raw_width = 6016;
         height = raw_height = 4014;
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
-        constexpr std::uint_fast16_t x_width = 6384, x_height = 4182;
-        is_cropped = read_crop.complete && (x_width - raw_width > is_cropped_margin || x_height - raw_height > is_cropped_margin);
-        if (!is_cropped) {
-            width = raw_width = x_width;
-            height = raw_height = x_height;
-        }
+        constexpr std::uint_fast16_t x_width = 6384, x_height = 4182;                                                               // RT
+        is_cropped = read_crop.complete && (x_width - raw_width > is_cropped_margin || x_height - raw_height > is_cropped_margin);  // RT
+        if (!is_cropped) {                                                                                                          // RT
+            width = raw_width = x_width;                                                                                            // RT
+            height = raw_height = x_height;                                                                                         // RT
+        }                                                                                                                           // RT
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;
         height = raw_height = 3856;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7693,12 +7693,12 @@ void CLASS parse_fuji (int offset)
     fseek (ifp, save+len, SEEK_SET);
   }
 
-  if (read_crop.crop_mode) {              // RT
-    height = read_crop.height;            // RT
-    width = read_crop.width;              // RT
-    top_margin = read_crop.top_margin;    // RT
-    left_margin = read_crop.left_margin;  // RT
-  }                                       // RT
+  if ((std::uint_fast16_t)read_crop.crop_mode) {  // RT
+    height = read_crop.height;                    // RT
+    width = read_crop.width;                      // RT
+    top_margin = read_crop.top_margin;            // RT
+    left_margin = read_crop.left_margin;          // RT
+  }                                               // RT
 
   height <<= fuji_layout;
   width  >>= fuji_layout;
@@ -10159,10 +10159,10 @@ canon_a5:
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
         raw_width = 6384;           // RT
         raw_height = 4182;          // RT
-        if (!read_crop.crop_mode) { // RT
-            width = raw_width;      // RT
-            height = raw_height;    // RT
-        }                           // RT
+        if (!(std::uint_fast16_t)read_crop.crop_mode) { // RT
+            width = raw_width;                          // RT
+            height = raw_height;                        // RT
+        }                                               // RT
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;
         height = raw_height = 3856;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7649,8 +7649,6 @@ void CLASS parse_fuji (int offset)
 
   fseek (ifp, offset, SEEK_SET);
   entries = get4();
-  int read_crop_c = 0;                                                  // RT
-  bool read_crop_dimensions = false;                                    // RT
   if (entries > 255) return;
   while (entries--) {
     tag = get2();
@@ -7673,7 +7671,7 @@ void CLASS parse_fuji (int offset)
       FORC(36) xtrans_abs[0][35-c] = fgetc(ifp) & 3;
     } else if (tag == 0x2ff0) {
       FORC4 cam_mul[c ^ 1] = get2();
-    } else if (tag == 0xc000 && len > 20000 && !read_crop_dimensions) { // RT
+    } else if (tag == 0xc000 && len > 20000) {
       c = order;
       order = 0x4949;
       while ((tag = get4()) > raw_width);
@@ -7682,21 +7680,27 @@ void CLASS parse_fuji (int offset)
       order = c;
     // RawImageCroppedSize 0x111 = 273 	(including borders)                RT
     } else if (tag == 0x111) {                                          // RT
-      height = read_crop.height = get2();                               // RT
-      width = read_crop.width = get2();                                 // RT
-      read_crop_dimensions = true;                                      // RT
-      read_crop_c += 2;                                                 // RT
+      read_crop.height = get2();                                        // RT
+      read_crop.width = get2();                                         // RT
       // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)  RT
     } else if (tag == 0x110){                                           // RT
       read_crop.top_margin = get2();                                    // RT
       read_crop.left_margin = get2();                                   // RT
-      read_crop_c += 2;                                                 // RT
     }                                                                   // RT
     // 0x115 = 277 RawImageAspectRatio                                     RT
     // 0x9650 = 38480 RawExposureBias                                      RT
 
     fseek (ifp, save+len, SEEK_SET);
   }
+
+  if (read_crop.crop_mode)                // RT
+  {                                       // RT
+    height = read_crop.height;            // RT
+    width = read_crop.width;              // RT
+    top_margin = read_crop.top_margin;    // RT
+    left_margin = read_crop.left_margin;  // RT
+  }                                       // RT
+
   height <<= fuji_layout;
   width  >>= fuji_layout;
 }

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7690,13 +7690,8 @@ void CLASS parse_fuji (int offset)
       read_crop.left_margin = get2();
       read_crop_c += 2;
     }
-    // 0x112 = 274 unknown tag
-    // 0x113 = 275 unknown tag
     // 0x115 = 277 RawImageAspectRatio
-    // 0x141 = 321 unknown tag
     // 0x9650 = 38480 RawExposureBias
-    // 0x9651 = 38481 unknown tag
-    // 0x17f8 = 6136 unknown tag
 
     fseek (ifp, save+len, SEEK_SET);
   }
@@ -10164,11 +10159,6 @@ canon_a5:
             width = raw_width = x_width;
             height = raw_height = x_height;
         }
-        // due to this (mainly raw_width and raw_height) not beimg read from the file, a segmentation fault occurs, when trying to read the raw image
-        // the following data should be read from the exif data, and passed to the corresponding variables:
-        // RAF - RawImageCroppedSize ------- Test image: 4992x3328
-        // raw_width = 4992;
-        // raw_height = 3328;
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;
         height = raw_height = 3856;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7693,8 +7693,7 @@ void CLASS parse_fuji (int offset)
     fseek (ifp, save+len, SEEK_SET);
   }
 
-  if (read_crop.crop_mode)                // RT
-  {                                       // RT
+  if (read_crop.crop_mode) {              // RT
     height = read_crop.height;            // RT
     width = read_crop.width;              // RT
     top_margin = read_crop.top_margin;    // RT
@@ -10161,8 +10160,8 @@ canon_a5:
         raw_width = 6384;           // RT
         raw_height = 4182;          // RT
         if (!read_crop.crop_mode) { // RT
-            width = 6384;           // RT
-            height = 4182;          // RT
+            width = raw_width;      // RT
+            height = raw_height;    // RT
         }                           // RT
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7113,8 +7113,8 @@ void CLASS apply_tiff()
     (unsigned)tiff_ifd[i].bps < 33 && (unsigned)tiff_ifd[i].samples < 13 && // RT
 	 ns && ((ns > os && (ties = 1)) ||
 		(ns == os && shot_select == ties++))) {
-      raw_width     = read_crop.complete ? read_crop.width : tiff_ifd[i].width;   // RT
-      raw_height    = read_crop.complete ? read_crop.height : tiff_ifd[i].height; // RT
+      raw_width     = tiff_ifd[i].width;
+      raw_height    = tiff_ifd[i].height;
       tiff_bps      = tiff_ifd[i].bps;
       tiff_compress = tiff_ifd[i].comp;
       data_offset   = tiff_ifd[i].offset;
@@ -7680,8 +7680,8 @@ void CLASS parse_fuji (int offset)
       order = c;
     // RawImageCroppedSize 0x111 = 273 	(including borders)                RT
     } else if (tag == 0x111) {                                          // RT
-      height = raw_height = read_crop.height = get2();                  // RT
-      width = raw_width = read_crop.width = get2();                     // RT
+      height = read_crop.height = get2();                               // RT
+      width = read_crop.width = get2();                                 // RT
       read_crop_dimensions = true;                                      // RT
       read_crop_c += 2;                                                 // RT
       // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)  RT

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7693,7 +7693,7 @@ void CLASS parse_fuji (int offset)
     fseek (ifp, save+len, SEEK_SET);
   }
 
-  if ((std::uint_fast16_t)read_crop.crop_mode) {  // RT
+  if (read_crop.crop_mode != CropMode::NA) {      // RT
     height = read_crop.height;                    // RT
     width = read_crop.width;                      // RT
     top_margin = read_crop.top_margin;            // RT
@@ -10159,7 +10159,7 @@ canon_a5:
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
         raw_width = 6384;           // RT
         raw_height = 4182;          // RT
-        if (!(std::uint_fast16_t)read_crop.crop_mode) { // RT
+        if (read_crop.crop_mode != CropMode::NA) {      // RT
             width = raw_width;                          // RT
             height = raw_height;                        // RT
         }                                               // RT

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -10159,7 +10159,7 @@ canon_a5:
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
         raw_width = 6384;           // RT
         raw_height = 4182;          // RT
-        if (read_crop.crop_mode != CropMode::NA) {      // RT
+        if (read_crop.crop_mode == CropMode::NA) {      // RT
             width = raw_width;                          // RT
             height = raw_height;                        // RT
         }                                               // RT

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7113,8 +7113,8 @@ void CLASS apply_tiff()
     (unsigned)tiff_ifd[i].bps < 33 && (unsigned)tiff_ifd[i].samples < 13 && // RT
 	 ns && ((ns > os && (ties = 1)) ||
 		(ns == os && shot_select == ties++))) {
-      raw_width     = tiff_ifd[i].width;
-      raw_height    = tiff_ifd[i].height;
+      raw_width     = read_crop.complete ? read_crop.width : tiff_ifd[i].width;
+      raw_height    = read_crop.complete ? read_crop.height : tiff_ifd[i].height;
       tiff_bps      = tiff_ifd[i].bps;
       tiff_compress = tiff_ifd[i].comp;
       data_offset   = tiff_ifd[i].offset;
@@ -7647,37 +7647,62 @@ void CLASS parse_fuji (int offset)
 
   fseek (ifp, offset, SEEK_SET);
   entries = get4();
+  int read_crop_c = 0;
+  bool read_crop_dimensions = false;
   if (entries > 255) return;
   while (entries--) {
     tag = get2();
     len = get2();
     save = ftell(ifp);
+    // tag 0x100 = 256 RawImageFullSize
     if (tag == 0x100) {
       raw_height = get2();
       raw_width  = get2();
     } else if (tag == 0x121) {
       height = get2();
       if ((width = get2()) == 4284) width += 3;
+      // tag 0x130 = 304 FujiLayout
     } else if (tag == 0x130) {
       fuji_layout = fgetc(ifp) >> 7;
       fuji_width = !(fgetc(ifp) & 8);
+      // tag 0x131 = 305 XTransLayout
     } else if (tag == 0x131) {
       filters = 9;
       FORC(36) xtrans_abs[0][35-c] = fgetc(ifp) & 3;
     } else if (tag == 0x2ff0) {
       FORC4 cam_mul[c ^ 1] = get2();
-    } else if (tag == 0xc000 && len > 20000) {
+    } else if (tag == 0xc000 && len > 20000 && !read_crop_dimensions) {
       c = order;
       order = 0x4949;
       while ((tag = get4()) > raw_width);
       width = tag;
       height = get4();
       order = c;
+    // RawImageCroppedSize 0x111 = 273 	(including borders)
+    } else if (tag == 0x111) {
+      height = raw_height = read_crop.height = get2();
+      width = raw_width = read_crop.width = get2();
+      read_crop_dimensions = true;
+      read_crop_c += 2;
+      // RawImageTopLeft 0x110 = 272 (top margin first, then left margin)
+    } else if (tag == 0x110){
+      read_crop.top_margin = get2();
+      read_crop.left_margin = get2();
+      read_crop_c += 2;
     }
+    // 0x112 = 274 unknown tag
+    // 0x113 = 275 unknown tag
+    // 0x115 = 277 RawImageAspectRatio
+    // 0x141 = 321 unknown tag
+    // 0x9650 = 38480 RawExposureBias
+    // 0x9651 = 38481 unknown tag
+    // 0x17f8 = 6136 unknown tag
+
     fseek (ifp, save+len, SEEK_SET);
   }
   height <<= fuji_layout;
   width  >>= fuji_layout;
+  read_crop.complete = read_crop_c == 4;
 }
 
 int CLASS parse_jpeg (int offset)
@@ -10133,8 +10158,17 @@ canon_a5:
         width = raw_width = 6016;
         height = raw_height = 4014;
     } else if (!strcmp(model, "X-Pro3") || !strcmp(model, "X-T3") || !strcmp(model, "X-T30") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-S10")) {
-        width = raw_width = 6384;
-        height = raw_height = 4182;
+        constexpr std::uint_fast16_t x_width = 6384, x_height = 4182;
+        is_cropped = read_crop.complete && (x_width - raw_width > is_cropped_margin || x_height - raw_height > is_cropped_margin);
+        if (!is_cropped) {
+            width = raw_width = x_width;
+            height = raw_height = x_height;
+        }
+        // due to this (mainly raw_width and raw_height) not beimg read from the file, a segmentation fault occurs, when trying to read the raw image
+        // the following data should be read from the exif data, and passed to the corresponding variables:
+        // RAF - RawImageCroppedSize ------- Test image: 4992x3328
+        // raw_width = 4992;
+        // raw_height = 3328;
     } else if (!strcmp(model, "DBP for GX680")) { // Special case for #4204
         width = raw_width = 5504;
         height = raw_height = 3856;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -76,22 +76,20 @@ public:
     }
 
 protected:
+    enum CropMode : std::uint_fast16_t {                                         // RT
+        NA = 0,                                                                  // RT
+        FullFrameOnGfx = 1,                                                      // RT
+        SportsFinderMode = 2,                                                    // RT
+        ElectronicShutter1_25xCrop = 4                                           // RT
+    };                                                                           // RT
     // stores the cropdata read from the file                                       RT
     struct CropData {                                                            // RT
         std::uint_fast16_t  width,                                               // RT
                             height,                                              // RT
                             top_margin,                                          // RT
                             left_margin;                                         // RT
-        bool complete = false;                                                   // RT
+        CropMode crop_mode = NA;                                                 // RT
     } read_crop;                                                                 // RT
-    /*                                                                              RT
-        If the difference between the read dimension (width /height)                RT
-        and the constant dimension (eg.: from cameraconstants)                      RT
-        is greater than this amount,                                                RT
-        then the file should be considered raw cropped (for fuji cropped raw)       RT
-    */                                                                           // RT
-    static constexpr std::uint_fast16_t is_cropped_margin = 500;                 // RT
-    bool is_cropped = false;                                                     // RT
     int exif_base, ciff_base, ciff_len;
     rtengine::IMFILE *ifp;
     FILE *ofp;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -76,22 +76,22 @@ public:
     }
 
 protected:
-    // stores the cropdata read from the file
-    struct CropData {
-        std::uint_fast16_t  width,
-                            height,
-                            top_margin,
-                            left_margin;
-        bool complete = false;
-    } read_crop;
-    /*
-        If the difference between the read dimension (width /height)
-        and the constant dimension (eg.: from cameraconstants) 
-        is greater than this amount,
-        then the file should be considered raw cropped (for fuji cropped raw)
-    */
-    static constexpr std::uint_fast16_t is_cropped_margin = 500;
-    bool is_cropped = false;
+    // stores the cropdata read from the file                                       RT
+    struct CropData {                                                            // RT
+        std::uint_fast16_t  width,                                               // RT
+                            height,                                              // RT
+                            top_margin,                                          // RT
+                            left_margin;                                         // RT
+        bool complete = false;                                                   // RT
+    } read_crop;                                                                 // RT
+    /*                                                                              RT
+        If the difference between the read dimension (width /height)                RT
+        and the constant dimension (eg.: from cameraconstants)                      RT
+        is greater than this amount,                                                RT
+        then the file should be considered raw cropped (for fuji cropped raw)       RT
+    */                                                                           // RT
+    static constexpr std::uint_fast16_t is_cropped_margin = 500;                 // RT
+    bool is_cropped = false;                                                     // RT
     int exif_base, ciff_base, ciff_len;
     rtengine::IMFILE *ifp;
     FILE *ofp;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -76,6 +76,22 @@ public:
     }
 
 protected:
+    // stores the cropdata read from the file
+    struct CropData {
+        std::uint_fast16_t  width,
+                            height,
+                            top_margin,
+                            left_margin;
+        bool complete = false;
+    } read_crop;
+    /*
+        If the difference between the read dimension (width /height)
+        and the constant dimension (eg.: from cameraconstants) 
+        is greater than this amount,
+        then the file should be considered raw cropped (for fuji cropped raw)
+    */
+    static constexpr std::uint_fast16_t is_cropped_margin = 500;
+    bool is_cropped = false;
     int exif_base, ciff_base, ciff_len;
     rtengine::IMFILE *ifp;
     FILE *ofp;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -76,7 +76,7 @@ public:
     }
 
 protected:
-    enum CropMode : std::uint_fast16_t {                                         // RT
+    enum class CropMode : std::uint_fast16_t {                                   // RT
         NA = 0,                                                                  // RT
         FullFrameOnGfx = 1,                                                      // RT
         SportsFinderMode = 2,                                                    // RT
@@ -88,7 +88,7 @@ protected:
                             height,                                              // RT
                             top_margin,                                          // RT
                             left_margin;                                         // RT
-        CropMode crop_mode = NA;                                                 // RT
+        CropMode crop_mode = CropMode::NA;                                       // RT
     } read_crop;                                                                 // RT
     int exif_base, ciff_base, ciff_len;
     rtengine::IMFILE *ifp;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -560,13 +560,13 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                 raw_crop_cc = true;
                 int lm, tm, w, h;
                 cc->get_rawCrop(raw_width, raw_height, lm, tm, w, h);
-                is_cropped = read_crop.complete && (raw_width - read_crop.width > is_cropped_margin || raw_height - read_crop.height > is_cropped_margin);
-                if (is_cropped){
-                    left_margin = read_crop.left_margin;
-                    top_margin = read_crop.top_margin;
-                    tm = 0;
-                    lm = 0;
-                }
+                is_cropped = read_crop.complete && (raw_width - read_crop.width > is_cropped_margin || raw_height - read_crop.height > is_cropped_margin);  // RT
+                if (is_cropped){                                                                                                                            // RT
+                    left_margin = read_crop.left_margin;                                                                                                    // RT
+                    top_margin = read_crop.top_margin;                                                                                                      // RT
+                    tm = 0;                                                                                                                                 // RT
+                    lm = 0;                                                                                                                                 // RT
+                }                                                                                                                                           // RT
 
                 if (isXtrans()) {
                     shiftXtransMatrix(6 - ((top_margin - tm) % 6), 6 - ((left_margin - lm) % 6));
@@ -576,10 +576,10 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                     }
                 }
 
-                if (!is_cropped) {
+                if (!is_cropped) {      // RT
                     left_margin = lm;
                     top_margin = tm;
-                }
+                }                       // RT
 
                 if (w < 0) {
                     iwidth += w;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -560,12 +560,6 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                 raw_crop_cc = true;
                 int lm, tm, w, h;
                 cc->get_rawCrop(raw_width, raw_height, lm, tm, w, h);
-                if (read_crop.crop_mode){                                                                                                                   // RT
-                    left_margin = read_crop.left_margin;                                                                                                    // RT
-                    top_margin = read_crop.top_margin;                                                                                                      // RT
-                    tm = 0;                                                                                                                                 // RT
-                    lm = 0;                                                                                                                                 // RT
-                }                                                                                                                                           // RT
 
                 if (isXtrans()) {
                     shiftXtransMatrix(6 - ((top_margin - tm) % 6), 6 - ((left_margin - lm) % 6));
@@ -575,10 +569,8 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                     }
                 }
 
-                if (!read_crop.crop_mode) { // RT
-                    left_margin = lm;
-                    top_margin = tm;
-                }                           // RT
+                left_margin = lm;
+                top_margin = tm;
 
                 if (w < 0) {
                     iwidth += w;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -560,8 +560,7 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                 raw_crop_cc = true;
                 int lm, tm, w, h;
                 cc->get_rawCrop(raw_width, raw_height, lm, tm, w, h);
-                is_cropped = read_crop.complete && (raw_width - read_crop.width > is_cropped_margin || raw_height - read_crop.height > is_cropped_margin);  // RT
-                if (is_cropped){                                                                                                                            // RT
+                if (read_crop.crop_mode){                                                                                                                   // RT
                     left_margin = read_crop.left_margin;                                                                                                    // RT
                     top_margin = read_crop.top_margin;                                                                                                      // RT
                     tm = 0;                                                                                                                                 // RT
@@ -576,10 +575,10 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                     }
                 }
 
-                if (!is_cropped) {      // RT
+                if (!read_crop.crop_mode) { // RT
                     left_margin = lm;
                     top_margin = tm;
-                }                       // RT
+                }                           // RT
 
                 if (w < 0) {
                     iwidth += w;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -560,6 +560,13 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                 raw_crop_cc = true;
                 int lm, tm, w, h;
                 cc->get_rawCrop(raw_width, raw_height, lm, tm, w, h);
+                is_cropped = read_crop.complete && (raw_width - read_crop.width > is_cropped_margin || raw_height - read_crop.height > is_cropped_margin);
+                if (is_cropped){
+                    left_margin = read_crop.left_margin;
+                    top_margin = read_crop.top_margin;
+                    tm = 0;
+                    lm = 0;
+                }
 
                 if (isXtrans()) {
                     shiftXtransMatrix(6 - ((top_margin - tm) % 6), 6 - ((left_margin - lm) % 6));
@@ -569,8 +576,10 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                     }
                 }
 
-                left_margin = lm;
-                top_margin = tm;
+                if (!is_cropped) {
+                    left_margin = lm;
+                    top_margin = tm;
+                }
 
                 if (w < 0) {
                     iwidth += w;


### PR DESCRIPTION
Fixes #6312 where opening a Fuji cropped raw RAF file would result in a Segmentation Fault. Now RT should read the metadata of cropped Fuji files and debayer the image accordingly. For non cropped files the behavior remains unchanged. I only tested it with the image referenced in the issue, and a few other (not cropped) [files](https://drive.google.com/file/d/13IbwuOPCrGMKV-H3BXqBVnGTPVrMRjGL/view?usp=sharing) I've found online.