### PR TITLE
Handle flat field images with different black levels than raw image

### DIFF
--- a/rtengine/ffmanager.cc
+++ b/rtengine/ffmanager.cc
@@ -145,6 +145,7 @@ void ffInfo::updateRawImage()
             int H = ri->get_height();
             int W = ri->get_width();
             ri->compress_image(0);
+            ri->set_prefilters();
             int rSize = W * ((ri->getSensorType() == ST_BAYER || ri->getSensorType() == ST_FUJI_XTRANS || ri->get_colors() == 1) ? 1 : 3);
             acc_t **acc = new acc_t*[H];
 
@@ -165,6 +166,7 @@ void ffInfo::updateRawImage()
 
                 if( !temp->loadRaw(true)) {
                     temp->compress_image(0);     //\ TODO would be better working on original, because is temporary
+                    temp->set_prefilters();
                     nFiles++;
 
                     if( ri->getSensorType() == ST_BAYER || ri->getSensorType() == ST_FUJI_XTRANS || ri->get_colors() == 1 ) {
@@ -204,6 +206,7 @@ void ffInfo::updateRawImage()
             ri = nullptr;
         } else {
             ri->compress_image(0);
+            ri->set_prefilters();
         }
     }
 

--- a/rtengine/rawimagesource.h
+++ b/rtengine/rawimagesource.h
@@ -138,7 +138,7 @@ public:
         return rgbSourceModified;   // tracks whether cached rgb output of demosaic has been modified
     }
 
-    void        processFlatField(const procparams::RAWParams &raw, const RawImage *riFlatFile, array2D<float> &rawData, const float black[4]);
+    void        processFlatField(const procparams::RAWParams &raw, RawImage *riFlatFile, array2D<float> &rawData, const float black[4]);
     void        copyOriginalPixels(const procparams::RAWParams &raw, RawImage *ri, const RawImage *riDark, RawImage *riFlatFile, array2D<float> &rawData  );
     void        scaleColors (int winx, int winy, int winw, int winh, const procparams::RAWParams &raw, array2D<float> &rawData); // raw for cblack
     void        WBauto(bool extra, double &tempref, double &greenref, array2D<float> &redloc, array2D<float> &greenloc, array2D<float> &blueloc, int bfw, int bfh, double &avg_rm, double &avg_gm, double &avg_bm, double &tempitc, double &greenitc, float &temp0, float &delta, int &bia,  int &dread, int &kcam, int &nocam, float &studgood, float &minchrom, int &kmin, float &minhist, float &maxhist, bool &twotimes, const procparams::WBParams & wbpar, int begx, int begy, int yEn, int xEn, int cx, int cy, const procparams::ColorManagementParams &cmp, const procparams::RAWParams &raw, const procparams::ToneCurveParams &hrp) override;


### PR DESCRIPTION
For bayer images handle flat field images with different black levels than the raw image.

## NOTES

* This is a port from ART.

* Looks likes this is implemented only for bayer CFA or monochrome images, not sure if something similar should be done also for xtrans CFA

Fixes #6986 