### PR TITLE
Keep values scope from 5.10 Selective Editing - for color & light - shadow/highlight - vibrance #7102

### DIFF
--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1170,9 +1170,11 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 if (params->locallab.spots.at(sp).equilret  && params->locallab.spots.at(sp).expreti) {
                     savenormreti.reset(new LabImage(*oprevl, true));
                 }
+                /*
                 if(params->locallab.spots.at(sp).colorscope != 30) {//compatibility with old method in controlspotpanel to change scope - default value 30
                     scopefp[sp]= params->locallab.spots.at(sp).colorscope;
                 }
+                */
                 // Set local curves of current spot to LUT
                 locRETgainCurve.Set(params->locallab.spots.at(sp).localTgaincurve);
                 locRETtransCurve.Set(params->locallab.spots.at(sp).localTtranscurve);
@@ -1587,7 +1589,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 bool islog = params->locallab.spots.at(sp).explog;
                 bool ismas = params->locallab.spots.at(sp).expmask;
                 bool iscie = params->locallab.spots.at(sp).expcie;
-                bool isset = iscolor || issh || isvib;
+                //bool isset = iscolor || issh || isvib;
                 
                 //set select spot settings 
                 LocallabListener::locallabsetLC locsetlc;
@@ -1615,6 +1617,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                         locallListener->cieChanged(locallcielc,params->locallab.selspot); 
                     }
                     locallListener->sigChanged(locallciesig,params->locallab.selspot);
+                    /*
                     if(params->locallab.spots.at(sp).colorscope != 30) {//compatibility with old method in controlspotpanel
                             locallListener->scopeChangedcol(scopefp[sp], params->locallab.selspot, iscolor);
                             locallListener->scopeChangedsh(scopefp[sp], params->locallab.selspot, issh);
@@ -1622,6 +1625,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                             locallListener->scopeChangedset(scopefp[sp], params->locallab.selspot, isset);
                             params->locallab.spots.at(sp).colorscope = 30;
                     }
+                    */
                    // if (mainfp[sp] >= 0) {//minimize call to idle register 
                         //used by Global fullimage.
                     locallListener->maiChanged(locallsetlc,params->locallab.selspot); 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1170,11 +1170,11 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 if (params->locallab.spots.at(sp).equilret  && params->locallab.spots.at(sp).expreti) {
                     savenormreti.reset(new LabImage(*oprevl, true));
                 }
-                /*
-                if(params->locallab.spots.at(sp).colorscope != 30) {//compatibility with old method in controlspotpanel to change scope - default value 30
-                    scopefp[sp]= params->locallab.spots.at(sp).colorscope;
-                }
-                */
+                
+               // if(params->locallab.spots.at(sp).colorscope != 30) {//compatibility with old method in controlspotpanel to change scope - default value 30
+               //     scopefp[sp]= params->locallab.spots.at(sp).colorscope;
+               // }
+                
                 // Set local curves of current spot to LUT
                 locRETgainCurve.Set(params->locallab.spots.at(sp).localTgaincurve);
                 locRETtransCurve.Set(params->locallab.spots.at(sp).localTtranscurve);
@@ -1589,7 +1589,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 bool islog = params->locallab.spots.at(sp).explog;
                 bool ismas = params->locallab.spots.at(sp).expmask;
                 bool iscie = params->locallab.spots.at(sp).expcie;
-                //bool isset = iscolor || issh || isvib;
+                bool isset = iscolor || issh || isvib;
                 
                 //set select spot settings 
                 LocallabListener::locallabsetLC locsetlc;
@@ -1618,14 +1618,14 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                     }
                     locallListener->sigChanged(locallciesig,params->locallab.selspot);
                     /*
-                    if(params->locallab.spots.at(sp).colorscope != 30) {//compatibility with old method in controlspotpanel
+                    if(params->locallab.spots.at(sp).colorscope != 0) {//compatibility with old method in controlspotpanel
                             locallListener->scopeChangedcol(scopefp[sp], params->locallab.selspot, iscolor);
                             locallListener->scopeChangedsh(scopefp[sp], params->locallab.selspot, issh);
                             locallListener->scopeChangedvib(scopefp[sp], params->locallab.selspot, isvib);
                             locallListener->scopeChangedset(scopefp[sp], params->locallab.selspot, isset);
-                            params->locallab.spots.at(sp).colorscope = 30;
+                            //params->locallab.spots.at(sp).colorscope = 30;
                     }
-                    */
+                   */
                    // if (mainfp[sp] >= 0) {//minimize call to idle register 
                         //used by Global fullimage.
                     locallListener->maiChanged(locallsetlc,params->locallab.selspot); 

--- a/rtengine/improccoordinator.cc
+++ b/rtengine/improccoordinator.cc
@@ -1589,7 +1589,7 @@ void ImProcCoordinator::updatePreviewImage(int todo, bool panningRelatedChange)
                 bool islog = params->locallab.spots.at(sp).explog;
                 bool ismas = params->locallab.spots.at(sp).expmask;
                 bool iscie = params->locallab.spots.at(sp).expcie;
