### PR TITLE
Fix for missing icons from the Windows installer

### DIFF
--- a/tools/win/InnoSetup/WindowsInnoSetup.iss.in
+++ b/tools/win/InnoSetup/WindowsInnoSetup.iss.in
@@ -102,6 +102,7 @@ Source: "{#MyBuildBasePath}\camconst.json"; DestDir: "{app}"; Flags: ignoreversi
 Source: "{#MyBuildBasePath}\dcpprofiles\*"; DestDir: "{app}\dcpprofiles\"; Flags: ignoreversion recursesubdirs createallsubdirs
 ;Source: "{#MyBuildBasePath}\etc\*"; DestDir: "{app}\etc\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyBuildBasePath}\iccprofiles\*"; DestDir: "{app}\iccprofiles\"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#MyBuildBasePath}\icons\*"; DestDir: "{app}\icons\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyBuildBasePath}\images\*"; DestDir: "{app}\images\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyBuildBasePath}\languages\*"; DestDir: "{app}\languages\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyBuildBasePath}\licenses\*"; DestDir: "{app}\licenses\"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
Updates the Inno setup to copy the icons folder which is new after merging the real hi-DPI pull request (#6830).