### PR TITLE
Format in output template

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -2222,8 +2222,10 @@ QUEUE_FORMAT_TITLE;File Format
 QUEUE_LOCATION_FOLDER;Save to folder
 QUEUE_LOCATION_TEMPLATE;Use template
 QUEUE_LOCATION_TEMPLATE_HELP_BUTTON_TOOLTIP;Show or hide a help panel with instructions for creating location templates
-QUEUE_LOCATION_TEMPLATE_HELP_EXAMPLES_BODY;If you want to save the output image alongside the source image, write:\n<b>%p1/%f</b>\n\nIf you want to save the output image in a folder named '<i>converted</i>' located in the source photo's folder, write:\n<b>%p1/converted/%f</b>\n\nIf you want to save the output image in\n'<i>/home/tom/photos/converted/2010-10-31</i>', write:\n<b>%p-3/converted/%P-4/%f</b>
+QUEUE_LOCATION_TEMPLATE_HELP_EXAMPLES_BODY;If you want to save the output image alongside the source image, write:\n<b>%p1/%f</b>\n\nIf you want to save the output image in a folder named '<i>converted</i>' located in the source photo's folder, write:\n<b>%p1/converted/%f</b>\n\nIf you want the output folder name to include the format (file name extension) of the output image, write:\n<b>%p1/converted_%e/%f</b>\n\nIf you want to save the output image in\n'<i>/home/tom/photos/converted/2010-10-31</i>', write:\n<b>%p-3/converted/%P-4/%f</b>
 QUEUE_LOCATION_TEMPLATE_HELP_EXAMPLES_TITLE;Common examples
+QUEUE_LOCATION_TEMPLATE_HELP_FORMAT_BODY;<b>%e</b> will be replaced by the photo's output format, as determined from the output file's file name extension.
+QUEUE_LOCATION_TEMPLATE_HELP_FORMAT_TITLE;Output File Format/File Name Extension
 QUEUE_LOCATION_TEMPLATE_HELP_INTRO;The output template field allows you to to dynamically customize the destination folder and filename. When you include certain specifiers, which begin with <b>%</b>, they are replaced by the program when each file is being saved.\n\nThe sections below describe each type of specifier.
 QUEUE_LOCATION_TEMPLATE_HELP_PATHS_BODY_1;Using this pathname as an example:
 QUEUE_LOCATION_TEMPLATE_HELP_PATHS_BODY_2;The meanings of the formatting strings are:

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -893,6 +893,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
 
 // Calculates automatic filename of processed batch entry, but just the base name
 // example output: "c:\out\converted\dsc0121"
+// format is the output file format, e.g. "jpg", "tif", "png", etc.  It is used to put format in file path using "%e"
 Glib::ustring BatchQueue::calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence, const Glib::ustring& format)
 {
 
@@ -990,7 +991,7 @@ Glib::ustring BatchQueue::calcAutoFileNameBase (const Glib::ustring& origFileNam
                     }
                 } else if (options.savePathTemplate[ix] == 'f') {
                     path += filename;
-                } else if (options.savePathTemplate[ix] == 'e') {
+                } else if (options.savePathTemplate[ix] == 'e') { // file format from input args
                     path += format;
                 } else if (options.savePathTemplate[ix] == 'r') { // rank from pparams
                     char rank;

--- a/rtgui/batchqueue.cc
+++ b/rtgui/batchqueue.cc
@@ -643,7 +643,7 @@ void BatchQueue::updateDestinationPathPreview()
     if (!selected.empty()) {
         auto& entry = *selected.at(0);
         int sequence = 0;   // Sequence during subsequent queue processing can't be determined here
-        Glib::ustring baseDestination = calcAutoFileNameBase(entry.filename, sequence);
+        Glib::ustring baseDestination = calcAutoFileNameBase(entry.filename, sequence, options.saveFormatBatch.format);
         Glib::ustring destination = Glib::ustring::compose ("%1.%2", baseDestination, options.saveFormatBatch.format);
 
         if (listener) {
@@ -759,8 +759,8 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
     SaveFormat saveFormat;
 
     if (processing->outFileName.empty()) { // auto file name
-        Glib::ustring s = calcAutoFileNameBase (processing->filename, processing->sequence);
         saveFormat = options.saveFormatBatch;
+        Glib::ustring s = calcAutoFileNameBase (processing->filename, processing->sequence, saveFormat.format);
         fname = autoCompleteFileName (s, saveFormat.format);
     } else { // use the save-as filename with automatic completion for uniqueness
         if (processing->forceFormatOpts) {
@@ -893,7 +893,7 @@ rtengine::ProcessingJob* BatchQueue::imageReady(rtengine::IImagefloat* img)
 
 // Calculates automatic filename of processed batch entry, but just the base name
 // example output: "c:\out\converted\dsc0121"
-Glib::ustring BatchQueue::calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence)
+Glib::ustring BatchQueue::calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence, const Glib::ustring& format)
 {
 
     std::vector<Glib::ustring> da;
@@ -990,6 +990,8 @@ Glib::ustring BatchQueue::calcAutoFileNameBase (const Glib::ustring& origFileNam
                     }
                 } else if (options.savePathTemplate[ix] == 'f') {
                     path += filename;
+                } else if (options.savePathTemplate[ix] == 'e') {
+                    path += format;
                 } else if (options.savePathTemplate[ix] == 'r') { // rank from pparams
                     char rank;
                     rtengine::procparams::ProcParams pparams;

--- a/rtgui/batchqueue.h
+++ b/rtgui/batchqueue.h
@@ -91,7 +91,7 @@ public:
     bool loadBatchQueue ();
     void resizeLoadedQueue();
 
-    static Glib::ustring calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence = 0);
+    static Glib::ustring calcAutoFileNameBase (const Glib::ustring& origFileName, int sequence=0, const Glib::ustring& format="");
     static int calcMaxThumbnailHeight();
 
 private:

--- a/rtgui/batchqueuepanel.cc
+++ b/rtgui/batchqueuepanel.cc
@@ -429,6 +429,9 @@ void BatchQueuePanel::populateTemplateHelpBuffer(Glib::RefPtr<Gtk::TextBuffer> b
         pos = buffer->insert_markup(pos, Glib::ustring::format("\n  <tt><b>", fspecifier, "</b> = <i>", result, "</i></tt>"));
     }
 
+    insertTopicHeading(M("QUEUE_LOCATION_TEMPLATE_HELP_FORMAT_TITLE"));
+    pos = buffer->insert_markup(pos, M("QUEUE_LOCATION_TEMPLATE_HELP_FORMAT_BODY"));
+
     insertTopicHeading(M("QUEUE_LOCATION_TEMPLATE_HELP_RANK_TITLE"));
     pos = buffer->insert_markup(pos, M("QUEUE_LOCATION_TEMPLATE_HELP_RANK_BODY"));
 


### PR DESCRIPTION
I added in a "%e" format specifier for the batch queue output location template.

I also updated the help panel for the batch queue output location to document the added specifier.

Now, for example, an output location of "%p1/converted_%e/%f" will include the file extension (output format) in the folder path for the output image.  So, the folder path will contain "converted_jpg" or "converted_png", etc., depending on the output file extension.

Resolves #7196