### PR TITLE
Multi-frame image crash fix

### DIFF
--- a/rtengine/rawimagesource.cc
+++ b/rtengine/rawimagesource.cc
@@ -2690,9 +2690,9 @@ void RawImageSource::copyOriginalPixels(const RAWParams &raw, RawImage *src, con
 */
         
         if (ri->getSensorType() == ST_BAYER) {
-            getMinValsBayer(ri->zeroIsBad());
+            getMinValsBayer(rawData, ri->zeroIsBad());
         } else {
-            getMinValsXtrans();
+            getMinValsXtrans(rawData);
         }
         //
         reddeha = minVals[0];
@@ -8384,7 +8384,7 @@ void RawImageSource::getRawValues(int x, int y, int rotate, int &R, int &G, int 
 /*
     Copyright (c) Ingo Weyrich  2020 (heckflosse67@gmx.de)
 */
-void RawImageSource::getMinValsXtrans() {
+void RawImageSource::getMinValsXtrans(const array2D<float> &rawData) {
 #ifdef _OPENMP
     #pragma omp parallel for reduction (min:minVals)
 #endif
@@ -8530,7 +8530,7 @@ void RawImageSource::applyDngGainMap(const float black[4], const std::vector<Gai
 /*
     Copyright (c) Ingo Weyrich  2020 (heckflosse67@gmx.de)
 */
-void RawImageSource::getMinValsBayer(bool zeroIsBad) {
+void RawImageSource::getMinValsBayer(const array2D<float> &rawData, bool zeroIsBad) {
 BENCHFUN
     if (!zeroIsBad) {
 #ifdef _OPENMP

--- a/rtengine/rawimagesource.h
+++ b/rtengine/rawimagesource.h
@@ -310,8 +310,8 @@ protected:
     void    vflip       (Imagefloat* im);
     void getRawValues(int x, int y, int rotate, int &R, int &G, int &B) override;
     void captureSharpening(const procparams::CaptureSharpeningParams &sharpeningParams, bool showMask, double &conrastThreshold, double &radius) override;
-    void getMinValsXtrans();
-    void getMinValsBayer(bool zeroIsBad);
+    void getMinValsXtrans(const array2D<float> &rawData);
+    void getMinValsBayer(const array2D<float> &rawData, bool zeroIsBad);
     void applyDngGainMap(const float black[4], const std::vector<GainMap> &gainMaps);
 public:
     void wbMul2Camera(double &rm, double &gm, double &bm) override;


### PR DESCRIPTION
Fixes the crash that happens when opening a file with sub-images when a certain sub-image is selected (SN mode for Canon Dual Pixel or sub-image >= 2 for pixel shift images). The code that calculated the raw minimum values was reading data from the wrong source, which may be uninitialized.

Closes #7213.