### PR TITLE
Raw crop for Sony ILCE-7M4

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -3041,7 +3041,8 @@ Camera constants:
 
     { // Quality C
         "make_model": "Sony ILCE-7M4",
-        "dcraw_matrix": [ 7460, -2365, -588, -5687, 13442, 2474, -624, 1156, 6584 ] // ColorMatrix2 using illuminant D65 from Adobe DNG Converter 14.2
+        "dcraw_matrix": [ 7460, -2365, -588, -5687, 13442, 2474, -624, 1156, 6584 ], // ColorMatrix2 using illuminant D65 from Adobe DNG Converter 14.2
+        "raw_crop": [ 0, 0, -10, 0 ]
     },
 
     { // Quality C,


### PR DESCRIPTION
Remove 10 columns of bad pixels from the right border.
See https://discuss.pixls.us/t/resolution-and-pixel-right-side-edge-pixel-stretch-bug-in-rawtherapee-with-sony-a7-ivs-arw-files/39191