### PR TITLE
bump macos CI workflow to macos-12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
macos-11 is obsolete to homebrew