### PR TITLE
Fix duplicate tag in Deutsch locale

### DIFF
--- a/rtdata/languages/Deutsch
+++ b/rtdata/languages/Deutsch
@@ -296,7 +296,7 @@ FILEBROWSER_SHOWTRASHHINT;Inhalt des Papierkorbs anzeigen.\nTaste: <b>Strg</b> +
 FILEBROWSER_SHOWUNCOLORHINT;Nur unmarkierte Bilder anzeigen.\nTaste: <b>Alt</b> + <b>0</b>
 FILEBROWSER_SHOWUNRANKHINT;Nur unbewertete Bilder anzeigen.\nTaste: <b>Umschalt</b>-<b>0</b>
 FILEBROWSER_THUMBSIZE;Miniaturbildgröße
-FILEBROWSER_UNRANK_TOOLTIP;Bewertung entfernen.\nTaste: <b><b>0</b>
+FILEBROWSER_UNRANK_TOOLTIP;Bewertung entfernen.\nTaste: <b>0</b>
 FILEBROWSER_ZOOMINHINT;Miniaturbilder vergrößern.\n\nIm Multi-Reitermodus:\nTaste: <b>+</b>\nIm Ein-Reitermodus:\nTaste: <b>Alt</b> <b>+</b>
 FILEBROWSER_ZOOMOUTHINT;Miniaturbilder verkleinern.\n\nIm Multi-Reitermodus:\nTaste: <b>-</b>\nIm Ein-Reitermodus:\nTaste: <b>Alt</b> <b>-</b>
 FILECHOOSER_FILTER_ANY;Alle Dateien


### PR DESCRIPTION
Hello,

The "Deutsch" locale has one message, with an unmatched additional `<b>` tag, which causes a Gtk-WARNING message:

```(rawtherapee:617420): Gtk-WARNING **: 08:29:35.684: Failed to set text 'Bewertung entfernen.
Taste: <b><b>0</b>' from markup due to error parsing markup: Fehler in Zeile 2, Zeichen 28: Element »markup« wurde geschlossen, aber das derzeit offene Element ist »b«
```
The German error message essentially just mentions that the b tag is not closed.

This PR removes the unmatched tag.


Kind regards,

pano