### PR TITLE
macOS CI: upgrades x86_64 runner to macOS 13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Per https://github.com/Beep6581/RawTherapee/issues/7267