### PR TITLE
Sony ILCE-7M3 (and other Sony cameras) black level

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -3091,7 +3091,6 @@ Camera constants:
         // "raw_crop": [ 8, 8, 6008, 4008 ], // full raw frame 6048x4024 Dcraw auto identify 6024x4024, jpeg 12,12,6000x4000
         // "ranges": { "black": 512, "white": 16300 }
         "ranges": {
-            "black": 512,
             "white": [
                 { "iso": [ 50, 64 ], "levels": 16100 }, // typical compressed 16372, non compressed 16383, LongEx iso50,16150 , 16275
                 { "iso": [ 80, 100, 125, 160 ], "levels": 16200 }, // typical compressed 16372, non compressed 16383, LongEx iso50,16150 , 16275

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -6741,6 +6741,7 @@ int CLASS parse_tiff_ifd (int base)
 	FORC3 if (i > (int)cblack[c]) i = cblack[c];
 	FORC4 cblack[c] -= i;
 	black = i;
+	sony_meta.sr2subifd_black2 = true;
 	break;
       case 29459:
 	FORC4 cam_mul[c] = get2();
@@ -9733,7 +9734,9 @@ void CLASS adobe_coeff (const char *make, const char *model)
       break;
     }
   if (load_raw == &CLASS sony_arw2_load_raw) { // RT: arw2 scale fix
-      black <<= 2;
+      if (!sony_meta.sr2subifd_black2) {
+        black <<= 2;
+      }
       tiff_bps += 2;
   } else if (load_raw == &CLASS panasonic_load_raw) {
       tiff_bps = RT_pana_info.bpp;
@@ -10468,7 +10471,8 @@ void CLASS identify()
     top_margin = filters = 0;
     strcpy (model,"C603");
   }
-  if (!strcmp(make,"Sony") && raw_width > 3888)
+  // From LibRaw: Do not set black if black or cblack is already set.
+  if (!strcmp(make,"Sony") && raw_width > 3888 && !black && !cblack[0])
     black = 128 << (tiff_bps - 12);
   if (is_foveon) {
     if (height*2 < width) pixel_aspect = 0.5;

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -174,6 +174,12 @@ protected:
         unsigned sub_frame_shot_select;
     };
 
+    struct SonyMeta
+    {
+        /// SR2SubIFD black levels tag 0x7310 exists.
+        bool sr2subifd_black2 = false;
+    };
+
     int fuji_total_lines, fuji_total_blocks, fuji_block_width, fuji_bits, fuji_raw_type, fuji_lossless;
 
     ushort raw_height, raw_width, height, width, top_margin, left_margin;
@@ -201,6 +207,7 @@ protected:
     std::string RT_software;
     double RT_baseline_exposure;
     struct MergedPixelshift merged_pixelshift;
+    struct SonyMeta sony_meta;
 
 public:
     struct CanonCR3Data {


### PR DESCRIPTION
The Sony ILCE-7M3 black level is different at extremely high ISOs. The metadata contains the correct black level. This pull request removes the black level from `camconst.json` and improves the usage of the dcraw metadata black level implemented in #7183. LibRaw already reads the metadata black level correctly.

Closes #7252.