### PR TITLE
imageio: fix issues/crash on png with transparency

### DIFF
--- a/rtengine/imageio.cc
+++ b/rtengine/imageio.cc
@@ -285,6 +285,7 @@ int ImageIO::loadPNG  (const Glib::ustring &fname)
 
     if (png_get_valid(png, info, PNG_INFO_tRNS)) {
         png_set_tRNS_to_alpha(png);
+        png_set_strip_alpha(png);
     }
 
     if (color_type & PNG_COLOR_MASK_ALPHA) {


### PR DESCRIPTION
If a png has a transparency chunk (tRNS), after converting the transparency to alpha we should also strip alpha (color_type is not updated with PNG_COLOR_MASK_ALPHA flag set) or the row parsing will return also the alpha channel causing a memory overflow.

To test this I created a test png file starting from the attached sng file ([sng tool](https://sng.sourceforge.net/))

[trns.png](https://github.com/Beep6581/RawTherapee/assets/1690273/2df8b693-b054-4a02-bafd-cd7f979d6271)
[trns.sng](https://github.com/Beep6581/RawTherapee/files/14805660/trns.sng.txt) (remove final txt extension required for upload)
