### PR TITLE
Add optional image rank/color load/save from/to xmp sidecar

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2033,6 +2033,7 @@ PREFERENCES_THUMBNAIL_INSPECTOR_JPEG;Embedded JPEG preview
 PREFERENCES_THUMBNAIL_INSPECTOR_MODE;Image to show
 PREFERENCES_THUMBNAIL_INSPECTOR_RAW;Neutral raw rendering
 PREFERENCES_THUMBNAIL_INSPECTOR_RAW_IF_NO_JPEG_FULLSIZE;Embedded JPEG if fullsize, neutral raw otherwise
+PREFERENCES_THUMBNAIL_RANK_COLOR_MODE;Load/Save thumbnail rank and color from/to XMP sidecars
 PREFERENCES_TOOLPANEL_AVAILABLETOOLS;Available Tools
 PREFERENCES_TOOLPANEL_CLONE_FAVORITES;Keep favorite tools in original locations
 PREFERENCES_TOOLPANEL_CLONE_FAVORITES_TOOLTIP;If set, favorite tools will appear in both the favorites tab and their original tabs.\n\nNote: Enabling this option may result in a slight delay when switching tabs.

--- a/rtengine/metadata.cc
+++ b/rtengine/metadata.cc
@@ -106,19 +106,6 @@ void clear_metadata_key(Data &data, const Key &key)
     }
 }
 
-template <typename Iterator, typename Integer = std::size_t>
-auto to_long(const Iterator &iter, Integer n = Integer{0}) -> decltype(
-#if EXIV2_TEST_VERSION(0,28,0)
-    iter->toInt64()
-) {
-    return iter->toInt64(n);
-#else
-    iter->toLong()
-) {
-    return iter->toLong(n);
-#endif
-}
-
 } // namespace
 
 

--- a/rtengine/metadata.h
+++ b/rtengine/metadata.h
@@ -97,4 +97,18 @@ private:
     static std::unique_ptr<ImageCache> cache_;
 };
 
+template <typename Iterator, typename Integer = std::size_t>
+auto to_long(const Iterator &iter, Integer n = Integer{0}) -> decltype(
+#if EXIV2_TEST_VERSION(0,28,0)
+    iter->toInt64()
+) {
+    return iter->toInt64(n);
+#else
+    iter->toLong()
+) {
+    return iter->toLong(n);
+#endif
+}
+
+
 } // namespace rtengine

--- a/rtgui/filebrowser.cc
+++ b/rtgui/filebrowser.cc
@@ -547,13 +547,13 @@ void FileBrowser::rightClicked ()
         untrash->set_sensitive (false);
 
         for (size_t i = 0; i < selected.size(); i++)
