### PR TITLE
Enable extensions that are missing from config

### DIFF
--- a/rtdata/languages/English (UK)
+++ b/rtdata/languages/English (UK)
@@ -2154,7 +2154,7 @@ TP_WBALANCE_PATCHLABEL_TOOLTIP;Display number of read colours (max=237).\nDispla
 !PREFERENCES_PARSEDEXT;Parsed Extensions
 !PREFERENCES_PARSEDEXTADD;Add extension
 !PREFERENCES_PARSEDEXTADDHINT;Add entered extension to the list.
-!PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.
+!PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.\nPredefined extensions cannot be deleted.
 !PREFERENCES_PARSEDEXTDOWNHINT;Move selected extension down in the list.
 !PREFERENCES_PARSEDEXTUPHINT;Move selected extension up in the list.
 !PREFERENCES_PERFORMANCE_MEASURE;Measure

--- a/rtdata/languages/English (US)
+++ b/rtdata/languages/English (US)
@@ -1971,7 +1971,7 @@
 !PREFERENCES_PARSEDEXT;Parsed Extensions
 !PREFERENCES_PARSEDEXTADD;Add extension
 !PREFERENCES_PARSEDEXTADDHINT;Add entered extension to the list.
-!PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.
+!PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.\nPredefined extensions cannot be deleted.
 !PREFERENCES_PARSEDEXTDOWNHINT;Move selected extension down in the list.
 !PREFERENCES_PARSEDEXTUPHINT;Move selected extension up in the list.
 !PREFERENCES_PERFORMANCE_MEASURE;Measure

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2038,7 +2038,7 @@ PREFERENCES_PANFACTORLABEL;Pan rate amplification
 PREFERENCES_PARSEDEXT;Parsed Extensions
 PREFERENCES_PARSEDEXTADD;Add extension
 PREFERENCES_PARSEDEXTADDHINT;Add entered extension to the list.
-PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.
+PREFERENCES_PARSEDEXTDELHINT;Delete selected extension from the list.\nPredefined extensions cannot be deleted.
 PREFERENCES_PARSEDEXTDOWNHINT;Move selected extension down in the list.
 PREFERENCES_PARSEDEXTUPHINT;Move selected extension up in the list.
 PREFERENCES_PERFORMANCE_MEASURE;Measure

--- a/rtdata/options/options.lin
+++ b/rtdata/options/options.lin
@@ -12,8 +12,8 @@ MultiUser=true
 
 [File Browser]
 # Image filename extensions to be looked for, and their corresponding search state (0/1 -> skip/include)
-ParseExtensions=3fr;arw;arq;cr2;cr3;crf;crw;dcr;dng;fff;iiq;jpg;jpeg;jxl;kdc;mef;mos;mrw;nef;nrw;orf;ori;pef;png;raf;raw;rw2;rwl;rwz;sr2;srf;srw;tif;tiff;x3f;
-ParseExtensionsEnabled=1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;0;1;0;1;1;1;1;1;1;1;1;1;1;1;
+ParseExtensions=
+ParseExtensionsEnabled=
 
 [Output]
 PathTemplate=%p1/converted/%f

--- a/rtdata/options/options.osx
+++ b/rtdata/options/options.osx
@@ -13,8 +13,8 @@ UseSystemTheme=false
 
 [File Browser]
 # Image filename extensions to be looked for, and their corresponding search state (0/1 -> skip/include)
-ParseExtensions=3fr;arw;arq;cr2;cr3;crf;crw;dcr;dng;fff;iiq;jpg;jpeg;jxl;kdc;mef;mos;mrw;nef;nrw;orf;ori;pef;png;raf;raw;rw2;rwl;rwz;sr2;srf;srw;tif;tiff;x3f;
-ParseExtensionsEnabled=1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;0;1;0;1;1;1;1;1;1;1;1;1;1;1;
+ParseExtensions=
+ParseExtensionsEnabled=
 
 [Output]
 PathTemplate=%p1/converted/%f

