### PR TITLE
dcraw: prefer raw crop and mask from dng metadata

### DIFF
--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6931,11 +6931,13 @@ it under the terms of the one of two licenses as you choose:
 	left_margin = getint(type);
 	height = getint(type) - top_margin;
 	width = getint(type) - left_margin;
+	RT_raw_crop_mask_from_constant = ThreeValBool::F;
 	break;
       case 50830:			/* MaskedAreas */
         for (i=0; i < len && i < 32; i++)
 	  ((int *)mask)[i] = getint(type);
 	black = 0;
+	RT_raw_crop_mask_from_constant = ThreeValBool::F;
 	break;
       case 51008:           /* OpcodeList1 */
         {
@@ -9167,6 +9169,9 @@ void CLASS adobe_coeff (const char *make, const char *model)
   }
   if (RT_blacklevel_from_constant == ThreeValBool::X || is_pentax_dng) {
     RT_blacklevel_from_constant = ThreeValBool::T;
+  }
+  if (RT_raw_crop_mask_from_constant == ThreeValBool::X || is_pentax_dng) {
+    RT_raw_crop_mask_from_constant = ThreeValBool::T;
   }
   if (RT_matrix_from_constant == ThreeValBool::X) {
     RT_matrix_from_constant = ThreeValBool::T;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -173,6 +173,7 @@ protected:
     enum class ThreeValBool { X = -1, F, T };
     ThreeValBool RT_whitelevel_from_constant;
     ThreeValBool RT_blacklevel_from_constant;
+    ThreeValBool RT_raw_crop_mask_from_constant;
     ThreeValBool RT_matrix_from_constant;
     std::string RT_software;
     double RT_baseline_exposure;

--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -29,9 +29,10 @@ RawImage::RawImage(const Glib::ustring &name)
     , allocation(nullptr)
 {
     memset(maximum_c4, 0, sizeof(maximum_c4));
-    RT_matrix_from_constant = ThreeValBool::X;
-    RT_blacklevel_from_constant = ThreeValBool::X;
     RT_whitelevel_from_constant = ThreeValBool::X;
+    RT_blacklevel_from_constant = ThreeValBool::X;
+    RT_raw_crop_mask_from_constant = ThreeValBool::X;
+    RT_matrix_from_constant = ThreeValBool::X;
 }
 
 RawImage::~RawImage()
@@ -556,7 +557,7 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
             orig_raw_width = raw_width;
             orig_raw_height = raw_height;
 
-            if (cc && cc->has_rawCrop(raw_width, raw_height)) {
+            if (RT_raw_crop_mask_from_constant == ThreeValBool::T && cc && cc->has_rawCrop(raw_width, raw_height)) {
                 raw_crop_cc = true;
                 int lm, tm, w, h;
                 cc->get_rawCrop(raw_width, raw_height, lm, tm, w, h);
@@ -591,7 +592,7 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
                 }
             }
 
-            if (cc && cc->has_rawMask(orig_raw_width, orig_raw_height, 0)) {
+            if (RT_raw_crop_mask_from_constant == ThreeValBool::T && cc && cc->has_rawMask(orig_raw_width, orig_raw_height, 0)) {
                 for (int i = 0; i < 2 && cc->has_rawMask(orig_raw_width, orig_raw_height, i); i++) {
                     cc->get_rawMask(orig_raw_width, orig_raw_height, i, mask[i][0], mask[i][1], mask[i][2], mask[i][3]);
                 }


### PR DESCRIPTION
Prefer raw crop and mask from dng metadata instead of camconst.json entries.

The unique exception, to keep backward compatibility, is from in camera Pentax DNGs. In such case, the preference goes to a camconst entry, if it exists.

This is based on discussion (see last comments) in #6826 

It uses the same logic already implemented for RT_whitelevel_from_constant and RT_blacklevel_from_constant

To sum up, from my understanding of the code and after reading some old discussions/issues:

* If black level, white level, and with this PR also raw crop and mask are provided by a DNG file with the exception of Pentax in camera DNG the DNG metadata values are preferred over camconst.
* The ColorMatrix1/2 entries from ADC generated DNG are ignored to keep constant whitebalancing between them and the source raw file (#4129)

## How to test
To test this PR use, for example, a Fuji XT3 file and convert it to dng with ADC. Change camconst to remove the source size filter from raw_crop:

```
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1596,10 +1596,7 @@ Camera constants:
     { // Quality A, samples provided by Daniel Catalina (#5839) and pi99y (#5860)
         "make_model": [ "FUJIFILM X-T3", "FUJIFILM X-PRO3" ],
         "dcraw_matrix": [ 13426,-6334,-1177,-4244,12136,2371,-580,1303,5980 ], // DNG_v11, standard_v2 d65
-        "raw_crop" : [
-           { "frame" : [6384, 4182], "crop": [ 0, 5, 6252, 4176] },
-           { "frame" : [6384, 3348], "crop": [624, 0, 5004, 3348] }
-        ],
+        "raw_crop": [ 0, 5, 6252, 4176],
         "white": [ 16170, 16275, 16170 ] // typical safe-margins with LENR
         // negligible aperture scaling effect
     },
```

Without this PR crop data is taken from camconst and the file is wrongly demosaiced, with this PR the crop data is taken from DNG metadata and correctly demosaiced.

@Lawrence37 @kmilos @Entropy512 

