### PR TITLE
Selective Editing - Avoid negatives values  - see on Pixls.us

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '[]'
+  publish_pre_dev_labels: '["Rawtherapee:avoidneg"]'
 
 jobs:
   build:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '["Rawtherapee:avoidneg"]'
+  publish_pre_dev_labels: '["Beep6581:avoidneg"]'
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '[]'
+  publish_pre_dev_labels: '["Rawtherapee:avoidneg"]'
 
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '["Rawtherapee:avoidneg"]'
+  publish_pre_dev_labels: '["Beep6581:avoidneg"]'
 
 
 jobs:

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1488,7 +1488,7 @@ HISTORY_MSG_ICM_WORKING_PRIM_METHOD;Primaries method
 HISTORY_MSG_ICM_WORKING_SLOPE;TRC - Slope
 HISTORY_MSG_ICM_WORKING_TRC_METHOD;TRC method
 HISTORY_MSG_ILLUM;CAL - SC - Illuminant
-HISTORY_MSG_LOCAL_AVOIDNEGATIVE;Local - SC - Avoid zero and negative values
+HISTORY_MSG_LOCAL_AVOIDNEGATIVE;Local - SC - Pre-filter zero and negative values
 HISTORY_MSG_LOCAL_CIE_CONTSIG;Local CIECAM - Sigmoid contrast
 HISTORY_MSG_LOCAL_CIE_SKEWSIG;Local CIECAM - Sigmoid skew
 HISTORY_MSG_LOCAL_CIE_SMOOTHTH;Local CIECAM - Attenuation threshold
@@ -2998,7 +2998,7 @@ TP_LOCALLAB_AVOID;Avoid color shift
 TP_LOCALLAB_AVOIDCOLORSHIFT_TOOLTIP;Fit colors into gamut of the working color space and apply Munsell correction (Uniform Perceptual Lab). Default: Munsell only.\n\nMunsell only: Fixes Lab mode hue drifts due to non-linearity when chromaticity is changed (Uniform Perceptual Lab).\nLab: Applies a gamut control in relative colorimetric. Munsell is then applied.\nXYZ Absolute: Applies gamut control in absolute colorimetric. Munsell is then applied.\nXYZ Relative: Applies gamut control in relative colorimetric. Munsell is then applied. The result is not the same as Lab.
 TP_LOCALLAB_AVOIDMUN;Munsell correction only
 TP_LOCALLAB_AVOIDMUN_TOOLTIP;Munsell correction always disabled when Jz or CAM16 is used.
-TP_LOCALLAB_AVOIDNEG;Avoid zero and negative values
+TP_LOCALLAB_AVOIDNEG;Pre-filter zero and negative values
 TP_LOCALLAB_AVOIDRAD;Soft radius
 TP_LOCALLAB_BALAN;ab-L balance (ΔE)
 TP_LOCALLAB_BALANEXP;Laplacian balance

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1488,7 +1488,7 @@ HISTORY_MSG_ICM_WORKING_PRIM_METHOD;Primaries method
 HISTORY_MSG_ICM_WORKING_SLOPE;TRC - Slope
 HISTORY_MSG_ICM_WORKING_TRC_METHOD;TRC method
 HISTORY_MSG_ILLUM;CAL - SC - Illuminant
-HISTORY_MSG_LOCAL_AVOIDNEGATIVE;Local - SC - Avoid negatives values
+HISTORY_MSG_LOCAL_AVOIDNEGATIVE;Local - SC - Avoid zero and negative values
 HISTORY_MSG_LOCAL_CIE_CONTSIG;Local CIECAM - Sigmoid contrast
 HISTORY_MSG_LOCAL_CIE_SKEWSIG;Local CIECAM - Sigmoid skew
 HISTORY_MSG_LOCAL_CIE_SMOOTHTH;Local CIECAM - Attenuation threshold
