### PR TITLE
camconst.json added Nikon Z f

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -2032,7 +2032,7 @@ Camera constants:
     },
 
     { // Quality C
-        "make_model" : "Nikon Z 6_2",
+        "make_model" : [ "Nikon Z 6_2", "Nikon Z f" ],
         "dcraw_matrix" : [9943, -3270, -839, -5323, 13269, 2259, -1198, 2083, 7557] // DNG
     },
 


### PR DESCRIPTION
According to Wikipedia, Nikon Z f uses the same sensor as Nikon Z 6 II.

Until further improvement with new measurements, we can reuse the existing Z 6 II constants.

Tested with a RAW image from the Z f and looks suitable.