### PR TITLE
Bump codeql actions to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
           echo "REF_NAME_FILTERED=$REF_NAME_FILTERED" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
@@ -90,6 +90,6 @@ jobs:
           mv AppDir/usr/bin/share AppDir/usr/
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
v2 is deprecated in github actions.  Fixes warnings in codeql analysis.
Ex: https://github.com/Beep6581/RawTherapee/actions/runs/9147294766?pr=7080