@@ -2998,7 +2998,7 @@ TP_LOCALLAB_AVOID;Avoid color shift
 TP_LOCALLAB_AVOIDCOLORSHIFT_TOOLTIP;Fit colors into gamut of the working color space and apply Munsell correction (Uniform Perceptual Lab). Default: Munsell only.\n\nMunsell only: Fixes Lab mode hue drifts due to non-linearity when chromaticity is changed (Uniform Perceptual Lab).\nLab: Applies a gamut control in relative colorimetric. Munsell is then applied.\nXYZ Absolute: Applies gamut control in absolute colorimetric. Munsell is then applied.\nXYZ Relative: Applies gamut control in relative colorimetric. Munsell is then applied. The result is not the same as Lab.
 TP_LOCALLAB_AVOIDMUN;Munsell correction only
 TP_LOCALLAB_AVOIDMUN_TOOLTIP;Munsell correction always disabled when Jz or CAM16 is used.
-TP_LOCALLAB_AVOIDNEG;Avoid negatives values
+TP_LOCALLAB_AVOIDNEG;Avoid zero and negative values
 TP_LOCALLAB_AVOIDRAD;Soft radius
 TP_LOCALLAB_BALAN;ab-L balance (ΔE)
 TP_LOCALLAB_BALANEXP;Laplacian balance

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1488,6 +1488,7 @@ HISTORY_MSG_ICM_WORKING_PRIM_METHOD;Primaries method
 HISTORY_MSG_ICM_WORKING_SLOPE;TRC - Slope
 HISTORY_MSG_ICM_WORKING_TRC_METHOD;TRC method
 HISTORY_MSG_ILLUM;CAL - SC - Illuminant
+HISTORY_MSG_LOCAL_AVOIDNEGATIVE;Local - SC - Avoid negatives values
 HISTORY_MSG_LOCAL_CIE_CONTSIG;Local CIECAM - Sigmoid contrast
 HISTORY_MSG_LOCAL_CIE_SKEWSIG;Local CIECAM - Sigmoid skew
 HISTORY_MSG_LOCAL_CIE_SMOOTHTH;Local CIECAM - Attenuation threshold
@@ -2997,6 +2998,7 @@ TP_LOCALLAB_AVOID;Avoid color shift
 TP_LOCALLAB_AVOIDCOLORSHIFT_TOOLTIP;Fit colors into gamut of the working color space and apply Munsell correction (Uniform Perceptual Lab). Default: Munsell only.\n\nMunsell only: Fixes Lab mode hue drifts due to non-linearity when chromaticity is changed (Uniform Perceptual Lab).\nLab: Applies a gamut control in relative colorimetric. Munsell is then applied.\nXYZ Absolute: Applies gamut control in absolute colorimetric. Munsell is then applied.\nXYZ Relative: Applies gamut control in relative colorimetric. Munsell is then applied. The result is not the same as Lab.
 TP_LOCALLAB_AVOIDMUN;Munsell correction only
 TP_LOCALLAB_AVOIDMUN_TOOLTIP;Munsell correction always disabled when Jz or CAM16 is used.
