### PR TITLE
modal quit dialog

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1677,6 +1677,7 @@ MAIN_MSG_NAVIGATOR;Navigator
 MAIN_MSG_OPERATIONCANCELLED;Operation cancelled
 MAIN_MSG_PATHDOESNTEXIST;The path\n\n<b>%1</b>\n\ndoes not exist. Please set a correct path in Preferences.
 MAIN_MSG_QOVERWRITE;Do you want to overwrite it?
+MAIN_MSG_QUIT;Do you really want to quit RawTherapee?
 MAIN_MSG_SETPATHFIRST;You first have to set a target path in Preferences in order to use this function!
 MAIN_MSG_TOOMANYOPENEDITORS;Too many open editors.\nPlease close an editor to continue.
 MAIN_MSG_WRITEFAILED;Failed to write\n<b>'%1'</b>\n\nMake sure that the folder exists and that you have write permission to it.

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -18,6 +18,7 @@
  */
 
 #include <gtkmm.h>
+#include <gtk/gtk.h>
 #include "rtwindow.h"
 #include "cachemanager.h"
 #include "preferences.h"
@@ -818,7 +819,21 @@ bool RTWindow::on_delete_event (GdkEventAny* event)
     if (isProcessing) {
         return true;
     }
-
+    
+    // Ask user "Do you really want to quit RawTherapee?"
+    GtkDialogFlags diaflags = GTK_DIALOG_MODAL;
+    Gtk::MessageDialog d = Gtk::MessageDialog (*this, M("MAIN_MSG_QUIT"), GTK_DIALOG_MODAL, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_OK_CANCEL, true);
+    int sigresp;
+    sigresp = d.run();
+        switch (sigresp) {
+            case Gtk::RESPONSE_OK:
+                break;
+            case Gtk::RESPONSE_CANCEL:
+                return true;
+            case Gtk::RESPONSE_DELETE_EVENT:
+                return true;
+        }
+    
     if ( fpanel ) {
         fpanel->saveOptions ();
     }

--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -821,7 +821,6 @@ bool RTWindow::on_delete_event (GdkEventAny* event)
     }
     
     // Ask user "Do you really want to quit RawTherapee?"
-    GtkDialogFlags diaflags = GTK_DIALOG_MODAL;
     Gtk::MessageDialog d = Gtk::MessageDialog (*this, M("MAIN_MSG_QUIT"), GTK_DIALOG_MODAL, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_OK_CANCEL, true);
     int sigresp;
     sigresp = d.run();


### PR DESCRIPTION
Exiting RawTherapee is costly because of the loss of the detailed processing history. In order to prevent accidental deletion of the main RT window, this PR presents a modal exit confirmation dialog on exit.
![exit2](https://github.com/Beep6581/RawTherapee/assets/17919239/7af6a510-7ae5-4c62-aa95-0879fb3d2385)