### PR TITLE
Fix for some Lensfun corrections not available

### DIFF
--- a/rtengine/rtlensfun.cc
+++ b/rtengine/rtlensfun.cc
@@ -455,6 +455,16 @@ LFLens LFDatabase::findLens(const LFCamera &camera, const Glib::ustring &name) c
     LFLens ret;
     if (data_ && !name.empty()) {
         MyMutex::MyLock lock(lfDBMutex);
+        if (!camera.data_) {
+            // Only the lens name provided. Try to find exact match by name.
+            LFLens candidate;
+            for (auto lens_list = data_->GetLenses(); lens_list[0]; lens_list++) {
+                candidate.data_ = lens_list[0];
+                if (name == candidate.getLens()) {
+                    return candidate;
+                }
+            }
+        }
         auto found = data_->FindLenses(camera.data_, nullptr, name.c_str());
         for (size_t pos = 0; !found && pos < name.size(); ) {
             // try to split the maker from the model of the lens -- we have to

--- a/rtengine/rtlensfun.h
+++ b/rtengine/rtlensfun.h
@@ -120,7 +120,7 @@ public:
 
     std::vector<LFCamera> getCameras() const;
     std::vector<LFLens> getLenses() const;
-    LFCamera findCamera(const Glib::ustring &make, const Glib::ustring &model) const;
+    LFCamera findCamera(const Glib::ustring &make, const Glib::ustring &model, bool autoMatch) const;
     LFLens findLens(const LFCamera &camera, const Glib::ustring &name) const;
 
     std::unique_ptr<LFModifier> findModifier(

--- a/rtgui/lensprofile.cc
+++ b/rtgui/lensprofile.cc
@@ -242,7 +242,7 @@ void LensProfilePanel::read(const rtengine::procparams::ProcParams* pp, const Pa
 
     if (pp->lensProf.lfAutoMatch()) {
         if (metadata) {
-            c = db->findCamera(metadata->getMake(), metadata->getModel());
+            c = db->findCamera(metadata->getMake(), metadata->getModel(), true);
             setLensfunCamera(c.getMake(), c.getModel());
         }
     } else if (pp->lensProf.lfManual()) {
@@ -521,7 +521,7 @@ void LensProfilePanel::onCorrModeChanged(const Gtk::RadioButton* rbChanged)
                 setLensfunLens("");
             } else if (metadata) {
                 const LFDatabase* const db = LFDatabase::getInstance();
-                const LFCamera c = db->findCamera(metadata->getMake(), metadata->getModel());
+                const LFCamera c = db->findCamera(metadata->getMake(), metadata->getModel(), true);
                 const LFLens l = db->findLens(c, metadata->getLens());
                 setLensfunCamera(c.getMake(), c.getModel());
                 setLensfunLens(l.getLens());
@@ -801,7 +801,7 @@ void LensProfilePanel::updateLensfunWarning()
             return;
         }
 
-        const LFCamera c = db->findCamera((*itc)[lf->lensfunModelCam.make], (*itc)[lf->lensfunModelCam.model]);
+        const LFCamera c = db->findCamera((*itc)[lf->lensfunModelCam.make], (*itc)[lf->lensfunModelCam.model], false);
         const auto itl = lensfunLenses->get_active();
 
         if (!itl) {


### PR DESCRIPTION
There's a possible bug in Lensfun which prevents it from matching certain lenses such as the Panasonic Lumix G 42.5mm f/1.7. I've added an additional lens search that does an exact match with the lens make and name.

Closes #5530.