+TP_LOCALLAB_AVOIDNEG;Avoid negatives values
 TP_LOCALLAB_AVOIDRAD;Soft radius
 TP_LOCALLAB_BALAN;ab-L balance (ΔE)
 TP_LOCALLAB_BALANEXP;Laplacian balance

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -14301,12 +14301,8 @@ void ImProcFunctions::Lab_Local(
     if(params->dirpyrequalizer.cbdlMethod == "bef") {//If user choose "after black and white" this function which removes negative values is not used, hence CBDL is best performed, after Selective Editing in Lab mode
         cbdl = true;
     }
-    bool dirpyrdeha = (params->dirpyrequalizer.enabled && cbdl)  ||  params->dehaze.enabled  || lp.avoidneg;//lp.avoidneg in setting 
+    nocrash = (params->dirpyrequalizer.enabled && cbdl)  ||  params->dehaze.enabled  || lp.avoidneg;//lp.avoidneg in setting 
     
-    if(dirpyrdeha) {
-        nocrash = true;
-    }
-
     
     if(nocrash) {//allows memory and conversion labrgb only in these cases and prevent negative RGB values
         const std::unique_ptr<Imagefloat> prov0(new Imagefloat(bw0, bh0));

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -843,6 +843,7 @@ struct local_params {
     float residhithr;
     float residgam;
     float residslop;
+    bool avoidneg;
     bool blwh;
     bool fftma;
     float blurma;
@@ -1892,6 +1893,7 @@ static void calcLocalParams(int sp, int oW, int oH, const LocallabParams& locall
     lp.residhithr = locallab.spots.at(sp).residhithr;
     lp.residgam = locallab.spots.at(sp).residgam;
     lp.residslop = locallab.spots.at(sp).residslop;
+    lp.avoidneg = locallab.spots.at(sp).avoidneg;
     lp.blwh = locallab.spots.at(sp).blwh;
     lp.senscolor = (int) locallab.spots.at(sp).colorscope;
     //replace scope color vibrance shadows
@@ -14276,13 +14278,45 @@ void ImProcFunctions::Lab_Local(
         return;
     }
 
-    //BENCHFUN
+
 
     constexpr int del = 3; // to avoid crash with [loy - begy] and [lox - begx] and bfh bfw  // with gtk2 [loy - begy-1] [lox - begx -1 ] and del = 1
     struct local_params lp;
     calcLocalParams(sp, oW, oH, params->locallab, lp, prevDeltaE, llColorMask, llColorMaskinv, llExpMask, llExpMaskinv, llSHMask, llSHMaskinv, llvibMask, lllcMask, llsharMask, llcbMask, llretiMask, llsoftMask, lltmMask, llblMask, lllogMask, ll_Mask, llcieMask, locwavCurveden, locwavdenutili);
 
     //avoidcolshi(lp, sp, transformed, reserved,  cy, cx, sk);
+    //BENCHFUN
+
+
+
+
+    //avoid negative values RGB then Lab when using before SE CBDL or Dehaze, or processor type...
+
+    int bw0 = transformed->W;
+    int bh0 = transformed->H;
+
+    float epsi0 = 0.000001f;
+    bool nocrash = false;
+    bool dirpyrdeha = params->dirpyrequalizer.enabled  ||  params->dehaze.enabled  || lp.avoidneg;//lp.avoidneg in setting 
+    if(dirpyrdeha) {
+        nocrash = true;
+    }
+
+    
+    if(nocrash) {//allows memory and conversion labrgb only in these cases and prevent negative RGB values
+        const std::unique_ptr<Imagefloat> prov0(new Imagefloat(bw0, bh0));
+        lab2rgb(*transformed, *prov0, params->icm.workingProfile);
+#ifdef _OPENMP
+        #pragma omp parallel for
+#endif
+            for (int i = 0; i < bh0; ++i)
+                for (int j = 0; j < bw0; ++j) {
+                    prov0->r(i, j) = (rtengine::max(prov0->r(i, j), epsi0));
+                    prov0->g(i, j) = (rtengine::max(prov0->g(i, j), epsi0));
+                    prov0->b(i, j) = (rtengine::max(prov0->b(i, j), epsi0)); 
+                }
+        rgb2lab(*prov0, *transformed, params->icm.workingProfile);
+    }
 
     const float radius = lp.rad / (sk * 1.4); //0 to 70 ==> see skip
     int levred;
@@ -21082,7 +21116,6 @@ void ImProcFunctions::Lab_Local(
     bool notlaplacian = false;//no use of strong Laplacian
 
     float epsi = 0.000001f;
-
 
     if((lp.laplacexp > 1.f && lp.exposena) || (lp.strng > 2.f && lp.sfena) || (lp.exposena && lp.expcomp != 0.f && params->dirpyrequalizer.enabled)){//strong Laplacian
         notlaplacian = true;

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -14297,7 +14297,12 @@ void ImProcFunctions::Lab_Local(
 
     float epsi0 = 0.000001f;
     bool nocrash = false;
-    bool dirpyrdeha = params->dirpyrequalizer.enabled  ||  params->dehaze.enabled  || lp.avoidneg;//lp.avoidneg in setting 
+    bool cbdl = false;
+    if(params->dirpyrequalizer.cbdlMethod == "bef") {//If user choose "after black and white" this function which removes negative values is not used, hence CBDL is best performed, after Selective Editing in Lab mode
+        cbdl = true;
+    }
+    bool dirpyrdeha = (params->dirpyrequalizer.enabled && cbdl)  ||  params->dehaze.enabled  || lp.avoidneg;//lp.avoidneg in setting 
+    
     if(dirpyrdeha) {
         nocrash = true;
     }

--- a/rtengine/iplocallab.cc
+++ b/rtengine/iplocallab.cc
@@ -14290,7 +14290,7 @@ void ImProcFunctions::Lab_Local(
 
 
 
-    //avoid negative values RGB then Lab when using before SE CBDL or Dehaze, or processor type...
+    //Pre-filter zero and negative values RGB then Lab when using before SE CBDL or Dehaze, or processor type...
 
     int bw0 = transformed->W;
     int bh0 = transformed->H;

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -3317,6 +3317,7 @@ LocallabParams::LocallabSpot::LocallabSpot() :
     transitgrad(0.0),
     hishow(options.complexity != 2),
     activ(true),
+    avoidneg(true),
     blwh(false),
     recurs(false),
     laplac(true),
@@ -5219,6 +5220,7 @@ bool LocallabParams::LocallabSpot::operator ==(const LocallabSpot& other) const
         && transitgrad == other.transitgrad
         && hishow == other.hishow
         && activ == other.activ
+        && avoidneg == other.avoidneg
         && blwh == other.blwh
         && recurs == other.recurs
         && laplac == other.laplac
@@ -7226,6 +7228,7 @@ int ProcParams::save(const Glib::ustring& fname, const Glib::ustring& fname2, bo
                 saveToKeyfile(!pedited || spot_edited->transitgrad, "Locallab", "Transitgrad_" + index_str, spot.transitgrad, keyFile);
                 saveToKeyfile(!pedited || spot_edited->hishow, "Locallab", "Hishow_" + index_str, spot.hishow, keyFile);
                 saveToKeyfile(!pedited || spot_edited->activ, "Locallab", "Activ_" + index_str, spot.activ, keyFile);
+                saveToKeyfile(!pedited || spot_edited->avoidneg, "Locallab", "Avoidneg_" + index_str, spot.avoidneg, keyFile);
                 saveToKeyfile(!pedited || spot_edited->blwh, "Locallab", "Blwh_" + index_str, spot.blwh, keyFile);
                 saveToKeyfile(!pedited || spot_edited->recurs, "Locallab", "Recurs_" + index_str, spot.recurs, keyFile);
                 saveToKeyfile(!pedited || spot_edited->laplac, "Locallab", "Laplac_" + index_str, spot.laplac, keyFile);
@@ -9560,6 +9563,7 @@ int ProcParams::load(const Glib::ustring& fname, ParamsEdited* pedited)
                 assignFromKeyfile(keyFile, "Locallab", "Transitgrad_" + index_str, spot.transitgrad, spotEdited.transitgrad);
                 assignFromKeyfile(keyFile, "Locallab", "Hishow_" + index_str, spot.hishow, spotEdited.hishow);
                 assignFromKeyfile(keyFile, "Locallab", "Activ_" + index_str, spot.activ, spotEdited.activ);
+                assignFromKeyfile(keyFile, "Locallab", "Avoidneg_" + index_str, spot.avoidneg, spotEdited.avoidneg);
                 assignFromKeyfile(keyFile, "Locallab", "Blwh_" + index_str, spot.blwh, spotEdited.blwh);
                 assignFromKeyfile(keyFile, "Locallab", "Recurs_" + index_str, spot.recurs, spotEdited.recurs);
                 assignFromKeyfile(keyFile, "Locallab", "Laplac_" + index_str, spot.laplac, spotEdited.laplac);

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -1118,6 +1118,7 @@ struct LocallabParams {
         double transitgrad;
         bool hishow;
         bool activ;
+        bool avoidneg;
         bool blwh;
         bool recurs;
         bool laplac;

--- a/rtgui/controlspotpanel.h
+++ b/rtgui/controlspotpanel.h
@@ -82,6 +82,7 @@ public:
         double avoidrad;
         bool hishow;
         bool activ;
+        bool avoidneg;
         bool blwh;
         bool recurs;
         bool laplac;
@@ -261,6 +262,7 @@ private:
 
     void hishowChanged();
     void activChanged();
+    void avoidnegChanged();
     void blwhChanged();
     void recursChanged();
     void laplacChanged();
@@ -323,6 +325,7 @@ private:
         Gtk::TreeModelColumn<double> avoidrad;
         Gtk::TreeModelColumn<bool> hishow;
         Gtk::TreeModelColumn<bool> activ;
+        Gtk::TreeModelColumn<bool> avoidneg;
         Gtk::TreeModelColumn<bool> blwh;
         Gtk::TreeModelColumn<bool> recurs;
         Gtk::TreeModelColumn<bool> laplac;
@@ -354,6 +357,7 @@ private:
 
     ControlSpots spots_;
     rtengine::ProcEvent EvLocallabavoidgamutMethod;
+    rtengine::ProcEvent EvLocallabavoidnegative;
 
     // Child widgets
     Gtk::ScrolledWindow* const scrolledwindow_;
@@ -420,6 +424,8 @@ private:
     sigc::connection hishowconn_;
     Gtk::CheckButton* const activ_;
     sigc::connection activConn_;
+    Gtk::CheckButton* const avoidneg_;
+    sigc::connection avoidnegConn_;
     Gtk::CheckButton* const blwh_;
     sigc::connection blwhConn_;
     Gtk::CheckButton* const recurs_;

--- a/rtgui/locallab.cc
+++ b/rtgui/locallab.cc
@@ -344,6 +344,7 @@ void Locallab::read(const rtengine::procparams::ProcParams* pp, const ParamsEdit
         r.avoidrad = pp->locallab.spots.at(i).avoidrad;
         r.hishow = pp->locallab.spots.at(i).hishow;
         r.activ = pp->locallab.spots.at(i).activ;
+        r.avoidneg = pp->locallab.spots.at(i).avoidneg;
         r.blwh = pp->locallab.spots.at(i).blwh;
         r.recurs = pp->locallab.spots.at(i).recurs;
         r.laplac = true; //pp->locallab.spots.at(i).laplac;
@@ -539,6 +540,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r.avoidrad = newSpot->avoidrad;
             r.hishow = newSpot->hishow;
             r.activ = newSpot->activ;
+            r.avoidneg = newSpot->avoidneg;
             r.blwh = newSpot->blwh;
             r.recurs = newSpot->recurs;
             r.laplac = newSpot->laplac;
@@ -879,6 +881,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
             r.avoidrad = newSpot->avoidrad;
             r.hishow = newSpot->hishow;
             r.activ = newSpot->activ;
+            r.avoidneg = newSpot->avoidneg;
             r.blwh = newSpot->blwh;
             r.recurs = newSpot->recurs;
             r.laplac = newSpot->laplac;
@@ -1051,6 +1054,7 @@ void Locallab::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedited
                     pp->locallab.spots.at(pp->locallab.selspot).avoidrad = r->avoidrad;
                     pp->locallab.spots.at(pp->locallab.selspot).hishow = r->hishow;
                     pp->locallab.spots.at(pp->locallab.selspot).activ = r->activ;
+                    pp->locallab.spots.at(pp->locallab.selspot).avoidneg = r->avoidneg;
                     pp->locallab.spots.at(pp->locallab.selspot).blwh = r->blwh;
                     pp->locallab.spots.at(pp->locallab.selspot).recurs = r->recurs;
                     pp->locallab.spots.at(pp->locallab.selspot).laplac = r->laplac;

--- a/rtgui/paramsedited.cc
+++ b/rtgui/paramsedited.cc
@@ -1317,6 +1317,7 @@ void ParamsEdited::initFrom(const std::vector<rtengine::procparams::ProcParams>&
                 locallab.spots.at(j).transitgrad = locallab.spots.at(j).transitgrad && pSpot.transitgrad == otherSpot.transitgrad;
                 locallab.spots.at(j).hishow = locallab.spots.at(j).hishow && pSpot.hishow == otherSpot.hishow;
                 locallab.spots.at(j).activ = locallab.spots.at(j).activ && pSpot.activ == otherSpot.activ;
+                locallab.spots.at(j).avoidneg = locallab.spots.at(j).avoidneg && pSpot.avoidneg == otherSpot.avoidneg;
                 locallab.spots.at(j).blwh = locallab.spots.at(j).blwh && pSpot.blwh == otherSpot.blwh;
                 locallab.spots.at(j).recurs = locallab.spots.at(j).recurs && pSpot.recurs == otherSpot.recurs;
                 locallab.spots.at(j).laplac = locallab.spots.at(j).laplac && pSpot.laplac == otherSpot.laplac;
@@ -3964,6 +3965,10 @@ void ParamsEdited::combine(rtengine::procparams::ProcParams& toEdit, const rteng
 
         if (locallab.spots.at(i).activ) {
             toEdit.locallab.spots.at(i).activ = mods.locallab.spots.at(i).activ;
+        }
+
+        if (locallab.spots.at(i).avoidneg) {
+            toEdit.locallab.spots.at(i).avoidneg = mods.locallab.spots.at(i).avoidneg;
         }
 
         if (locallab.spots.at(i).blwh) {
@@ -8338,6 +8343,7 @@ LocallabParamsEdited::LocallabSpotEdited::LocallabSpotEdited(bool v) :
     transitgrad(v),
     hishow(v),
     activ(v),
+    avoidneg(v),
     blwh(v),
     recurs(v),
     laplac(v),
@@ -9123,6 +9129,7 @@ void LocallabParamsEdited::LocallabSpotEdited::set(bool v)
     transitgrad = v;
     hishow = v;
     activ = v;
+    avoidneg = v;
     blwh = v;
     recurs = v;
     laplac = v;

--- a/rtgui/paramsedited.h
+++ b/rtgui/paramsedited.h
@@ -458,6 +458,7 @@ public:
         bool transitgrad;
         bool hishow;
         bool activ;
+        bool avoidneg;
         bool blwh;
         bool recurs;
         bool laplac;


### PR DESCRIPTION
I am trying to solve this problem knowing that on my machine both on Windows 11 (24H2) and under Ubuntu 24.04 in all cases that I tried with the Raw and the pp3 provided, in "preview" mode, in TIF output or in Queue (fast export, etc.) no crash occurs.

On the other hand I tried "Contrast by detail levels" then SE with Color & Light contrast, there I noticed a crash.
From tests done on another branch in development, it seems that upstream of SE, CBDL or Dehaze can generate RGB values ​​with very low negative values ​​(of the order of -0.01 on a scale of [0 65535]) which are poorly accepted by SE in some cases only.

I added at the beginning of the SE code, a check that ensures that there are no negative RGB values, in 3 cases:
* Contrast by detail levels enable 
* Haze removal enable
* I added a checkbox, enable by default in SA > Settings > Specific cases > **Avoid negatives values**. I don't know if this will be effective for what is discussed in the thread on Pixls.us, but it's worth a try (because I don't have any crashes in this case). Maybe it is due to a specific processor (AMD, Intel or a Bios configuration...) which could be more (or less) precise for certain calculations where the results are close to zero or to a Raw Type with particular black point, or ??.

https://discuss.pixls.us/t/crash-when-exporting-or-moving-detail-window/48453/1