### PR TITLE
Fix Temperature Correlation White Balance in CLI

### DIFF
--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -277,10 +277,10 @@ private:
         currWB = ColorTemp(params.wb.temperature, params.wb.green, params.wb.equal, params.wb.method, params.wb.observer);
         ColorTemp currWBitc;
 
-        if (params.wb.method == "autitcgreen"  && flush) {
+        if (params.wb.method == "autitcgreen") {
             imgsrc->getrgbloc(0, 0, fh, fw, 0, 0, fh, fw, params.wb);
         }
-        const bool autowb = (params.wb.method == "autitcgreen" && imgsrc->isRAW() && flush);
+        const bool autowb = (params.wb.method == "autitcgreen" && imgsrc->isRAW());
         ColorTemp autoWB;
         int dread = 0;
         int bia = 1;


### PR DESCRIPTION
I ran into #7221 myself today, and I found this as a possible solution.

I was able to replicate that issue with the dev version, and this change seems to fix it with no unintended side effects (at least so far for my workflow with my small sample of test images). 

I'm by no means a C++ expert, so what I've done could definitely have some unintended side-effects, but this seems to work well enough for my use, so I'm putting it here in case it helps someone else. 
 