### PR TITLE
Fix for all EXIF data getting selected

### DIFF
--- a/rtgui/metadatapanel.cc
+++ b/rtgui/metadatapanel.cc
@@ -79,8 +79,10 @@ void MetaDataPanel::read(const rtengine::procparams::ProcParams* pp, const Param
         }
     }
 
-    exifpanel->read(pp, pedited);
-    iptcpanel->read(pp, pedited);
+    if (!batchMode) { // Not used in batch mode.
+        exifpanel->read(pp, pedited);
+        iptcpanel->read(pp, pedited);
+    }
     
     enableListener();
 }
@@ -94,8 +96,10 @@ void MetaDataPanel::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         pedited->metadata.mode = metadataMode->get_active_row_number() != 3;
     }
 
-    exifpanel->write(pp, pedited);
-    iptcpanel->write(pp, pedited);
+    if (!batchMode) { // Invalid in batch mode.
+        exifpanel->write(pp, pedited);
+        iptcpanel->write(pp, pedited);
+    }
 }
 
 


### PR DESCRIPTION
The batch edit tab does not support editing EXIF and IPTC data, so it doesn't make sense for the GUI to write the values to the processing parameters.

Closes #6993.