### PR TITLE
Fix for channel mixer deactivation

### DIFF
--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2039,9 +2039,9 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
     };
 
     bool mixchannels = params->chmixer.enabled &&
-                       (params->chmixer.red[0] != 100 || params->chmixer.red[1] != 0     || params->chmixer.red[2] != 0   ||
-                        params->chmixer.green[0] != 0 || params->chmixer.green[1] != 100 || params->chmixer.green[2] != 0 ||
-                        params->chmixer.blue[0] != 0  || params->chmixer.blue[1] != 0    || params->chmixer.blue[2] != 100);
+                       (params->chmixer.red[0] != 1000 || params->chmixer.red[1] != 0     || params->chmixer.red[2] != 0   ||
+                        params->chmixer.green[0] != 0 || params->chmixer.green[1] != 1000 || params->chmixer.green[2] != 0 ||
+                        params->chmixer.blue[0] != 0  || params->chmixer.blue[1] != 0    || params->chmixer.blue[2] != 1000);
 
     FlatCurve* hCurve = nullptr;
     FlatCurve* sCurve = nullptr;


### PR DESCRIPTION
The channel mixer used to be deactivated with the default values. When the precision of the channel mixer was increased by multiplying the integer values by 10, it caused the deactivation to occur with values of 10 instead of 100. This pull request changes the deactivation values to 1000, which corresponds to an actual value of 100.