-            if ((static_cast<FileBrowserEntry*>(selected[i]))->thumbnail->getStage()) {
+            if ((static_cast<FileBrowserEntry*>(selected[i]))->thumbnail->getTrashed()) {
                 untrash->set_sensitive (true);
                 break;
             }
 
         for (size_t i = 0; i < selected.size(); i++)
-            if (!(static_cast<FileBrowserEntry*>(selected[i]))->thumbnail->getStage()) {
+            if (!(static_cast<FileBrowserEntry*>(selected[i]))->thumbnail->getTrashed()) {
                 trash->set_sensitive (true);
                 break;
             }
@@ -649,7 +649,7 @@ void FileBrowser::addEntry_ (FileBrowserEntry* entry)
     entry->addButtonSet(new FileThumbnailButtonSet(entry));
     entry->getThumbButtonSet()->setRank(entry->thumbnail->getRank());
     entry->getThumbButtonSet()->setColorLabel(entry->thumbnail->getColorLabel());
-    entry->getThumbButtonSet()->setInTrash(entry->thumbnail->getStage());
+    entry->getThumbButtonSet()->setInTrash(entry->thumbnail->getTrashed());
     entry->getThumbButtonSet()->setButtonListener(this);
     entry->resize(getThumbnailHeight());
     entry->filtered = !checkFilter(entry);
@@ -1023,12 +1023,12 @@ void FileBrowser::menuItemActivated (Gtk::MenuItem* m)
             const auto thumbnail = mselected[i]->thumbnail;
             const auto rank = thumbnail->getRank();
             const auto colorLabel = thumbnail->getColorLabel();
-            const auto stage = thumbnail->getStage();
+            const auto stage = thumbnail->getTrashed();
 
             thumbnail->createProcParamsForUpdate (false, true);
             thumbnail->setRank(rank);
             thumbnail->setColorLabel(colorLabel);
-            thumbnail->setStage(stage);
+            thumbnail->setTrashed(stage);
 
             // Empty run to update the thumb
             rtengine::procparams::ProcParams params = thumbnail->getProcParams ();
@@ -1558,8 +1558,8 @@ bool FileBrowser::checkFilter (ThumbBrowserEntryBase* entryb) const   // true ->
             ((entry->thumbnail->isRecentlySaved() && filter.showRecentlySaved[0]) && !filter.showRecentlySaved[1]) ||
             ((!entry->thumbnail->isRecentlySaved() && filter.showRecentlySaved[1]) && !filter.showRecentlySaved[0]) ||
 
-            (entry->thumbnail->getStage() && !filter.showTrash) ||
-            (!entry->thumbnail->getStage() && !filter.showNotTrash)) {
+            (entry->thumbnail->getTrashed() && !filter.showTrash) ||
+            (!entry->thumbnail->getTrashed() && !filter.showNotTrash)) {
         return false;
     }
 
@@ -1625,11 +1625,11 @@ void FileBrowser::toTrashRequested (std::vector<FileBrowserEntry*> tbe)
 
         // no need to notify listeners as item goes to trash, likely to be deleted
 
-        if (tbe[i]->thumbnail->getStage()) {
+        if (tbe[i]->thumbnail->getTrashed()) {
             continue;
         }
 
-        tbe[i]->thumbnail->setStage (true);
+        tbe[i]->thumbnail->setTrashed (true);
 
         if (tbe[i]->getThumbButtonSet()) {
             tbe[i]->getThumbButtonSet()->setRank (tbe[i]->thumbnail->getRank());
@@ -1649,11 +1649,11 @@ void FileBrowser::fromTrashRequested (std::vector<FileBrowserEntry*> tbe)
     for (size_t i = 0; i < tbe.size(); i++) {
         // if thumbnail was marked inTrash=true then param file must be there, no need to run customprofilebuilder
 
-        if (!tbe[i]->thumbnail->getStage()) {
+        if (!tbe[i]->thumbnail->getTrashed()) {
             continue;
         }
 
-        tbe[i]->thumbnail->setStage (false);
+        tbe[i]->thumbnail->setTrashed (false);
 
         if (tbe[i]->getThumbButtonSet()) {
             tbe[i]->getThumbButtonSet()->setRank (tbe[i]->thumbnail->getRank());
@@ -1784,7 +1784,7 @@ void FileBrowser::buttonPressed (LWButton* button, int actionCode, void* actionD
         FileBrowserEntry* entry = static_cast<FileBrowserEntry*>(actionData);
         tbe.push_back (entry);
 
-        if (!entry->thumbnail->getStage()) {
+        if (!entry->thumbnail->getTrashed()) {
             toTrashRequested (tbe);
         } else {
             fromTrashRequested (tbe);

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1910,7 +1910,7 @@ void FileCatalog::emptyTrash ()
     std::vector<FileBrowserEntry*> toDel;
 
     for (const auto entry : t) {
-        if ((static_cast<FileBrowserEntry*>(entry))->thumbnail->getStage() == 1) {
+        if ((static_cast<FileBrowserEntry*>(entry))->thumbnail->getTrashed()) {
             toDel.push_back(static_cast<FileBrowserEntry*>(entry));
         }
     }
@@ -1926,7 +1926,7 @@ bool FileCatalog::trashIsEmpty ()
     const auto& t = fileBrowser->getEntries();
 
     for (const auto entry : t) {
-        if ((static_cast<FileBrowserEntry*>(entry))->thumbnail->getStage() == 1) {
+        if ((static_cast<FileBrowserEntry*>(entry))->thumbnail->getTrashed()) {
             return false;
         }
     }

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -694,6 +694,7 @@ void Options::setDefaults()
     lastICCProfCreatorDir = "";
     gimpPluginShowInfoDialog = true;
     maxRecentFolders = 15;
+    thumbnailRankColorMode = Options::ThumbnailPropertyMode::PROCPARAMS;
     sortMethod = SORT_BY_NAME;
     sortDescending = false;
     rtSettings.lensfunDbDirectory = ""; // set also in main.cc and main-cli.cc
@@ -1365,6 +1366,15 @@ void Options::readFromFile(Glib::ustring fname)
 
                 if (keyFile.has_key("File Browser", "BrowseRecursiveFollowLinks")) {
                     browseRecursiveFollowLinks = keyFile.get_boolean("File Browser", "BrowseRecursiveFollowLinks");
+                }
+
+                if (keyFile.has_key("File Browser", "ThumbnailRankColorMode")) {
+                    std::string val = keyFile.get_string("File Browser", "ThumbnailRankColorMode");
+                    if (val == "xmp") {
+                        thumbnailRankColorMode = ThumbnailPropertyMode::XMP;
+                    } else {
+                        thumbnailRankColorMode = ThumbnailPropertyMode::PROCPARAMS;
+                    }
                 }
             }
 
@@ -2461,6 +2471,14 @@ void Options::saveToFile(Glib::ustring fname)
             }
 
             keyFile.set_string_list("File Browser", "RecentFolders", temp);
+        }
+        switch (thumbnailRankColorMode) {
+        case ThumbnailPropertyMode::XMP:
+            keyFile.set_string("File Browser", "ThumbnailRankColorMode", "xmp");
+            break;
+        default: // ThumbnailPropertyMode::PROCPARAMS
+            keyFile.set_string("File Browser", "ThumbnailRankColorMode", "procparams");
+            break;
         }
         keyFile.set_integer("File Browser", "SortMethod", sortMethod);
         keyFile.set_boolean("File Browser", "SortDescending", sortDescending);

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -492,6 +492,12 @@ public:
     size_t maxRecentFolders;                   // max. number of recent folders stored in options file
     std::vector<Glib::ustring> recentFolders;  // List containing all recent folders
 
+    enum class ThumbnailPropertyMode {
+        PROCPARAMS, // store rank and color in procparams sidecars
+        XMP // store rank and color xmp sidecar
+    };
+    ThumbnailPropertyMode thumbnailRankColorMode;
+
     enum SortMethod {
         SORT_BY_NAME,
         SORT_BY_DATE,

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1470,6 +1470,9 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     vbro->pack_start(*sameThumbSize, Gtk::PACK_SHRINK, 0);
     vbro->pack_start(*ckbInternalThumbIfUntouched, Gtk::PACK_SHRINK, 0);
 
+    thumbnailRankColorMode = Gtk::manage(new Gtk::CheckButton(M("PREFERENCES_THUMBNAIL_RANK_COLOR_MODE")));
+    vbro->pack_start(*thumbnailRankColorMode, Gtk::PACK_SHRINK, 0);
+
     Gtk::Box* hbrecent = Gtk::manage(new Gtk::Box());
     Gtk::Label* labrecent = Gtk::manage (new Gtk::Label (M("PREFERENCES_MAXRECENTFOLDERS") + ":", Gtk::ALIGN_START));
     maxRecentFolders = Gtk::manage(new Gtk::SpinButton());
@@ -2029,6 +2032,8 @@ void Preferences::storePreferences()
 
     moptions.rtSettings.metadata_xmp_sync = rtengine::Settings::MetadataXmpSync(metadataSyncCombo->get_active_row_number());
     moptions.rtSettings.xmp_sidecar_style = rtengine::Settings::XmpSidecarStyle(xmpSidecarCombo->get_active_row_number());
+
+    moptions.thumbnailRankColorMode = thumbnailRankColorMode->get_active() ? Options::ThumbnailPropertyMode::XMP : Options::ThumbnailPropertyMode::PROCPARAMS;
 }
 
 void Preferences::fillPreferences()
@@ -2287,6 +2292,8 @@ void Preferences::fillPreferences()
 
     metadataSyncCombo->set_active(int(moptions.rtSettings.metadata_xmp_sync));
     xmpSidecarCombo->set_active(int(moptions.rtSettings.xmp_sidecar_style));
+
+    thumbnailRankColorMode->set_active(moptions.thumbnailRankColorMode == Options::ThumbnailPropertyMode::XMP);
 }
 
 /*

--- a/rtgui/preferences.h
+++ b/rtgui/preferences.h
@@ -224,6 +224,8 @@ class Preferences final :
 
     Gtk::CheckButton* ckbInternalThumbIfUntouched;
 
+    Gtk::CheckButton *thumbnailRankColorMode;
+
     Gtk::Entry* txtCustProfBuilderPath;
     Gtk::ComboBoxText* custProfBuilderLabelType;
 

--- a/rtgui/thumbnail.cc
+++ b/rtgui/thumbnail.cc
@@ -141,7 +141,7 @@ Thumbnail::Thumbnail(CacheManager* cm, const Glib::ustring& fname, CacheImageDat
         // TODO? should we call notifylisterners_procParamsChanged here?
 
         setRank(cfs.rankOld);
-        setStage(cfs.inTrashOld);
+        setTrashed(cfs.inTrashOld);
     }
 
     delete tpp;
@@ -444,7 +444,7 @@ void Thumbnail::clearProcParams (int whoClearedIt)
         // preserve rank, colorlabel and inTrash across clear
         int rank = getRank();
         int colorlabel = getColorLabel();
-        int inTrash = getStage();
+        int inTrash = getTrashed();
 
 
         cfs.recentlySaved = false;
@@ -460,7 +460,7 @@ void Thumbnail::clearProcParams (int whoClearedIt)
         setRank(rank);
         pparamsValid = cfs.rating != rank;
         setColorLabel(colorlabel);
-        setStage(inTrash);
+        setTrashed(inTrash);
 
         // params could get validated by rank/inTrash values restored above
         if (pparamsValid) {
@@ -563,7 +563,7 @@ void Thumbnail::setProcParams (const ProcParams& pp, ParamsEdited* pe, int whoCh
         // do not update rank, colorlabel and inTrash
         const int rank = getRank();
         const int colorlabel = getColorLabel();
-        const int inTrash = getStage();
+        const int inTrash = getTrashed();
 
         if (pe) {
             pe->combine(*pparams, pp, true);
@@ -575,7 +575,7 @@ void Thumbnail::setProcParams (const ProcParams& pp, ParamsEdited* pe, int whoCh
 
         setRank(rank);
         setColorLabel(colorlabel);
-        setStage(inTrash);
+        setTrashed(inTrash);
 
         if (updateCacheNow) {
             updateCache();
@@ -1115,15 +1115,15 @@ void Thumbnail::setColorLabel  (int colorlabel)
     }
 }
 
-int Thumbnail::getStage () const
+bool Thumbnail::getTrashed () const
 {
     return pparams->inTrash;
 }
 
-void Thumbnail::setStage (bool stage)
+void Thumbnail::setTrashed (bool trashed)
 {
-    if (pparams->inTrash != stage) {
-        pparams->inTrash = stage;
+    if (pparams->inTrash != trashed) {
+        pparams->inTrash = trashed;
         pparamsValid = true;
     }
 }

--- a/rtgui/thumbnail.h
+++ b/rtgui/thumbnail.h
@@ -78,6 +78,30 @@ class Thumbnail
 
     bool            initial_;
 
+    // Properties holds values and edited states for rank, color and trashed
+    struct Properties {
+        template <class T> struct Property {
+            T value;
+            bool edited;
+            Property(T v): value(v), edited(false) {}
+            Property& operator=(T v)
+            {
+                value = v;
+                edited = true;
+                return *this;
+            }
+            operator T() const { return value; }
+        };
+        Property<int> rank;
+        Property<int> color;
+        Property<bool> trashed;
+
+        explicit Properties(int r=0, int c=0, bool t=false):
+            rank(r), color(c), trashed(t) {}
+        bool edited() const { return rank.edited || color.edited || trashed.edited; }
+    };
+    Properties properties;
+
     // vector of listeners
     std::vector<ThumbnailListener*> listeners;
 
@@ -90,6 +114,8 @@ class Thumbnail
     Glib::ustring    getCacheFileName (const Glib::ustring& subdir, const Glib::ustring& fext) const;
 
     void saveMetadata();
+    void loadProperties();
+    void updateProcParamsProperties();
 
 public:
     Thumbnail (CacheManager* cm, const Glib::ustring& fname, CacheImageData* cf);

--- a/rtgui/thumbnail.h
+++ b/rtgui/thumbnail.h
@@ -116,6 +116,7 @@ class Thumbnail
     void saveMetadata();
     void loadProperties();
     void updateProcParamsProperties();
+    void saveXMPSidecarProperties();
 
 public:
     Thumbnail (CacheManager* cm, const Glib::ustring& fname, CacheImageData* cf);

--- a/rtgui/thumbnail.h
+++ b/rtgui/thumbnail.h
@@ -155,8 +155,8 @@ public:
     int             getColorLabel  () const;
     void            setColorLabel  (int colorlabel);
 
-    int             getStage () const;
-    void            setStage (bool stage);
+    bool            getTrashed () const;
+    void            setTrashed (bool trashed);
 
     void            addThumbnailListener (ThumbnailListener* tnl);
     void            removeThumbnailListener (ThumbnailListener* tnl);


### PR DESCRIPTION
## TLDR

Add optional image rank/color load/save from/to xmp sidecar

Why only rank and color and not trash?
* Rank is mappable to `xmp.Rating` (but no support for -1 rating)
* Colors can be mapped to `xmp.Label` with some downsides due to a non standardized use of a label string.
* trash doesn't clearly map to -1 rating. If we really want to do this there's the need to change the current rawtherapee rank/trash logic.

**A detailed explanation is in the NOTES below.**

* Also color could be confusing (see NOTES below) so I'm open to just keep the rating if preferred.

* If this will be merged I'll add related docs to rawpedia for integrating this with other tools like digikam.

* Should Fix different opened issues (need to reference them here....)

## Description

These are 3 (self contained) patches. They're split to better explain the various changes, so I suggest to look at them one by one.

Add optional ability to load/save image rank property from/to xmp sidecar "xmp.Rating" and color property from xmp "xmp.Label" ignoring the ones provided in the processing params file.

This behavior is disabled by default and an option under settings -> file browser has been added to enable it.

When enabled:

* On load:
  * rank and color are not read from processing params.
  * rank is mapped from xmp sidecar file rating entry.
  * color is mapped from xmp sidecar file label entry.

* On save:
  * rank and color are saved to the xmp sidecar
  * rank and color are also saved to the processing param (pp3) files to keep them in sync

Rating mapping:

Since rating can be also -1 but rank only goes from 0 to 5, the -1 value is ignored like already done when importing from embedded xmp data.

Color mapping:

XMP has no color concept, usually programs like digikam uses the label field to write a color name ("Red", "Orange"). The problem is that this isn't standardized and label can be any string. Additionally Rawtherapee has 5 specific colors while other programs can have different colors with different name so they won't be shown if they don't map to the 5
color names supported by rawtherapee. On save only the 5 color supported by rawtherapee wil be saved.

## NOTES

* The main use case is to do culling by rating using another program like digikam, but be able to see and change the same rating also in rawtherapee. So a bidirectional sync. This can be accomplished by **correctly** configuring the "culling" program to read/write the rating to an xmp sidecar file (choosing one of the two xmp extension modes supported by rawtherapee).

* This is something already implemented in ART but with also trash mapped to xmp rating -1.

## Trash mapping issues

When testing the ART implementation, the mapping of trash to rating = -1 caused some bad/confusing behavior.
So I felt that the better way was to map only the rating and colors (also with some downsides) and leave trash in the processing parameters.

Here some reason of this choice:

* There's no trash concept in xmp, there's the rejected concept assigned
  to a rating == -1.
* We could map rejected to trash but in rawtherapee rank and trash are two different values and an image can have both rank >= 0 and trashed set to true.
  Using an unique value like rating for rank and trash (when -1) will require changing the current rawtherapee logic.
* Also digikam only handles ratings from 0 to 5 (no -1) and handles trash in its own internal way without reflecting it in the xmp sidecar.

## Color mapping issues

* XMP has no color concept, usually programs like digikam uses the xmp label field to write a color name ("Red", "Orange"). The problem is that this isn't standardized and label can be any string. Additionally Rawtherapee has 5 specific colors while other programs can have different colors with different name so they won't be shown if they don't map to the 5 color names supported by rawtherapee. 
* Every app has custom support for color and uses additional fields. This patch only uses the xmp.Label field.
  * As an example "digikam" by default uses an additional custom field (`digiKam.ColorLabel`) to save color labels. This has the priority over the xmp label field. So if the xmp has already the `digiKam.ColorLabel` (because you set the color with digikam), the changes to colors done by rawtherapee to the xmp.Label fields are ignored. For a working two way sync Digikam must be configured to prefer the xml.Label field.


