### PR TITLE
ProcessorTargets: support PowerPC

### DIFF
--- a/ProcessorTargets.cmake
+++ b/ProcessorTargets.cmake
@@ -10,6 +10,8 @@ set(PROC_TARGET_2_LABEL native CACHE STRING "Processor-2 label - use it for your
 # The flag is different on x86 and Arm based processors
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL arm64)
     set(PROC_TARGET_2_FLAGS "-mcpu=native" CACHE STRING "Processor-2 flags")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "ppc|powerpc")
+    set(PROC_TARGET_2_FLAGS "-mtune=native" CACHE STRING "Processor-2 flags")
 else()
     set(PROC_TARGET_2_FLAGS "-march=native" CACHE STRING "Processor-2 flags")
 endif()


### PR DESCRIPTION
`-march` is unsupported on PowerPC, `-mcpu` is supported but may produce incorrect code on some targets; `-mtune` is supported and works robustly.