### PR TITLE
dcp: avoid file descriptor leak on error.

### DIFF
--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -1134,6 +1134,7 @@ DCPProfile::DCPProfile(const Glib::ustring& filename) :
     DCPMetadata md(file);
     if (!md.parse()) {
         printf ("Unable to load DCP profile '%s'.", filename.c_str());
+        fclose(file);
         return;
     }
 


### PR DESCRIPTION
If the provided file doesn't contain valid dcp metadata the DCPProfile constructor will return without closing the file descriptor.

Fixes #7045 