### PR TITLE
Change default behavior Local Adjustments settings Avoid Color Shift to XYZ Absolute

### DIFF
--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -2972,7 +2972,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     structexclu(0),
     struc(4.0),
     shapeMethod("IND"),
-    avoidgamutMethod("MUNS"),
+    avoidgamutMethod("XYZ"),
     loc{150, 150, 150, 150},
     centerX(0),
     centerY(0),

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -407,7 +407,7 @@ ControlSpotPanel::ControlSpotPanel():
     avoidgamutMethod_->append(M("TP_LOCALLAB_GAMUTXYZABSO"));
     avoidgamutMethod_->append(M("TP_LOCALLAB_GAMUTXYZRELA"));
     avoidgamutMethod_->append(M("TP_LOCALLAB_GAMUTMUNSELL"));
-    avoidgamutMethod_->set_active(4);
+    avoidgamutMethod_->set_active(2);
     avoidgamutconn_ = avoidgamutMethod_->signal_changed().connect(
                      sigc::mem_fun(
                          *this, &ControlSpotPanel::avoidgamutMethodChanged));


### PR DESCRIPTION
I propose this small change of 2 files - Procparams.cc and Controlspotpanel.cc - both seem necessary to ensure proper functioning.

This change aims to avoid bad behavior when the image contains strong highlights (artifacts, bad command responses, etc.).

This choice executes a gamut check in XYZ mode, at the end of the various actions on an RT-spot, whatever the number of tools used in this RT-spot.

Of course it is followed by “Munsell correction”, which corrects color drift specific to Lab mode (blue/purple, red/orange, green, etc.)

The increase in processing time is reasonable on average 200ms (full image) and concerns an RT-spot.

Of course the user can always select another choice ("none", "Munsell only", etc.)

Jacques