### PR TITLE
Fix DCPProfile constructor not respecting the verbose setting

### DIFF
--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -1131,13 +1131,17 @@ DCPProfile::DCPProfile(const Glib::ustring& filename) :
         });
 
     if (file == nullptr) {
-        printf ("Unable to load DCP profile '%s' !", filename.c_str());
+        if (settings->verbose) {
+            printf ("Unable to load DCP profile '%s' !", filename.c_str());
+        }
         return;
     }
 
     DCPMetadata md(file.get());
     if (!md.parse()) {
-        printf ("Unable to load DCP profile '%s'.", filename.c_str());
+        if (settings->verbose) {
+            printf ("Unable to load DCP profile '%s'.", filename.c_str());
+        }
         return;
     }
 

--- a/rtengine/dcp.cc
+++ b/rtengine/dcp.cc
@@ -1132,7 +1132,7 @@ DCPProfile::DCPProfile(const Glib::ustring& filename) :
 
     if (file == nullptr) {
         if (settings->verbose) {
-            printf ("Unable to load DCP profile '%s' !", filename.c_str());
+            printf ("Unable to load DCP profile '%s' !\n", filename.c_str());
         }
         return;
     }
@@ -1140,7 +1140,7 @@ DCPProfile::DCPProfile(const Glib::ustring& filename) :
     DCPMetadata md(file.get());
     if (!md.parse()) {
         if (settings->verbose) {
-            printf ("Unable to load DCP profile '%s'.", filename.c_str());
+            printf ("Unable to load DCP profile '%s'.\n", filename.c_str());
         }
         return;
     }


### PR DESCRIPTION
Couple of prints in the DCPProfile constructor were printing regardless of the verbose setting.