--- a/rtdata/options/options.win
+++ b/rtdata/options/options.win
@@ -14,8 +14,8 @@ UseSystemTheme=false
 
 [File Browser]
 # Image filename extensions to be looked for, and their corresponding search state (0/1 -> skip/include)
-ParseExtensions=3fr;arw;arq;cr2;cr3;crf;crw;dcr;dng;fff;iiq;jpg;jpeg;jxl;kdc;mef;mos;mrw;nef;nrw;orf;ori;pef;png;raf;raw;rw2;rwl;rwz;sr2;srf;srw;tif;tiff;x3f;
-ParseExtensionsEnabled=1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;0;1;0;1;1;1;1;1;1;1;1;1;1;1;
+ParseExtensions=
+ParseExtensionsEnabled=
 
 [Output]
 PathTemplate=%p1/converted/%f

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -1268,6 +1268,35 @@ void Options::readFromFile(Glib::ustring fname)
                     }
                 }
 
+                // check and add extensions that are missing from config
+                static const std::vector<std::string> extensions_known = {
+                    "3fr", "arw", "arq", "cr2",  "cr3", "crf", "crw",  "dcr", "dng",
+                    "fff", "iiq", "jpg", "jpeg", "jxl", "kdc", "mef",  "mos", "mrw",
+                    "nef", "nrw", "orf", "ori",  "pef", "png", "raf",  "raw", "rw2",
+                    "rwl", "rwz", "sr2", "srf",  "srw", "tif", "tiff", "x3f"};
+
+                std::map<std::string, int> extensions_checked;
+
+                if (parseExtensions.size() == parseExtensionsEnabled.size()) {
+                    for (auto i = 0; i < parseExtensions.size(); ++i) {
+                        extensions_checked[parseExtensions[i]] = parseExtensionsEnabled[i];
+                    }
+                }
+
+                parseExtensions.clear();
+                parseExtensionsEnabled.clear();
+
+                for (auto const &i : extensions_known) {
+                    if (extensions_checked.count(i) == 0) {
+                        extensions_checked[i] = 1;
+                    }
+                }
+
+                for (auto const &x : extensions_checked) {
+                    parseExtensions.emplace_back(x.first);
+                    parseExtensionsEnabled.emplace_back(x.second);
+                }
+
                 if (keyFile.has_key("File Browser", "ThumbnailArrangement")) {
                     fbArrangement = keyFile.get_integer("File Browser", "ThumbnailArrangement");
                 }

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -1269,30 +1269,24 @@ void Options::readFromFile(Glib::ustring fname)
                 }
 
                 // check and add extensions that are missing from config
-                static const std::vector<std::string> extensions_known = {
-                    "3fr", "arw", "arq", "cr2",  "cr3", "crf", "crw",  "dcr", "dng",
-                    "fff", "iiq", "jpg", "jpeg", "jxl", "kdc", "mef",  "mos", "mrw",
-                    "nef", "nrw", "orf", "ori",  "pef", "png", "raf",  "raw", "rw2",
-                    "rwl", "rwz", "sr2", "srf",  "srw", "tif", "tiff", "x3f"};
-
-                std::map<std::string, int> extensions_checked;
+                std::map<std::string, int> checkedExtensions;
 
                 if (parseExtensions.size() == parseExtensionsEnabled.size()) {
                     for (auto i = 0; i < parseExtensions.size(); ++i) {
-                        extensions_checked[parseExtensions[i]] = parseExtensionsEnabled[i];
+                        checkedExtensions[parseExtensions[i]] = parseExtensionsEnabled[i];
                     }
                 }
 
                 parseExtensions.clear();
                 parseExtensionsEnabled.clear();
 
