### PR TITLE
Streamline Windows build action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,21 +35,22 @@ jobs:
         with:
           location: C:\msys2
           update: true
+          msystem: MINGW64
           install: |
             gzip
             git
             intltool
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-make
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-gtkmm3
-            mingw-w64-x86_64-lcms2
-            mingw-w64-x86_64-fftw
-            mingw-w64-x86_64-lensfun
-            mingw-w64-x86_64-libiptcdata
-            mingw-w64-x86_64-exiv2
+          pacboy: |
+            cc:p
+            pkgconf:p
+            cmake:p
+            ninja:p
+            gtkmm3:p
+            lcms2:p
+            fftw:p
+            lensfun:p
+            libiptcdata:p
+            exiv2:p
 
       - name: Configure build
         run: |
@@ -63,11 +64,6 @@ jobs:
             echo "Cache suffix is '$CACHE_SUFFIX'."
           fi
 
-          echo "Making build directory."
-          mkdir build
-          echo "Changing working directory to the build directory."
-          cd build
-
           echo "Running CMake configure."
           cmake \
             -G "Ninja" \
@@ -75,21 +71,18 @@ jobs:
             -DCACHE_NAME_SUFFIX="$CACHE_SUFFIX" \
             -DPROC_TARGET_NUMBER="1" \
             -DLENSFUNDBDIR="share/lensfun" \
-            ..
+            -S . -B build
 
           echo "Recording filtered ref name."
           echo "REF_NAME_FILTERED=$REF_NAME_FILTERED" >> "$(cygpath -u $GITHUB_ENV)"
 
       - name: Build RawTherapee
-        working-directory: ./build
         run: |
           echo "Running CMake install."
-          cmake --build . --target install
+          cmake --build build --target install
 
       - name: Include Lensfun
         run: |
-          echo "Patching lensfun-update-data script."
-          sed -i 's/HTTPError\(, ValueError\)/URLError\1/' $(which lensfun-update-data)
           echo "Updating Lensfun database."
           lensfun-update-data
           echo "Creating Lensfun directory in the build directory."


### PR DESCRIPTION
Use pacboy for msystem independent install (easier to switch/test more [environments](https://www.msys2.org/docs/environments/) later)
Use build directory directly from CMake
Remove lensfun patch (included upstream)