### PR TITLE
Fixes issue #7282

### DIFF
--- a/rtgui/dirpyrdenoise.cc
+++ b/rtgui/dirpyrdenoise.cc
@@ -574,6 +574,7 @@ void DirPyrDenoise::read (const ProcParams* pp, const ParamsEdited* pedited)
         passes->setEditedState     (pedited->dirpyrDenoise.passes ? Edited : UnEdited);
         set_inconsistent           (multiImage && !pedited->dirpyrDenoise.enabled);
         median->set_inconsistent   (!pedited->dirpyrDenoise.median);
+        lshape->setUnChanged       (!pedited->dirpyrDenoise.lcurve);
         ccshape->setUnChanged      (!pedited->dirpyrDenoise.cccurve);
 
         //      perform->set_inconsistent (!pedited->dirpyrDenoise.perform);


### PR DESCRIPTION
This is supposed to fix issue [#7282] "Noise Reduction Luminance Curve changed when using Batch Edit".

Please note: I have not tried to understand the underlying logic but was only looking for places where "lcurve" (affected by the bug) and "cccurve" (not affected by the bug) were treated differently. Please verify that this fix does not introduce unintended side effects.