### PR TITLE
Windows/innosetup: comment out deleted font

### DIFF
--- a/tools/win/InnoSetup/WindowsInnoSetup.iss.in
+++ b/tools/win/InnoSetup/WindowsInnoSetup.iss.in
@@ -119,7 +119,7 @@ Source: "{#MyBuildBasePath}\*.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyBuildBasePath}\gspawn-win{#MyBitDepth}-helper.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyBuildBasePath}\gspawn-win{#MyBitDepth}-helper-console.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyBuildBasePath}\gdb.exe"; DestDir: "{app}"; Flags: skipifsourcedoesntexist ignoreversion
-Source: "{#MyBuildBasePath}\fonts\DroidSansMonoSlashed.ttf"; DestDir: "{fonts}"; FontInstall: "Droid Sans Mono Slashed"; Flags: onlyifdoesntexist uninsneveruninstall
+;Source: "{#MyBuildBasePath}\fonts\DroidSansMonoSlashed.ttf"; DestDir: "{fonts}"; FontInstall: "Droid Sans Mono Slashed"; Flags: onlyifdoesntexist uninsneveruninstall
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
bf988ad2744865f151611a2761a91c9d90f7ba83 removes the default font in favor of the OS default. `tools/win/InnoSetup/WindowsInnoSetup.iss.in` Line 122 causes the win build fail trying to load the deleted font.