### PR TITLE
Quick info font size

### DIFF
--- a/rtgui/imagearea.cc
+++ b/rtgui/imagearea.cc
@@ -155,7 +155,7 @@ void ImageArea::setInfoText (Glib::ustring text)
 
     // update font
     fontd.set_weight (Pango::WEIGHT_BOLD);
-    const int fontSize = 10; // pt
+    const int fontSize = options.fontSize;
     // Non-absolute size is defined in "Pango units" and shall be multiplied by
     // Pango::SCALE from "pt":
     fontd.set_size (fontSize * Pango::SCALE);


### PR DESCRIPTION
The quick info font size is always 10pt. This makes it use the main font size set in Preferences.