### PR TITLE
Clean up framing compiler warnings

### DIFF
--- a/rtengine/ipresize.cc
+++ b/rtengine/ipresize.cc
@@ -399,22 +399,6 @@ Dimensions Framing::computeRelativeImageBBoxInFrame(const Dimensions& imgSize,
     }
 
     double imgAspectRatio = imgSize.aspectRatio();
-    // Compute the width:height ratio of the border size for the requested
-    // image size and framed size.
-    //
-    // We do this by creating a dummy image. Then, scale the framed size to be
-    // larger than the dummy image such that there is a non-zero difference for
-    // widths and heights.
-    double borderAspectRatio = [&]()
-    {
-        Dimensions fakeImage = fromAspectRatio(framedSize, imgAspectRatio);
-        Dimensions bigFrame = clampToBBox(framedSize, fakeImage, OUTSIDE_BBOX);
-        bigFrame.width *= 2.0;
-        bigFrame.height *= 2.0;
-
-        Dimensions diff(bigFrame.width - fakeImage.width, bigFrame.height - fakeImage.height);
-        return diff.aspectRatio();
-    }();
 
     Side side = pickReferenceSide(framing, imgSize);
     double scale = framing.relativeBorderSize;
@@ -425,13 +409,10 @@ Dimensions Framing::computeRelativeImageBBoxInFrame(const Dimensions& imgSize,
 
     auto computedSizes = computeImgAndBorderSize(frameBasis, scale);
     double imgBasis = computedSizes.first;
-    double borderBasis = computedSizes.second;
 
     // Compute image and border lengths for the non-basis side
     double imgBasisToOther = side == Side::WIDTH ? 1.0 / imgAspectRatio : imgAspectRatio;
-    double borderBasisToOther = side == Side::WIDTH ? 1.0 / borderAspectRatio : borderAspectRatio;
     double imgOther = imgBasis * imgBasisToOther;
-    double borderOther = borderBasis * borderBasisToOther;
 
     // Find the maximum allowed image size considering min size limits
     double maxImageBasis = frameBasis;

--- a/rtgui/compressgamut.cc
+++ b/rtgui/compressgamut.cc
@@ -24,7 +24,7 @@
 
 #include "eventmapper.h"
 
-#include "../rtengine/procparams.h"
+#include "rtengine/procparams.h"
 
 using namespace rtengine;
 using namespace rtengine::procparams;

--- a/rtgui/framing.cc
+++ b/rtgui/framing.cc
@@ -27,8 +27,8 @@
 #include "paramsedited.h"
 #include "resize.h"
 
-#include "../rtengine/color.h"
-#include "../rtengine/procparams.h"
+#include "rtengine/color.h"
+#include "rtengine/procparams.h"
 
 #include <array>
 #include <iomanip>

--- a/rtgui/framing.h
+++ b/rtgui/framing.h
@@ -25,7 +25,7 @@
 #include "guiutils.h"
 #include "toolpanel.h"
 
-#include "../rtengine/procevents.h"
+#include "rtengine/procevents.h"
 
 #include <memory>
 

--- a/rtgui/toolpanelcoord.cc
+++ b/rtgui/toolpanelcoord.cc
@@ -201,6 +201,7 @@ const std::vector<ToolTree> TRANSFORM_PANEL_TOOLS = {
             },
             {
                 .id = Tool::FRAMING,
+                .children = {},
             },
         },
     },


### PR DESCRIPTION
* Remove unused variables/dead code
* Add missing `.children = {}`
* Remove relative includes