-                bool isset = iscolor || issh || isvib;
+              // bool isset = iscolor || issh || isvib;
                 
                 //set select spot settings 
                 LocallabListener::locallabsetLC locsetlc;

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -9144,7 +9144,11 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "labgridAHighmerg_" + index_str, spot.labgridAHighmerg, spotEdited.labgridAHighmerg);
                 assignFromKeyfile(keyFile, "Locallab", "labgridBHighmerg_" + index_str, spot.labgridBHighmerg, spotEdited.labgridBHighmerg);
                 assignFromKeyfile(keyFile, "Locallab", "Strengthgrid_" + index_str, spot.strengthgrid, spotEdited.strengthgrid);
-                assignFromKeyfile(keyFile, "Locallab", "Sensi_" + index_str, spot.sensi, spotEdited.sensi);
+                if (ppVersion <= 350) {
+                    assignFromKeyfile(keyFile, "Locallab", "Sensi_" + index_str,  spot.colorscope, spotEdited.sensi);
+                } else {
+                    assignFromKeyfile(keyFile, "Locallab", "Sensi_" + index_str, spot.sensi, spotEdited.sensi);
+                }
                 assignFromKeyfile(keyFile, "Locallab", "Structcol_" + index_str, spot.structcol, spotEdited.structcol);
                 assignFromKeyfile(keyFile, "Locallab", "Strcol_" + index_str, spot.strcol, spotEdited.strcol);
                 assignFromKeyfile(keyFile, "Locallab", "Strcolab_" + index_str, spot.strcolab, spotEdited.strcolab);
@@ -9282,7 +9286,11 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "shadows_" + index_str, spot.shadows, spotEdited.shadows);
                 assignFromKeyfile(keyFile, "Locallab", "s_tonalwidth_" + index_str, spot.s_tonalwidth, spotEdited.s_tonalwidth);
                 assignFromKeyfile(keyFile, "Locallab", "sh_radius_" + index_str, spot.sh_radius, spotEdited.sh_radius);
-                assignFromKeyfile(keyFile, "Locallab", "sensihs_" + index_str, spot.sensihs, spotEdited.sensihs);
+                if (ppVersion <= 350) {
+                    assignFromKeyfile(keyFile, "Locallab", "sensihs_" + index_str, spot.colorscope, spotEdited.sensihs);
+                } else {
+                    assignFromKeyfile(keyFile, "Locallab", "sensihs_" + index_str, spot.sensihs, spotEdited.sensihs);
+                }
                 assignFromKeyfile(keyFile, "Locallab", "EnaSHMask_" + index_str, spot.enaSHMask, spotEdited.enaSHMask);
                 assignFromKeyfile(keyFile, "Locallab", "CCmaskSHCurve_" + index_str, spot.CCmaskSHcurve, spotEdited.CCmaskSHcurve);
                 assignFromKeyfile(keyFile, "Locallab", "LLmaskSHCurve_" + index_str, spot.LLmaskSHcurve, spotEdited.LLmaskSHcurve);
@@ -9336,7 +9344,11 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "ProtectSkins_" + index_str, spot.protectskins, spotEdited.protectskins);
                 assignFromKeyfile(keyFile, "Locallab", "AvoidColorShift_" + index_str, spot.avoidcolorshift, spotEdited.avoidcolorshift);
                 assignFromKeyfile(keyFile, "Locallab", "PastSatTog_" + index_str, spot.pastsattog, spotEdited.pastsattog);
-                assignFromKeyfile(keyFile, "Locallab", "Sensiv_" + index_str, spot.sensiv, spotEdited.sensiv);
+                if (ppVersion <= 350) {
+                    assignFromKeyfile(keyFile, "Locallab", "Sensiv_" + index_str, spot.colorscope, spotEdited.sensiv);
+                } else {
+                    assignFromKeyfile(keyFile, "Locallab", "Sensiv_" + index_str, spot.sensiv, spotEdited.sensiv);
+                }
                 assignFromKeyfile(keyFile, "Locallab", "SkinTonesCurve_" + index_str, spot.skintonescurve, spotEdited.skintonescurve);
                 assignFromKeyfile(keyFile, "Locallab", "CCmaskvibCurve_" + index_str, spot.CCmaskvibcurve, spotEdited.CCmaskvibcurve);
                 assignFromKeyfile(keyFile, "Locallab", "LLmaskvibCurve_" + index_str, spot.LLmaskvibcurve, spotEdited.LLmaskvibcurve);

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -9144,8 +9144,13 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "labgridAHighmerg_" + index_str, spot.labgridAHighmerg, spotEdited.labgridAHighmerg);
                 assignFromKeyfile(keyFile, "Locallab", "labgridBHighmerg_" + index_str, spot.labgridBHighmerg, spotEdited.labgridBHighmerg);
                 assignFromKeyfile(keyFile, "Locallab", "Strengthgrid_" + index_str, spot.strengthgrid, spotEdited.strengthgrid);
