### PR TITLE
Fix for macOS ARM build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -140,6 +140,8 @@ jobs:
 
   armbuild:
     runs-on: macos-14
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Add permission to upload artifacts to release tags.