### PR TITLE
camconst.json add Fujifilm X-T200

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1556,7 +1556,7 @@ Camera constants:
     },
 
     { // Quality C
-        "make_model": [ "FUJIFILM X-T100" ],
+        "make_model": [ "FUJIFILM X-T100", "FUJIFILM X-T200" ],
         "dcraw_matrix" : [11673, -4760, -1041, -3988, 12058, 2166, -771, 1417, 5568], // taken from ART
         "ranges": { "white": 16100 }
     },


### PR DESCRIPTION
Same sensor, been using X-T100 configs for my X-T200 and results work fine to me.