### PR TITLE
options: fix BrowseRecursiveFollowLinks reading

### DIFF
--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -1364,7 +1364,7 @@ void Options::readFromFile(Glib::ustring fname)
                 }
 
                 if (keyFile.has_key("File Browser", "BrowseRecursiveFollowLinks")) {
-                    browseRecursiveFollowLinks = keyFile.get_integer("File Browser", "BrowseRecursiveFollowLinks");
+                    browseRecursiveFollowLinks = keyFile.get_boolean("File Browser", "BrowseRecursiveFollowLinks");
                 }
             }
 


### PR DESCRIPTION
PR #6769 added the boolean BrowseRecursiveFollowLinks options, but while it's saved as a boolean, it's read as an integer causing this error:

```
Options::readFromFile / Error code 5 while reading values from "/home/sgotti/.config/RawTherapee/options":
Key file contains key “BrowseRecursiveFollowLinks” in group “File Browser” which has a value that cannot be interpreted.
```