### PR TITLE
Support for images with more than 6 sub-frames

### DIFF
--- a/rtgui/bayerprocess.cc
+++ b/rtgui/bayerprocess.cc
@@ -745,7 +745,7 @@ void BayerProcess::FrameCountChanged(int n, int frameNum)
 
             imageNumber->remove_all();
             imageNumber->append("1");
-            for (int i = 2; i <= std::min(n, 6); ++i) {
+            for (int i = 2; i <= n; ++i) {
                 std::ostringstream entry;
                 entry << i;
                 imageNumber->append(entry.str());


### PR DESCRIPTION
This lifts the restriction on images with 7 or more sub-frames. The restriction is there to prevent a crash with Hasselblad pixelshift files (#5433) by only allowing sub-frames 2 to 7 to be selected. With this pull request, the restriction applies only to images with the make "Hasselblad".

I also refactored a bit to use `unique_ptr`.

Closes #7143.