### PR TITLE
Sony ILCE-7CR / ILCE-7RM5 camconst

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -3076,7 +3076,17 @@ Camera constants:
     { // Quality C,
         "make_model": "Sony ILCE-7RM4",
         "dcraw_matrix": [ 7662, -2686, -660, -5240, 12965, 2530, -796, 1508, 6167 ],
-        "raw_crop": [ 0, 0, -32, 0 ] // full raw frame 9600x6376 - 32 rightmost columns are garbage. Using -32 instead of 9568 to support also 16-shot pixelshift files
+        "raw_crop": [ 0, 0, -32, 0 ], // full raw frame 9600x6376 - 32 rightmost columns are garbage. Using -32 instead of 9568 to support also 16-shot pixelshift files
+        "pdaf_pattern": [ 0,12,18,36,42,60,66,72,78,96,108,120,126,138,156,168,180,186,192,198,210,222,228,240,246,252,270,276,282,288,306,312,318,330,336,348,360,366,372,378,390,396,408,420 ], // Assume the pattern is the same as the ILCE-7CR.
+        "pdaf_offset": 1
+    },
+
+    { // Quality B
+        "make_model": [ "Sony ILCE-7CR", "Sony ILCE-7RM5" ], // 7RM5 is assumed to have the same sensor as the 7CR.
+        "dcraw_matrix": [ 8200, -2976, -719, -4296, 12053, 2532, -429, 1282, 5774 ], // DNG v15.2 for ILCE-7CR and ILCE-7RM5.
+        "raw_crop": [ 0, 0, -32, 0 ], // A few repeated pixels on the right edge.
+        "pdaf_pattern": [ 0,12,18,36,42,60,66,72,78,96,108,120,126,138,156,168,180,186,192,198,210,222,228,240,246,252,270,276,282,288,306,312,318,330,336,348,360,366,372,378,390,396,408,420 ], // From issue #6938. Slightly different every repetition, maybe the real pattern is 3 or more multiples of 420 pixels. This is a composite.
+        "pdaf_offset": 1
     },
 
     { // Quality B, assumed correct for 9M2 as well


### PR DESCRIPTION
PDAF pattern, raw crop, and dcraw matrix for the ILCE-7CR and ILCE-7RM5. The PDAF pattern does not perfectly repeat, but is very close. A better sample image would be needed to determine if the pattern is larger. So far, it looks like it does not repeat perfectly every 840 pixels either (the current pattern is 420 pixels). The two or three extra false rows per pattern is unlikely to have a noticeable effect on the image quality.

Closes #6938.