### PR TITLE
Include offset times in default EXIF tags

### DIFF
--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -6204,6 +6204,12 @@ std::vector<std::string> MetaDataParams::basicExifKeys = {
 };
 
 
+const std::vector<std::string> additional_default_exif_keys = {
+    "Exif.Photo.OffsetTimeDigitized",
+    "Exif.Photo.OffsetTimeOriginal",
+};
+
+
 MetaDataParams::MetaDataParams():
     mode(MetaDataParams::EDIT),
     exifKeys{},
@@ -6211,6 +6217,7 @@ MetaDataParams::MetaDataParams():
     iptc{}
 {
     exifKeys = basicExifKeys;
+    exifKeys.insert(exifKeys.end(), additional_default_exif_keys.begin(), additional_default_exif_keys.end());
 }
 
 


### PR DESCRIPTION
By default, copies OffsetTimeDigitized and OffsetTimeOriginal to the exported image which preserves the timezone data for the capture and created times.

Closes #7179.