+                assignFromKeyfile(keyFile, "Locallab", "Colorscope_" + index_str, spot.colorscope, spotEdited.colorscope);
+
                 if (ppVersion <= 350) {
-                    assignFromKeyfile(keyFile, "Locallab", "Sensi_" + index_str,  spot.colorscope, spotEdited.sensi);
+                    if (keyFile.has_key("Locallab", "Colorscope_" + index_str)) {
+                        spot.sensi = keyFile.get_integer("Locallab", "Colorscope_" + index_str);
+                        spotEdited.sensi = true;
+                    }
                 } else {
                     assignFromKeyfile(keyFile, "Locallab", "Sensi_" + index_str, spot.sensi, spotEdited.sensi);
                 }
@@ -9287,7 +9292,10 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "s_tonalwidth_" + index_str, spot.s_tonalwidth, spotEdited.s_tonalwidth);
                 assignFromKeyfile(keyFile, "Locallab", "sh_radius_" + index_str, spot.sh_radius, spotEdited.sh_radius);
                 if (ppVersion <= 350) {
-                    assignFromKeyfile(keyFile, "Locallab", "sensihs_" + index_str, spot.colorscope, spotEdited.sensihs);
+                    if (keyFile.has_key("Locallab", "Colorscope_" + index_str)) {
+                        spot.sensihs = keyFile.get_integer("Locallab", "Colorscope_" + index_str);
+                        spotEdited.sensihs = true;
+                    }
                 } else {
                     assignFromKeyfile(keyFile, "Locallab", "sensihs_" + index_str, spot.sensihs, spotEdited.sensihs);
                 }
@@ -9345,7 +9353,10 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "AvoidColorShift_" + index_str, spot.avoidcolorshift, spotEdited.avoidcolorshift);
                 assignFromKeyfile(keyFile, "Locallab", "PastSatTog_" + index_str, spot.pastsattog, spotEdited.pastsattog);
                 if (ppVersion <= 350) {
-                    assignFromKeyfile(keyFile, "Locallab", "Sensiv_" + index_str, spot.colorscope, spotEdited.sensiv);
+                    if (keyFile.has_key("Locallab", "Colorscope_" + index_str)) {
+                        spot.sensiv = keyFile.get_integer("Locallab", "Colorscope_" + index_str);
+                        spotEdited.sensiv = true;
+                    }
                 } else {
                     assignFromKeyfile(keyFile, "Locallab", "Sensiv_" + index_str, spot.sensiv, spotEdited.sensiv);
                 }

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -395,7 +395,7 @@ ControlSpotPanel::ControlSpotPanel():
 //    ToolParamBlock* const artifBox2 = Gtk::manage(new ToolParamBlock());
 
     artifBox2->pack_start(*preview_);
-   // artifBox2->pack_start(*colorscope_);//unused with contrlspotpanel since 17 / 01 : 2024 but data used in color, vibrance, sh
+    artifBox2->pack_start(*colorscope_);//unused with contrlspotpanel since 17 / 01 : 2024 but data used in color, vibrance, sh
     colorscope_->hide();
     pack_start(*artifBox2);
     ToolParamBlock* const specCaseBox = Gtk::manage(new ToolParamBlock());

--- a/rtgui/controlspotpanel.cc
+++ b/rtgui/controlspotpanel.cc
@@ -395,7 +395,7 @@ ControlSpotPanel::ControlSpotPanel():
 //    ToolParamBlock* const artifBox2 = Gtk::manage(new ToolParamBlock());
 
     artifBox2->pack_start(*preview_);
-    artifBox2->pack_start(*colorscope_);//unused with contrlspotpanel since 17 / 01 : 2024 but data used in color, vibrance, sh
+   // artifBox2->pack_start(*colorscope_);//unused with contrlspotpanel since 17 / 01 : 2024 but data used in color, vibrance, sh
     colorscope_->hide();
     pack_start(*artifBox2);
     ToolParamBlock* const specCaseBox = Gtk::manage(new ToolParamBlock());

--- a/rtgui/ppversion.h
+++ b/rtgui/ppversion.h
@@ -1,11 +1,13 @@
 #pragma once
 
 // This number has to be incremented whenever the PP3 file format is modified or the behaviour of a tool changes
-#define PPVERSION 350
+#define PPVERSION 351
 #define PPVERSION_AEXP 301 //value of PPVERSION when auto exposure algorithm was modified
 
 /*
   Log of version changes
+   351  2024-06-19
+        take into account Global in selectibe editing
    350  2023-03-05
         introduced white balance standard observer
    349  2020-10-29

--- a/rtgui/ppversion.h
+++ b/rtgui/ppversion.h
@@ -7,7 +7,7 @@
 /*
   Log of version changes
    351  2024-06-19
-        take into account Global in selectibe editing
+        take into account Global in selective editing
    350  2023-03-05
         introduced white balance standard observer
    349  2020-10-29


### PR DESCRIPTION
I replace a complex manner (in improccoordinator) to manage this problem, by using ppversion (<=350)  in procparams

In 5.10 and before, les 3 scopes for Color &  Light, Shadows/Highlight, Vibrance were grouped and used the value of scope in settings

Now, with the new manner for manage spot, each tool has its own scope.

Issue #7102



