### PR TITLE
Fix for rank, color label, and trash status reset

### DIFF
--- a/rtgui/thumbnail.cc
+++ b/rtgui/thumbnail.cc
@@ -485,7 +485,7 @@ void Thumbnail::clearProcParams (int whoClearedIt)
         pparams->setDefaults();
 
         // preserve rank, colorlabel and inTrash across clear
-        updateProcParamsProperties();
+        updateProcParamsProperties(true);
 
         // params could get validated by updateProcParamsProperties
         if (pparamsValid) {
@@ -594,7 +594,7 @@ void Thumbnail::setProcParams (const ProcParams& pp, ParamsEdited* pe, int whoCh
         pparamsValid = true;
 
         // do not update rank, colorlabel and inTrash
-        updateProcParamsProperties();
+        updateProcParamsProperties(true);
 
         if (updateCacheNow) {
             updateCache();
@@ -1295,25 +1295,25 @@ void Thumbnail::loadProperties()
     }
 }
 
-void Thumbnail::updateProcParamsProperties()
+void Thumbnail::updateProcParamsProperties(bool forceUpdate)
 {
-    if (!properties.edited()) {
+    if (!(properties.edited() || forceUpdate)) {
         return;
     }
 
-    if (properties.trashed.edited && properties.trashed != pparams->inTrash) {
+    if ((properties.trashed.edited || forceUpdate) && properties.trashed != pparams->inTrash) {
         pparams->inTrash = properties.trashed;
         pparamsValid = true;
     }
 
     // save procparams rank and color also when options.thumbnailRankColorMode == Options::ThumbnailPropertyMode::XMP
     // so they'll be kept in sync
-    if (properties.rank.edited && properties.rank != pparams->rank) {
+    if ((properties.rank.edited || forceUpdate) && properties.rank != pparams->rank) {
         pparams->rank = properties.rank;
         pparamsValid = true;
     }
 
-    if (properties.color.edited && properties.color != pparams->colorlabel) {
+    if ((properties.color.edited || forceUpdate) && properties.color != pparams->colorlabel) {
         pparams->colorlabel = properties.color;
         pparamsValid = true;
     }

--- a/rtgui/thumbnail.h
+++ b/rtgui/thumbnail.h
@@ -115,7 +115,7 @@ class Thumbnail
 
     void saveMetadata();
     void loadProperties();
-    void updateProcParamsProperties();
+    void updateProcParamsProperties(bool forceUpdate = false);
     void saveXMPSidecarProperties();
 
 public:


### PR DESCRIPTION
Prevents the rank, color label, and trash status from getting reset after editing an image or clearing its processing profile.

Whenever the processing parameters get reset or saved, the rank, color label, and trash status start with the default values and the original values must be transferred. This was the case with 5.10 and older, but after some refactoring for the XMP synchronization feature (#6988), the values are only transferred if changed during the current session. There are flags for each parameter that indicates if the value has changed. If the flag is not set, the value does not get transferred.

@sgotti I introduced a way to force-update the values in the processing parameters. I'm thinking it is better to just remove the check for the edited flag, but I am hesitant to use that approach. I get the feeling that there is a reason for the check due to the fact that there is the check *in addition to* comparing the old and new values.

Closes #7218.