### PR TITLE
Remove GUI mask in Global mode

### DIFF
--- a/rtgui/locallabtools.cc
+++ b/rtgui/locallabtools.cc
@@ -1020,7 +1020,7 @@ void LocallabColor::updateguicolor(int spottype)
                 expmaskcol1->hide();
                 expmaskcol->hide();
                 exprecov->hide();
-
+                enaColorMask->set_active(false);
                 previewcol->hide();
                 previewcol->set_active(false);
                 resetMaskView();
@@ -3035,6 +3035,8 @@ void LocallabExposure::updateguiexpos(int spottype)
                 sensiex->hide();
                 previewexe->hide();
                 showmaskexpMethod->set_active(0);
+                enaExpMask->set_active(false);
+                enaExpMaskaft->set_active(false);
                 previewexe->set_active(false);
                 expmaskexp->hide();
                 exprecove->hide();
@@ -4572,6 +4574,7 @@ void LocallabShadow::updateguishad(int spottype)
                 previewsh->hide();
                 exprecovs->hide();
                 expmasksh->hide();
+                enaSHMask->set_active(false);
                 previewsh->set_active(false);
                 resetMaskView();
             } else {
@@ -5753,6 +5756,7 @@ void LocallabVibrance::updateguivib(int spottype)
                 sensiv->hide();
                 showmaskvibMethod->set_active(0);
                 previewvib->hide();
+                enavibMask->set_active(false);
                 previewvib->set_active(false);
                 exprecovv->hide();
                 expmaskvib->hide();
@@ -7559,6 +7563,7 @@ void LocallabBlur::updateguiblur(int spottype)
                 sensiden->hide();
                 invbl->hide();
                 expmaskbl->hide();
+                enablMask->set_active(false);
             } else {
                 sensibn->show();
                 sensiden->show();

--- a/rtgui/locallabtools.cc
+++ b/rtgui/locallabtools.cc
@@ -1016,19 +1016,27 @@ void LocallabColor::updateguicolor(int spottype)
             if(spottype == 3) {
                 invers->hide();
                 sensi->hide();
-                showmaskcolMethod->set_active(0);               
+                showmaskcolMethod->set_active(0);
+                expmaskcol1->hide();
+                expmaskcol->hide();
+                exprecov->hide();
+
                 previewcol->hide();
                 previewcol->set_active(false);
                 resetMaskView();
             } else {
                 invers->show();
                 sensi->show();
+                expmaskcol1->show();
+                expmaskcol->show();
+                exprecov->show();
                 if(!invers->get_active()) {
                     previewcol->show();
                 } else {
                     previewcol->hide();
                 }
-                
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
+
             }
             enableListener();
 
@@ -3028,16 +3036,21 @@ void LocallabExposure::updateguiexpos(int spottype)
                 previewexe->hide();
                 showmaskexpMethod->set_active(0);
                 previewexe->set_active(false);
-                
+                expmaskexp->hide();
+                exprecove->hide();
                 resetMaskView();
            } else {
                 inversex->show();
                 sensiex->show();
+                expmaskexp->show();
+                exprecove->show();
+
                 if(!inversex->get_active()) {
                     previewexe->show();
                 } else {
                     previewexe->hide();
                 }
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
             }
             enableListener();
 
@@ -4557,16 +4570,21 @@ void LocallabShadow::updateguishad(int spottype)
                 sensihs->hide();
                 showmaskSHMethod->set_active(0);
                 previewsh->hide();
+                exprecovs->hide();
+                expmasksh->hide();
                 previewsh->set_active(false);
                 resetMaskView();
             } else {
                 sensihs->show();
                 inverssh->show();
+                exprecovs->show();
+                expmasksh->show();
                 if(!inverssh->get_active()) {
                     previewsh->show();
                 } else {
                     previewsh->hide();
                 }
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
                 
             }
             enableListener();
@@ -5736,10 +5754,16 @@ void LocallabVibrance::updateguivib(int spottype)
                 showmaskvibMethod->set_active(0);
                 previewvib->hide();
                 previewvib->set_active(false);
+                exprecovv->hide();
+                expmaskvib->hide();
                 resetMaskView();
             } else {
                 sensiv->show();
                 previewvib->show();
+                exprecovv->show();
+                expmaskvib->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
+
             }
             enableListener();
 
@@ -7534,11 +7558,13 @@ void LocallabBlur::updateguiblur(int spottype)
                 sensibn->hide();
                 sensiden->hide();
                 invbl->hide();
-
+                expmaskbl->hide();
             } else {
                 sensibn->show();
                 sensiden->show();
                 invbl->show();
+                expmaskbl->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
 
             }
             enableListener();

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -430,6 +430,9 @@ void LocallabTone::updateguitone(int spottype)
                 sensitm->hide();
                 exprecovt->hide();
                 expmasktm->hide();
+                enatmMask->set_active(false);
+                enatmMaskaft->set_active(false);
+                
              //   showmasktmMethodConn.block(true);
                 showmasktmMethod->set_active(0);
              //   showmasktmMethodConn.block(false);
@@ -1196,6 +1199,8 @@ void LocallabRetinex::updateguireti(int spottype)
                 sensih->hide();
                 exprecovr->hide();
                 expmaskreti->hide();
