### PR TITLE
Japanese on Windows crash fix

### DIFF
--- a/rtgui/profilepanel.cc
+++ b/rtgui/profilepanel.cc
@@ -138,12 +138,12 @@ ProfilePanel::~ProfilePanel ()
 
 bool ProfilePanel::isCustomSelected()
 {
-    return profiles->getCurrentLabel() == Glib::ustring ("(" + M("PROFILEPANEL_PCUSTOM") + ")");
+    return profiles->getCurrentLabel().collate_key() == Glib::ustring ("(" + M("PROFILEPANEL_PCUSTOM") + ")").collate_key();
 }
 
 bool ProfilePanel::isLastSavedSelected()
 {
-    return profiles->getCurrentLabel() == Glib::ustring ("(" + M("PROFILEPANEL_PLASTSAVED") + ")");
+    return profiles->getCurrentLabel().collate_key() == Glib::ustring ("(" + M("PROFILEPANEL_PLASTSAVED") + ")").collate_key();
 }
 
 Gtk::TreeIter ProfilePanel::getCustomRow()


### PR DESCRIPTION
This works around a possible GLib bug where a string may not compare equal to itself. Using `raw()` instead of `collate_key()` also works, but I'm not sure if there are potential issues with using `raw()`.

Closes #7304.