### PR TITLE
GitHub Actions triggers for release branches

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -4,11 +4,14 @@ on:
     branches:
       - dev
       - releases
+      - 'release-[0-9]+.*'
     tags:
       - '[0-9]+.*'
   pull_request:
     branches:
       - dev
+      - releases
+      - 'release-[0-9]+.*'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,16 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'dev' ]
+    branches:
+      - dev
+      - releases
+      - 'release-[0-9]+.*'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ 'dev' ]
+    branches:
+      - dev
+      - releases
+      - 'release-[0-9]+.*'
   schedule:
     - cron: '56 5 * * 1'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,11 +4,14 @@ on:
     branches:
       - dev
       - releases
+      - 'release-[0-9]+.*'
     tags:
       - '[0-9]+.*'
   pull_request:
     branches:
       - dev
+      - releases
+      - 'release-[0-9]+.*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,11 +4,14 @@ on:
     branches:
       - dev
       - releases
+      - 'release-[0-9]+.*'
     tags:
       - '[0-9]+.*'
   pull_request:
     branches:
       - dev
+      - releases
+      - 'release-[0-9]+.*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Enables GitHub Actions workflows to run when:

- A branch named `release-[0-9]+.*` is updated
- A pull request targeting `releases` is updated
- A pull request targeting `release-[0-9]+.*` is updated