### PR TITLE
Selective Editing icon

### DIFF
--- a/rtdata/icons/rawtherapee/scalable/apps/rt-spot.svg
+++ b/rtdata/icons/rawtherapee/scalable/apps/rt-spot.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="rt-spot.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs815" />
+  <metadata
+     id="metadata818">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Lawrence37</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:description>RawTherapee icon: RT spot.</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <circle
+     style="opacity:0.7;fill:none;stroke:#cccccc;stroke-width:2"
+     id="spot"
+     cx="12"
+     cy="12"
+     r="2" />
+  <g
+     id="frame"
+     style="opacity:0.7">
+    <path
+       id="rect"
+       style="opacity:1;fill:none;stroke:#cccccc;stroke-width:2"
+       d="M 3,5 H 21 V 19 H 3 Z" />
+    <circle
+       style="opacity:1;fill:#cccccc;fill-opacity:1"
+       id="node-left"
+       cx="3"
+       cy="12"
+       r="2.5" />
+    <circle
+       style="fill:#cccccc;fill-opacity:1;stroke:none"
+       id="node-top"
+       cx="12"
+       cy="5"
+       r="2.5" />
+    <circle
+       style="fill:#cccccc;fill-opacity:1;stroke:none"
+       id="node-right"
+       cx="21"
+       cy="12"
+       r="2.5" />
+    <circle
+       style="fill:#cccccc;fill-opacity:1;stroke:none"
+       id="node-bottom"
+       cx="12"
+       cy="19"
+       r="2.5" />
+  </g>
+</svg>

--- a/rtgui/toolbar.cc
+++ b/rtgui/toolbar.cc
@@ -27,8 +27,7 @@ ToolBar::ToolBar () : showColPickers(true), listener (nullptr), pickerListener(n
 {
 
     editingMode = false;
-   //handimg.reset(new RTImage("hand-open", Gtk::ICON_SIZE_LARGE_TOOLBAR));
-    handimg.reset(new RTImage("hand-open-hicontrast", Gtk::ICON_SIZE_LARGE_TOOLBAR));
+    handimg.reset(new RTImage("hand-open", Gtk::ICON_SIZE_LARGE_TOOLBAR));
     editinghandimg.reset(new RTImage("crosshair-adjust", Gtk::ICON_SIZE_LARGE_TOOLBAR));
 
     handTool = Gtk::manage (new Gtk::ToggleButton ());

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -465,7 +465,7 @@ ToolPanelCoordinator::ToolPanelCoordinator (bool batch) : ipc (nullptr), favorit
     toiD = Gtk::manage (new TextOrIcon ("detail", M ("MAIN_TAB_DETAIL"), M ("MAIN_TAB_DETAIL_TOOLTIP")));
     toiC = Gtk::manage (new TextOrIcon ("color-circles", M ("MAIN_TAB_COLOR"), M ("MAIN_TAB_COLOR_TOOLTIP")));
     toiW = Gtk::manage (new TextOrIcon ("atom", M ("MAIN_TAB_ADVANCED"), M ("MAIN_TAB_ADVANCED_TOOLTIP")));
-    toiL = Gtk::manage(new TextOrIcon("hand-open", M("MAIN_TAB_LOCALLAB"), M("MAIN_TAB_LOCALLAB_TOOLTIP")));
+    toiL = Gtk::manage(new TextOrIcon("rt-spot", M("MAIN_TAB_LOCALLAB"), M("MAIN_TAB_LOCALLAB_TOOLTIP")));
 
     toiT = Gtk::manage (new TextOrIcon ("transform", M ("MAIN_TAB_TRANSFORM"), M ("MAIN_TAB_TRANSFORM_TOOLTIP")));
     toiR = Gtk::manage (new TextOrIcon ("bayer", M ("MAIN_TAB_RAW"), M ("MAIN_TAB_RAW_TOOLTIP")));


### PR DESCRIPTION
Adds a new icon for Selective Editing and reverts the hand tool icon back to the normal version instead of the high-contrast version. The new icon is a rectangular RT spot, similar to the one shown in https://github.com/Beep6581/RawTherapee/issues/7129#issuecomment-2241265977.
The actual icon: ![rt-spot.svg](https://raw.githubusercontent.com/Lawrence37/RawTherapee/selective-editing-icon/rtdata/icons/rawtherapee/scalable/apps/rt-spot.svg)
Here's how it looks in the GUI with the RawTherapee theme:
|Scale|Screenshot|
|-|-|
|Standard DPI|![image](https://github.com/user-attachments/assets/b878dbeb-2a89-4f42-8031-498e6969900f)|
|HiDPI (2x)|![image](https://github.com/user-attachments/assets/a04851bb-f854-4496-88d1-08c86b127c80)|

I made the lines thicker and reduced the opacity to 70% to better match the style of the other tab icons. This is a compromise icon for 5.11 until better icons can be made for the Selective Editing and possibly Advanced tabs.

@Benitoite @Desmis @marter001 @rebio