### PR TITLE
Fix for Nikon D5 black level when using LibRaw

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -1857,7 +1857,7 @@ Camera constants:
     { // Quality B, no LENR samples
         "make_model": "Nikon D5",
         "dcraw_matrix": [ 9200,-3522,-992,-5755,13803,2117,-754,1486,6338 ], // DNG v13.2
-        "ranges": { "black": 0, "white": 16300 } // WL typical 16383 set to 16300 for safety
+        "ranges": { "white": 16300 } // WL typical 16383 set to 16300 for safety
     },
 
     { // Quality C


### PR DESCRIPTION
With LibRaw, the black level is provided in the global black variable instead of the per-channel array. Black levels in `camconst.json` override the global black level instead of adding to the black level as with the per-channel levels. LibRaw and dcraw have the same black level for the D5, so it is sufficient to remove the black level from `camconst.json`.