### PR TITLE
Fix Windows automated builds (Adwaita cursors)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -129,14 +129,6 @@ jobs:
             "symbolic/ui" \
             "$BUILD_DIR/share/icons/Adwaita/symbolic"
           cp 'index.theme' "$BUILD_DIR/share/icons/Adwaita"
-          mkdir -p "$BUILD_DIR/share/icons/Adwaita/cursors"
-          cp -r \
-            "cursors/plus.cur" \
-            "cursors/sb_h_double_arrow.cur" \
-            "cursors/sb_left_arrow.cur" \
-            "cursors/sb_right_arrow.cur" \
-            "cursors/sb_v_double_arrow.cur" \
-            "$BUILD_DIR/share/icons/Adwaita/cursors"
           cd -
 
           echo "Copying GDK pixbuf."


### PR DESCRIPTION
This is an attempt to fix the Windows builds which stopped working after the upgrade to the latest Adwaita icon package. Some cursors were removed/renamed and all the ones that are (supposedly) required, as indicated in RawPedia, are affected. I simply removed the cursors completely and RawTherapee seems to run just fine. The caveat is that I tested through Wine, so I'd like confirmation on an actual Windows environment. At least the build succeeds, and a working pipeline with possibly bad artifacts is better than nothing.