### PR TITLE
Fix mutex try lock for debug builds

### DIFF
--- a/rtgui/threadutils.cc
+++ b/rtgui/threadutils.cc
@@ -29,9 +29,13 @@
 
 MyMutex::MyMutex() : locked(false) {}
 
-void MyMutex::checkLock ()
+bool MyMutex::checkLock (bool noError)
 {
     if (locked) {
+        if (noError) {
+            return false;
+        }
+
         std::cerr << "MyMutex already locked!" << std::endl;
 
 #ifdef _WIN32
@@ -42,6 +46,7 @@ void MyMutex::checkLock ()
     }
 
     locked = true;
+    return true;
 }
 
 void MyMutex::checkUnlock ()

--- a/rtgui/threadutils.h
+++ b/rtgui/threadutils.h
@@ -59,7 +59,7 @@ public:
 
 private:
     bool locked;
-    bool checkLock (bool noError=false);
+    bool checkLock (bool noError = false);
     void checkUnlock ();
 #endif
 };

--- a/rtgui/threadutils.h
+++ b/rtgui/threadutils.h
@@ -59,7 +59,7 @@ public:
 
 private:
     bool locked;
-    void checkLock ();
+    bool checkLock (bool noError=false);
     void checkUnlock ();
 #endif
 };
@@ -172,10 +172,10 @@ inline bool MyMutex::trylock ()
 {
     if (MyMutexBase::try_lock ()) {
 #if STRICT_MUTEX && !NDEBUG
-        checkLock ();
-#endif
-
+        return checkLock(true);
+#else
         return true;
+#endif
     }
 
     return false;


### PR DESCRIPTION
The debug build crashes because failing to acquire a lock with `trylock` throws an error. `trylock` should not throw an error upon failing, but just return false. The release build works properly. This fixes the bug for debug builds.