### PR TITLE
Read camera white balance for Canon EOS R6m2, R7, and more

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6124,7 +6124,7 @@ get2_256:
       // imCanon.ColorDataVer = 11;
       imCanon.ColorDataSubVer = get2();
 
-      fseek(ifp, save1 + ((0x0069+0x0064) << 1), SEEK_SET);
+      fseek(ifp, save1 + (0x0069 << 1), SEEK_SET);
       FORC4 cam_mul[c ^ (c >> 1)] = (float)get2();
 
       offsetChannelBlackLevel2 = save1 + ((0x0069+0x0102) << 1);


### PR DESCRIPTION
PR #6543 added support for these cameras, but the code for reading the camera white balance multipliers was incorrectly ported from LibRaw. It was reading the wrong tag, the daylight white balance instead of the as-shot white balance. Here's the LibRaw code where the tags were mixed up:
https://github.com/LibRaw/LibRaw/blob/a4c9b1981ee4ac2a144e7a290988428cc5bb7e85/src/metadata/canon.cpp#L1253-L1259

Test images can be found in [this comment on the forum](https://discuss.pixls.us/t/questions-how-to-choose-a-dcp-profile-if-at-all/42404/46).