### PR TITLE
Fix for Blur/Grain & Denoise in global mode

### DIFF
--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -8913,7 +8913,10 @@ void ImProcFunctions::BlurNoise_Local(LabImage *tmp1, LabImage * originalmask, c
                 const float chrodelta2 = SQR(std::sqrt(SQR(maskptr->a[y][x]) + SQR(maskptr->b[y][x])) - chromaref * 327.68f);
                 const float huedelta2 = abdelta2 - chrodelta2;
                 const float dE = std::sqrt(kab * (kch * chrodelta2 + kH * huedelta2) + kL * SQR(refL - maskptr->L[y][x]));
-                const float reducdE = calcreducdE(dE, maxdE, mindE, maxdElim, mindElim, lp.iterat, limscope, lp.sensbn);
+                float reducdE = calcreducdE(dE, maxdE, mindE, maxdElim, mindElim, lp.iterat, limscope, lp.sensbn);
+                if(lp.fullim == 3 ) {//disabled scope
+                    reducdE = 1.f;
+                }
 
                 float difL = (tmp1->L[y - ystart][x - xstart] - original->L[y][x]) * localFactor * reducdE;
                 transformed->L[y][x] = CLIP(original->L[y][x] + difL);


### PR DESCRIPTION
@Desmis I created this PR from your `fixbug-blur` branch to fix the blur not being applied to the entire image when global mode is selected. There are a lot more changes than I expected, so I'll need you to explain what they do. I need more context to understand the code.

Closes #7226.