### PR TITLE
Divider between buttons in the pop-up button

### DIFF
--- a/rtdata/themes/RawTherapee.css
+++ b/rtdata/themes/RawTherapee.css
@@ -1300,6 +1300,11 @@ combobox, .popupbutton-arrow {
     min-height: 2em;
 }
 
+/* Visual divider between the icon and arrow in the pop-up button. */
+.image-combo button.Left {
+    border-right: solid 0.083333333333333333em #202020;
+}
+
 /* Makes image-combobox small icons centered */
 button.toggle > grid > image {
     padding: 0.3333333333333333em;


### PR DESCRIPTION
This adds a divider between the left button and the arrow button in all the pop-up buttons to clearly show that there are two buttons. It applies to the RawTherapee theme. The TooWaBlue themes already have a divider.

Before
![image](https://github.com/Beep6581/RawTherapee/assets/45837045/adea95d5-4ed6-44ce-b940-cc1a9defa139)

After
![image](https://github.com/Beep6581/RawTherapee/assets/45837045/afe33918-028d-45ad-a834-ba113b1d2582)

Closes #6968.