### PR TITLE
Fix for crash when moving cursor over loading raw image

### DIFF
--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -16,6 +16,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -743,6 +744,8 @@ void RawImageSource::getWBMults(const ColorTemp &ctemp, const RAWParams &raw, st
 
 void RawImageSource::getImage(const ColorTemp &ctemp, int tran, Imagefloat* image, const PreviewProps &pp, const ToneCurveParams &hrp, const RAWParams &raw)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
     MyMutex::MyLock lock(getImageMutex);
 
     tran = defTransform(ri, tran);
@@ -1744,6 +1747,8 @@ void RawImageSource::preprocess(const RAWParams &raw, const LensProfParams &lens
 
 void RawImageSource::demosaic(const RAWParams &raw, bool autoContrast, double &contrastThreshold, bool cache)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
     MyTime t1, t2;
     t1.set();
 
@@ -3837,6 +3842,8 @@ void RawImageSource::hlRecovery(const std::string &method, float* red, float* gr
 
 void RawImageSource::getAutoExpHistogram(LUTu & histogram, int& histcompr)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
 //    BENCHFUN
     histcompr = 3;
 
@@ -7481,6 +7488,8 @@ void RawImageSource::getrgbloc(int begx, int begy, int yEn, int xEn, int cx, int
 
 void RawImageSource::getAutoWBMultipliersitc(bool extra, double & tempref, double & greenref, double & tempitc, double & greenitc, float &temp0, float &delta,  int &bia, int &dread, int &kcam, int &nocam, float &studgood, float &minchrom, int &kmin,  float &minhist, float &maxhist, int begx, int begy, int yEn, int xEn, int cx, int cy, int bf_h, int bf_w, double & rm, double & gm, double & bm, const WBParams & wbpar, const ColorManagementParams & cmp, const RAWParams & raw, const ToneCurveParams &hrp)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
 //    BENCHFUN
     constexpr double clipHigh = 64000.0;
 
@@ -7710,6 +7719,8 @@ void RawImageSource::getAutoWBMultipliersitc(bool extra, double & tempref, doubl
 
 void RawImageSource::getAutoWBMultipliers(double &rm, double &gm, double &bm)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
 //    BENCHFUN
     constexpr double clipHigh = 64000.0;
 
@@ -7926,6 +7937,7 @@ void RawImageSource::getAutoWBMultipliers(double &rm, double &gm, double &bm)
 
 ColorTemp RawImageSource::getSpotWB(std::vector<Coord2D> &red, std::vector<Coord2D> &green, std::vector<Coord2D> &blue, int tran, double equal, StandardObserver observer)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
 
     int x;
     int y;
@@ -8265,7 +8277,7 @@ void RawImageSource::init()
 
 void RawImageSource::getRawValues(int x, int y, int rotate, int &R, int &G, int &B)
 {
-    if (d1x) { // Nikon D1x has special sensor. We just skip it
+    if (rawData.getWidth() != W || rawData.getHeight() != H || d1x) { // Nikon D1x has special sensor. We just skip it
         R = G = B = 0;
         return;
     }
@@ -8313,6 +8325,8 @@ bool RawImageSource::isGainMapSupported() const
 
 void RawImageSource::applyDngGainMap(const float black[4], const std::vector<GainMap> &gainMaps)
 {
+    assert(rawData.getHeight() == H && rawData.getWidth() == W);
+
     // now we can apply each gain map to raw_data
     array2D<float> mvals[2][2];
 


### PR DESCRIPTION
If the image has the demosic method set to None, the navigator requests the raw value of the pixel under the cursor. When loading an image, the raw data may not be completely loaded when the request occurs. It causes a crash due to an out of bound access. I added a check that returns zero values for the pixel if the data is not loaded and also asserts for debug builds to catch other use-before-initialization errors. The data loading is asynchronous which makes it difficult to have a "proper" fix. That's why I opted for this simple fix.

Closes #6875.