### PR TITLE
AppImage workflow debug build

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [release]
+        build_type: [release, debug]
     steps:
       - name: Checkout source
         uses: actions/checkout@v3


### PR DESCRIPTION
GDB works on AppImages, both directly and on the extracted files. This pull request enables the debug build for AppImages. Linux users who report bugs will have debug builds readily available to them.