### PR TITLE
Fix for artifact uploading from GitHub Actions

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -20,6 +20,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   build:
     runs-on: macos-13
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
Adds the necessary permission to allow the workflows to upload artifacts to release tags.