### PR TITLE
parse_qt: possible integer overflow

### DIFF
--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -6817,8 +6817,6 @@ void CLASS parse_qt (int end)
   while (ftell(ifp)+7 < end) {
     save = ftell(ifp);
     if ((size = get4()) < 8) return;
-    if ((int)size < 0) return; // 2+GB is too much
-    if (save + size < save) return; // 32bit overflow
     fread (tag, 4, 1, ifp);
     if (!memcmp(tag,"moov",4) ||
 	!memcmp(tag,"udta",4) ||

--- a/rtengine/dcraw.c
+++ b/rtengine/dcraw.c
@@ -6817,6 +6817,8 @@ void CLASS parse_qt (int end)
   while (ftell(ifp)+7 < end) {
     save = ftell(ifp);
     if ((size = get4()) < 8) return;
+    if ((int)size < 0) return; // 2+GB is too much
+    if (save + size < save) return; // 32bit overflow
     fread (tag, 4, 1, ifp);
     if (!memcmp(tag,"moov",4) ||
 	!memcmp(tag,"udta",4) ||

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -7842,6 +7842,8 @@ void CLASS parse_qt (int end)
   while (ftell(ifp)+7 < end) {
     save = ftell(ifp);
     if ((size = get4()) < 8) return;
+    if ((int)size < 0) return; // 2+GB is too much
+    if (save + size < save) return; // 32bit overflow
     fread (tag, 4, 1, ifp);
     if (!memcmp(tag,"moov",4) ||
 	!memcmp(tag,"udta",4) ||


### PR DESCRIPTION
Description
This PR fixes a possible integer overflow in parse_qt() that was cloned from LibRaw but did not receive the security patch. The original issue was reported and fixed under https://github.com/LibRaw/LibRaw/commit/1334647862b0c90b2e8cb2f668e66627d9517b17. This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2018-5815
https://github.com/LibRaw/LibRaw/commit/1334647862b0c90b2e8cb2f668e66627d9517b17