### PR TITLE
Initial support for OM TG-7

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -2206,7 +2206,7 @@ Camera constants:
     },
 
     { // Quality B
-        "make_model": "OLYMPUS TG-6",
+        "make_model": [ "OLYMPUS TG-6", "OM Digital Solutions TG-7" ],
         "dcraw_matrix" : [10899, -3833, -1082, -2112, 10736, 1575, -267, 1452, 5269], // DNG v13.2
         "raw_crop": [ 0, 0, -24, 0 ] // 24 pixels at right are garbage
     },

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -10434,7 +10434,7 @@ konica_400z:
     filters = 0x16161616;
     load_raw = &CLASS packed_load_raw;
     load_flags = 30;
-  } else if (!strcmp(make,"Olympus")) {
+  } else if (!strcmp(make,"Olympus") || !strncmp(make, "OM Digi", 7)) {
     height += height & 1;
     if (exif_cfa) filters = exif_cfa;
     if (width == 4100) width -= 4;


### PR DESCRIPTION
Adds support for reading the CFA pattern for OM Digital Solutions cameras and adds the dcraw matrix and raw crop for the OM Digital Solutions TG-7.