### PR TITLE
Sony lens identification improvement

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -66,6 +66,34 @@ auto to_long(const Iterator &iter, Integer n = Integer{0}) -> decltype(
 }
 
 /**
+ * Returns if the values at the iterator are equal to the given values.
+ *
+ * @param iter The iterator.
+ * @param compare_to The values to compare to.
+ * @param get_value A function that accepts the iterator and an index and
+ * returns the value at the index.
+ * @return If the values are equal.
+ */
+template <typename Iterator, typename T>
+bool tag_values_equal(
+    const Iterator &iter,
+    const std::initializer_list<T> compare_to,
+    std::function<T (const Iterator &, std::size_t)> get_value)
+{
+    const auto size = compare_to.size();
+    if (size != iter->count()) {
+        return false;
+    }
+    std::size_t i = 0;
+    for (const auto value : compare_to) {
+        if (get_value(iter, i++) != value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Convenience class for reading data from a metadata tag's bytes value.
  *
  * It maintains an offset. Data is read starting from the offset, then the
@@ -604,14 +632,18 @@ FramesData::FramesData(const Glib::ustring &fname, time_t ts) :
         } else if (!make.compare(0, 4, "SONY")) {
             // ExifTool prefers LensType2 over LensType (called
             // Exif.Sony2.LensID by Exiv2). Exiv2 doesn't support LensType2 yet,
-            // so we let Exiv2 try it's best. For non ILCE/NEX cameras which
-            // likely don't have LensType2, we use Exif.Sony2.LensID because
-            // Exif.Photo.LensModel may be incorrect (see
-            // https://discuss.pixls.us/t/call-for-testing-rawtherapee-metadata-handling-with-exiv2-includes-cr3-support/36240/36).
+            // so we let Exiv2 try it's best. If the LensSpec is unknown, the
+            // lens information may be incorrect, so we use Exif.Sony2.LensID
+            // which lists all possible lenses.
             if (
-                // Camera model is neither a ILCE, ILME, nor NEX.
-                (!find_exif_tag("Exif.Image.Model") ||
-                    (pos->toString().compare(0, 4, "ILCE") && pos->toString().compare(0, 4, "ILME") && pos->toString().compare(0, 3, "NEX"))) &&
+                // LensSpec is unknown.
+                (find_exif_tag("Exif.Sony2.LensSpec") &&
+                    tag_values_equal<decltype(pos), long>(
+                        pos,
+                        {0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L},
+                        [](const decltype(pos) &iter, std::size_t n) {
+                            return to_long(iter, n);
+                        })) &&
                 // LensID exists. 0xFFFF could be one of many lenses.
                 find_exif_tag("Exif.Sony2.LensID") && to_long(pos) && to_long(pos) != 0xFFFF) {
                 lens = pos->print(&exif);


### PR DESCRIPTION
Looking at the metadata for various ARWs, I noticed the lens information in the metadata is correct as long as the LensSpec is not unknown. This improves the lens identification by checking the LensSpec. If it is unknown, take the lens name from the LensID. Otherwise, let Exiv2 handle the lens name.

Unknown LensSpec example: https://discuss.pixls.us/t/call-for-testing-rawtherapee-metadata-handling-with-exiv2-includes-cr3-support/36240/36
Known LensSpec example: https://github.com/Beep6581/RawTherapee/issues/7278#issuecomment-2569091194

Closes #7278.