### PR TITLE
Minolta RD175 LibRaw white level fix

### DIFF
--- a/rtengine/rawimage.cc
+++ b/rtengine/rawimage.cc
@@ -796,11 +796,21 @@ int RawImage::loadRaw(bool loadData, unsigned int imageNum, bool closeFile, Prog
 #ifdef LIBRAW_USE_OPENMP
                 MyMutex::MyLock lock(*librawMutex);
 #endif
+
+                // For some cameras like Minolta RD175, the real white level is
+                // read with LibRaw::unpack(). Here, we initialize LibRaw's
+                // maximum with the value read earlier. Later, we read the value
+                // back in case it has changed.
+                libraw->imgdata.color.maximum = maximum;
+
                 err = libraw->unpack();
             }
             if (err) {
                 return err;
             }
+
+            // Update white level in case LibRaw::unpack() read a new value.
+            maximum = libraw->imgdata.color.maximum;
 
             auto &rd = libraw->imgdata.rawdata;
             raw_image = rd.raw_image;


### PR DESCRIPTION
The function for loading the image data from Minolta RD175 raw images sets the white level. White levels are typically determined while reading the image metadata. In rare cases, LibRaw (and dcraw too because the code is from dcraw) sets the correct white level while reading the image data, but this new white level was not taken into consideration.

Closes #7328.