### PR TITLE
Improve SpotRemoval 

### DIFF
--- a/rtgui/spot.cc
+++ b/rtgui/spot.cc
@@ -893,4 +893,7 @@ void Spot::tweakParams(procparams::ProcParams& pparams)
     pparams.gradient.enabled = false;
     pparams.pcvignette.enabled = false;
     pparams.colorappearance.enabled = false;
+    pparams.locallab.enabled = false;
+   // pparams.toneCurve.hrenabled = false;  // not sure for this one, it could be useful for ExpComp w/o performance penalty
+    pparams.toneCurve.histmatching = false;
 }

--- a/rtgui/toolbar.cc
+++ b/rtgui/toolbar.cc
@@ -27,8 +27,8 @@ ToolBar::ToolBar () : showColPickers(true), listener (nullptr), pickerListener(n
 {
 
     editingMode = false;
-
-    handimg.reset(new RTImage("hand-open", Gtk::ICON_SIZE_LARGE_TOOLBAR));
+   //handimg.reset(new RTImage("hand-open", Gtk::ICON_SIZE_LARGE_TOOLBAR));
+    handimg.reset(new RTImage("hand-open-hicontrast", Gtk::ICON_SIZE_LARGE_TOOLBAR));
     editinghandimg.reset(new RTImage("crosshair-adjust", Gtk::ICON_SIZE_LARGE_TOOLBAR));
 
     handTool = Gtk::manage (new Gtk::ToggleButton ());


### PR DESCRIPTION
Hello
As agreed with @Hombre57 , I added 2 lines in tweakParams "spot.cc"
    pparams.locallab.enabled = false;
   // pparams.toneCurve.hrenabled = false;  // not sure for this one, it could be useful for ExpComp w/o performance penalty
    pparams.toneCurve.histmatching = false;

And as some users pointed out that the icons in the toolbar were the same for "Local adjustments" and "Spot Removal", I changed the one for Spot Removal with "hand-open-hicontrast" ( I didn't find another acceptable icon) in "toolbar.cc"

see #7026 
I will be away today and in Paris since tomorrow.


Jacques