-                for (auto const &i : extensions_known) {
-                    if (extensions_checked.count(i) == 0) {
-                        extensions_checked[i] = 1;
+                for (auto const &i : knownExtensions) {
+                    if (checkedExtensions.count(i) == 0) {
+                        checkedExtensions[i] = 1;
                     }
                 }
 
-                for (auto const &x : extensions_checked) {
+                for (auto const &x : checkedExtensions) {
                     parseExtensions.emplace_back(x.first);
                     parseExtensionsEnabled.emplace_back(x.second);
                 }

--- a/rtgui/options.cc
+++ b/rtgui/options.cc
@@ -471,7 +471,7 @@ void Options::setDefaults()
     curvebboxpos = 1;
     complexity = 2;
     spotmet = 0;
-    
+
     inspectorWindow = false;
     zoomOnScroll = true;
     prevdemo = PD_Sidecar;
@@ -580,8 +580,8 @@ void Options::setDefaults()
 
     rtSettings.darkFramesPath = "";
     rtSettings.flatFieldsPath = "";
-	rtSettings.cameraProfilesPath = "";
-	rtSettings.lensProfilesPath = "";
+    rtSettings.cameraProfilesPath = "";
+    rtSettings.lensProfilesPath = "";
 
 #ifdef _WIN32
     const gchar* sysRoot = g_getenv("SystemRoot");  // Returns e.g. "c:\Windows"
@@ -673,8 +673,8 @@ void Options::setDefaults()
     lastIccDir = rtSettings.iccDirectory;
     lastDarkframeDir = rtSettings.darkFramesPath;
     lastFlatfieldDir = rtSettings.flatFieldsPath;
-	lastCameraProfilesDir = rtSettings.cameraProfilesPath;
-	lastLensProfilesDir = rtSettings.lensProfilesPath;
+    lastCameraProfilesDir = rtSettings.cameraProfilesPath;
+    lastLensProfilesDir = rtSettings.lensProfilesPath;
 //  rtSettings.bw_complementary = true;
     // There is no reasonable default for curves. We can still suppose that they will take place
     // in a subdirectory of the user's own ProcParams presets, i.e. in a subdirectory
@@ -816,7 +816,7 @@ void Options::readFromFile(Glib::ustring fname)
                     rtSettings.cameraProfilesPath = keyFile.get_string("General", "CameraProfilesPath");
                 }
 
-				if (keyFile.has_key("General", "LensProfilesPath")) {
+                if (keyFile.has_key("General", "LensProfilesPath")) {
                     rtSettings.lensProfilesPath = keyFile.get_string("General", "LensProfilesPath");
                 }
 
@@ -2424,8 +2424,8 @@ void Options::saveToFile(Glib::ustring fname)
         keyFile.set_string("General", "Version", RTVERSION);
         keyFile.set_string("General", "DarkFramesPath", rtSettings.darkFramesPath);
         keyFile.set_string("General", "FlatFieldsPath", rtSettings.flatFieldsPath);
-		keyFile.set_string("General", "CameraProfilesPath", rtSettings.cameraProfilesPath);
-		keyFile.set_string("General", "LensProfilesPath", rtSettings.lensProfilesPath);
+        keyFile.set_string("General", "CameraProfilesPath", rtSettings.cameraProfilesPath);
+        keyFile.set_string("General", "LensProfilesPath", rtSettings.lensProfilesPath);
         keyFile.set_boolean("General", "Verbose", rtSettings.verbose);
         keyFile.set_integer("General", "Cropsleep", rtSettings.cropsleep);
         keyFile.set_double("General", "Reduchigh", rtSettings.reduchigh);

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -331,7 +331,7 @@ public:
     bool overwriteOutputFile;
     int complexity;
     int spotmet;
-    
+
     bool inspectorWindow; // open inspector in separate window
     bool zoomOnScroll;    // translate scroll events to zoom
 
@@ -472,8 +472,8 @@ public:
     Glib::ustring lastIccDir;
     Glib::ustring lastDarkframeDir;
     Glib::ustring lastFlatfieldDir;
-	Glib::ustring lastCameraProfilesDir;
-	Glib::ustring lastLensProfilesDir;
+    Glib::ustring lastCameraProfilesDir;
+    Glib::ustring lastLensProfilesDir;
     Glib::ustring lastRgbCurvesDir;
     Glib::ustring lastLabCurvesDir;
     Glib::ustring lastRetinexDir;

--- a/rtgui/options.h
+++ b/rtgui/options.h
@@ -310,6 +310,13 @@ public:
     int maxThumbnailWidth;
     std::size_t maxCacheEntries;
     int thumbInterp; // 0: nearest, 1: bilinear
+
+    std::vector<std::string> knownExtensions = {
+        "3fr", "arw", "arq", "cr2",  "cr3", "crf", "crw",  "dcr", "dng",
+        "fff", "iiq", "jpg", "jpeg", "jxl", "kdc", "mef",  "mos", "mrw",
+        "nef", "nrw", "orf", "ori",  "pef", "png", "raf",  "raw", "rw2",
+        "rwl", "rwz", "sr2", "srf",  "srw", "tif", "tiff", "x3f"};
+
     std::vector<Glib::ustring> parseExtensions;   // List containing all extensions type
     std::vector<int> parseExtensionsEnabled;      // List of bool to retain extension or not
     std::vector<Glib::ustring> parsedExtensions;  // List containing all retained extensions (lowercase)

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -1552,9 +1552,9 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
 
     frmnu->add (*menuGrid);
 
-
     Gtk::Frame* fre = Gtk::manage(new Gtk::Frame(M("PREFERENCES_PARSEDEXT")));
     Gtk::Box* vbre = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
+
     Gtk::Box* hb0 = Gtk::manage(new Gtk::Box());
     Gtk::Label* elab = Gtk::manage (new Gtk::Label (M("PREFERENCES_PARSEDEXTADD") + ":", Gtk::ALIGN_START));
     hb0->pack_start(*elab, Gtk::PACK_SHRINK, 4);
@@ -1582,6 +1582,7 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     hb0->pack_end(*moveExtUp, Gtk::PACK_SHRINK, 4);
     hb0->pack_end(*delExt, Gtk::PACK_SHRINK, 4);
     hb0->pack_end(*addExt, Gtk::PACK_SHRINK, 4);
+
     extensions = Gtk::manage(new Gtk::TreeView());
     Gtk::ScrolledWindow* hscrollw = Gtk::manage(new Gtk::ScrolledWindow());
     hscrollw->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
@@ -1591,8 +1592,9 @@ Gtk::Widget* Preferences::getFileBrowserPanel()
     extensions->append_column_editable("Enabled", extensionColumns.enabled);
     extensions->append_column("Extension", extensionColumns.ext);
     extensions->set_headers_visible(false);
-    vbre->pack_start(*hscrollw);
+
     vbre->pack_start(*hb0, Gtk::PACK_SHRINK, 4);
+    vbre->pack_start(*hscrollw);
 
     fre->add(*vbre);
 
@@ -2679,7 +2681,7 @@ void Preferences::addExtPressed()
         }
     }
 
-    Gtk::TreeRow row = * (extensionModel->append());
+    Gtk::TreeRow row = * (extensionModel->prepend());
 
     row[extensionColumns.enabled] = true;
     row[extensionColumns.ext]     = extension->get_text();

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -2687,8 +2687,29 @@ void Preferences::addExtPressed()
 
 void Preferences::delExtPressed()
 {
+    const Glib::RefPtr<Gtk::TreeSelection> selection = extensions->get_selection();
 
-    extensionModel->erase(extensions->get_selection()->get_selected());
+    if (!selection) {
+        return;
+    }
+
+    const Gtk::TreeModel::iterator selected = selection->get_selected();
+
+    if (!selected) {
+        return;
+    }
+
+    bool delOkay = true;
+    for (auto const &x : moptions.knownExtensions) {
+        if (x == (*selected)[extensionColumns.ext]) {
+            delOkay = false;
+            break;
+        }
+    }
+
+    if (delOkay) {
+        extensionModel->erase(selected);
+    }
 }
 
 void Preferences::moveExtUpPressed()

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -656,7 +656,7 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     Gtk::Grid* dirgrid = Gtk::manage(new Gtk::Grid());
     setExpandAlignProperties(dirgrid, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
-	// Dark Frames Dir
+    // Dark Frames Dir
     Gtk::Label *dfLab = Gtk::manage(new Gtk::Label(M("PREFERENCES_DIRDARKFRAMES") + ":"));
     setExpandAlignProperties(dfLab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
     darkFrameDir = Gtk::manage(new MyFileChooserButton(M("PREFERENCES_DIRDARKFRAMES"), Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER));
@@ -705,7 +705,7 @@ Gtk::Widget* Preferences::getImageProcessingPanel ()
     dirgrid->attach_next_to(*cameraProfilesDirLabel, *clutsDirLabel, Gtk::POS_BOTTOM, 1, 1);
     dirgrid->attach_next_to(*cameraProfilesDir, *cameraProfilesDirLabel, Gtk::POS_RIGHT, 1, 1);
 
-	  //Lens Profiles Dir
+    //Lens Profiles Dir
     Gtk::Label *lensProfilesDirLabel = Gtk::manage(new Gtk::Label(M("PREFERENCES_LENSPROFILESDIR") + ":"));
     lensProfilesDirLabel->set_tooltip_text(M("PREFERENCES_LENSPROFILESDIR_TOOLTIP"));
     setExpandAlignProperties(lensProfilesDirLabel, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -1111,7 +1111,7 @@ Gtk::Widget* Preferences::getGeneralPanel()
     workflowGrid->attach_next_to(*curveBBoxPosL, *flayoutlab, Gtk::POS_BOTTOM, 1, 1);
     workflowGrid->attach_next_to(*curveBBoxPosC, *editorLayout, Gtk::POS_BOTTOM, 1, 1);
     workflowGrid->attach_next_to(*curveBBoxPosRestartL, *lNextStart, Gtk::POS_BOTTOM, 1, 1);
-    
+
     curveBBoxPosS = Gtk::manage(new Gtk::ComboBoxText());
     setExpandAlignProperties(curveBBoxPosS, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_BASELINE);
 
@@ -2013,8 +2013,8 @@ void Preferences::storePreferences()
 
     moptions.curvebboxpos = curveBBoxPosC->get_active_row_number();
     moptions.complexity = complexitylocal->get_active_row_number();
-    moptions.spotmet = spotlocal->get_active_row_number(); 
-    
+    moptions.spotmet = spotlocal->get_active_row_number();
+
     moptions.inspectorWindow = inspectorWindowCB->get_active();
     moptions.zoomOnScroll = zoomOnScrollCB->get_active();
     moptions.histogramPosition = ckbHistogramPositionLeft->get_active() ? 1 : 2;
@@ -2673,10 +2673,11 @@ void Preferences::addExtPressed()
 
     Gtk::TreeNodeChildren c = extensionModel->children();
 
-    for (size_t i = 0; i < c.size(); i++)
+    for (size_t i = 0; i < c.size(); i++) {
         if (c[i][extensionColumns.ext] == extension->get_text()) {
             return;
         }
+    }
 
     Gtk::TreeRow row = * (extensionModel->append());
 

--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -2701,7 +2701,7 @@ void Preferences::extensionsChanged()
 
 void Preferences::extensionChanged()
 {
-    if (extension->get_text()[0] == '\0') {
+    if (extension->get_text().empty()) {
         addExt->set_sensitive(false);
         return;
     }

--- a/rtgui/preferences.h
+++ b/rtgui/preferences.h
@@ -323,6 +323,8 @@ public:
     void observer10Toggled ();
 
     void selectStartupDir ();
+    void extensionsChanged ();
+    void extensionChanged ();
     void addExtPressed ();
     void delExtPressed ();
     void moveExtUpPressed ();


### PR DESCRIPTION
This PR adds and enables supported file extensions that are missing from config.  Feature is described in https://github.com/Beep6581/RawTherapee/pull/6367#issuecomment-2132712754

> One more possible improvement. Users who are upgrading will not see jxl images because their settings carry over. It would be good to automatically add the jxl extension to the list of file types to load if the version in the options file shows 5.10 or older. (@Lawrence37)

Notes:
* This PR changes default state of ori and png to enabled.  See [#6367 (comment)](https://github.com/Beep6581/RawTherapee/pull/6367#issuecomment-950320058).
* Known extensions are prevented from being removed from list.  Otherwise they would be added back in enabled state.  Disable by unchecking.
* Potential side effect I haven't checked for: List may be reordered during checks.