+                enaretiMask->set_active(false);
+                enaretiMasktmap->set_active(false);
             } else {
                 sensih->show();
                 exprecovr->show();
@@ -3134,6 +3139,7 @@ void LocallabContrast::updateguicont(int spottype)
                 previewlc->hide();
                 previewlc->set_active(false);
                 resetMaskView();
+                enalcMask->set_active(false);
                 exprecovw->hide();
                 expmasklc->hide();
             } else {
@@ -4898,6 +4904,7 @@ void LocallabCBDL::updateguicbdl(int spottype)
                 sensicb->hide();
                 exprecovcb->hide();
                 expmaskcb->hide();
+                enacbMask->set_active(false);
             } else {
                 exprecovcb->show();
                 expmaskcb->show();
@@ -5863,6 +5870,7 @@ void LocallabLog::updateguilog(int spottype)
                 showmaskLMethod->set_active(0);               
                 previewlog->hide();
                 previewlog->set_active(false);
+                enaLMask->set_active(false);
                 resetMaskView();
                 exprecovl->hide();
                 expmaskL->hide();
@@ -7272,7 +7280,7 @@ void LocallabMask::updateguimask(int spottype)
 
             if(spottype == 3) {
                 sensimask->hide();
-                showmask_Method->set_active(0);               
+                showmask_Method->set_active(0);
                 previewmas->hide();
                 previewmas->set_active(false);
                 resetMaskView();
@@ -7281,6 +7289,7 @@ void LocallabMask::updateguimask(int spottype)
                 softradiusmask->hide();
                 showmask_Method->hide();
                 enamask->hide();
+                enamask->set_active(false);
                 mask_CurveEditorG->hide();
                 struFrame->hide();
                 blurFrame->hide();
@@ -9205,6 +9214,8 @@ void Locallabcie::updateguicie(int spottype)
                 previewcie->hide();
                 exprecovcie->hide();
                 expmaskcie->hide();
+                enacieMask->set_active(false);
+                enacieMaskall->set_active(false);
                 previewcie->set_active(false);
                 resetMaskView();
             } else {

--- a/rtgui/locallabtools2.cc
+++ b/rtgui/locallabtools2.cc
@@ -428,6 +428,8 @@ void LocallabTone::updateguitone(int spottype)
 
             if(spottype == 3) {
                 sensitm->hide();
+                exprecovt->hide();
+                expmasktm->hide();
              //   showmasktmMethodConn.block(true);
                 showmasktmMethod->set_active(0);
              //   showmasktmMethodConn.block(false);
@@ -439,6 +441,10 @@ void LocallabTone::updateguitone(int spottype)
             } else {
                 sensitm->show();
                 previewtm->show();
+                exprecovt->show();
+                expmasktm->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
+                
            }
             enableListener();
 
@@ -1188,8 +1194,13 @@ void LocallabRetinex::updateguireti(int spottype)
 
             if(spottype == 3) {
                 sensih->hide();
+                exprecovr->hide();
+                expmaskreti->hide();
             } else {
                 sensih->show();
+                exprecovr->show();
+                expmaskreti->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
             }
             enableListener();
 
@@ -3123,10 +3134,14 @@ void LocallabContrast::updateguicont(int spottype)
                 previewlc->hide();
                 previewlc->set_active(false);
                 resetMaskView();
-                
+                exprecovw->hide();
+                expmasklc->hide();
             } else {
                 sensilc->show();
                 previewlc->show();
+                exprecovw->show();
+                expmasklc->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
             }
             enableListener();
 
@@ -4881,8 +4896,13 @@ void LocallabCBDL::updateguicbdl(int spottype)
 
             if(spottype == 3) {
                 sensicb->hide();
+                exprecovcb->hide();
+                expmaskcb->hide();
             } else {
+                exprecovcb->show();
+                expmaskcb->show();
                 sensicb->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
             }
             enableListener();
 
@@ -5844,10 +5864,14 @@ void LocallabLog::updateguilog(int spottype)
                 previewlog->hide();
                 previewlog->set_active(false);
                 resetMaskView();
-                
+                exprecovl->hide();
+                expmaskL->hide();
             } else {
                 sensilog->show();
                 previewlog->show();
+                exprecovl->show();
+                expmaskL->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
             }
             enableListener();
 
@@ -7252,10 +7276,31 @@ void LocallabMask::updateguimask(int spottype)
                 previewmas->hide();
                 previewmas->set_active(false);
                 resetMaskView();
+                blendmask->hide();
+                blendmaskab->hide();
+                softradiusmask->hide();
+                showmask_Method->hide();
+                enamask->hide();
+                mask_CurveEditorG->hide();
+                struFrame->hide();
+                blurFrame->hide();
+                toolmaskFrame->hide();
                 
             } else {
                 sensimask->show();
                 previewmas->show();
+                blendmask->show();
+                blendmaskab->show();
+                softradiusmask->show();
+                showmask_Method->show();
+                enamask->show();
+                mask_CurveEditorG->show();
+                struFrame->show();
+                blurFrame->show();
+                toolmaskFrame->show();
+                
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
+                
            }
             enableListener();
 
@@ -9158,11 +9203,16 @@ void Locallabcie::updateguicie(int spottype)
                 sensicie->hide();
                 showmaskcieMethod->set_active(0);
                 previewcie->hide();
+                exprecovcie->hide();
+                expmaskcie->hide();
                 previewcie->set_active(false);
                 resetMaskView();
             } else {
                 sensicie->show();
                 previewcie->show();
+                exprecovcie->show();
+                expmaskcie->show();
+                updateGUIToMode(static_cast<modeType>(complexity->get_active_row_number()));
            }
             enableListener();
 


### PR DESCRIPTION
Masks can't work well in Global mode, due to the lack of deltaE.
The solution in place in "dev" didn't work in Global mode, but let the GUI show.

This (easy) modification to the GUI solves the problem of disabling and hiding
* Mask and modifications
* Recovery based on luminance mask
I only change all void  as : void Locallabxxx::updateguixxx(int spottype) 

Jacques
