### PR TITLE
FramesData: add missing isDNG initialization.

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -274,6 +274,7 @@ FramesData::FramesData(const Glib::ustring &fname, time_t ts) :
     sampleFormat(IIOSF_UNKNOWN),
     isPixelShift(false),
     isHDR(false),
+    isDNG(false),
     w_(-1),
     h_(-1)
 {


### PR DESCRIPTION
FramesData isDNG wasn't initialized.

This will randomly cause images to be considered as dng files when the underlying value is different than 0 since the metadata parsing could exit before the code that checks for the Exif.Image.DNGVersion tag.