### PR TITLE
Black and white level overrides for Samsung DNGs

### DIFF
--- a/rtengine/camconst.json
+++ b/rtengine/camconst.json
@@ -2861,6 +2861,16 @@ Camera constants:
         }
     },
 
+    { // Quality A
+        "make_model": [ "Pentax K20D", "Samsung GX20" ], // Based on Samsung GX20 data.
+        "ranges": {
+            "white": [
+                { "iso": 100, "levels": 4000 },
+                { "iso": 200, "levels": 4095 }
+            ]
+        }
+    },
+
     { // Quality C, only raw crop
         "make_model": "Samsung EX2F",
         "raw_crop": [ 16, 7, -4, -4 ]

--- a/rtengine/dcraw.cc
+++ b/rtengine/dcraw.cc
@@ -9695,15 +9695,18 @@ void CLASS adobe_coeff (const char *make, const char *model)
 
   // -- RT --------------------------------------------------------------------
   const bool is_pentax_dng = dng_version && !strncmp(RT_software.c_str(), "PENTAX", 6);
+  const bool is_samsung_dng = dng_version && !strcmp("Samsung", make) && normalized_make == "Pentax" && RT_software.rfind(model, 0) == 0;
+  /** Is it a DNG from the camera? */
+  const bool is_camera_dng = is_pentax_dng || is_samsung_dng;
   // indicate that DCRAW wants these from constants (rather than having loaded these from RAW file
   // note: this is simplified so far, in some cases dcraw calls this when it has say the black level
   // from file, but then we will not provide any black level in the tables. This case is mainly just
   // to avoid loading table values if we have loaded a DNG conversion of a raw file (which already
   // have constants stored in the file).
-  if (RT_whitelevel_from_constant == ThreeValBool::X || is_pentax_dng) {
+  if (RT_whitelevel_from_constant == ThreeValBool::X || is_camera_dng) {
     RT_whitelevel_from_constant = ThreeValBool::T;
   }
-  if (RT_blacklevel_from_constant == ThreeValBool::X || is_pentax_dng) {
+  if (RT_blacklevel_from_constant == ThreeValBool::X || is_camera_dng) {
     RT_blacklevel_from_constant = ThreeValBool::T;
   }
   if (RT_matrix_from_constant == ThreeValBool::X) {

--- a/rtengine/dcraw.h
+++ b/rtengine/dcraw.h
@@ -205,6 +205,8 @@ protected:
     ThreeValBool RT_blacklevel_from_constant;
     ThreeValBool RT_matrix_from_constant;
     std::string RT_software;
+    std::string normalized_make;
+    std::string normalized_model;
     double RT_baseline_exposure;
     struct MergedPixelshift merged_pixelshift;
     struct SonyMeta sony_meta;


### PR DESCRIPTION
Black and white levels are typically taken from the DNG metadata. Values in `camconst.json` are ignored. The exception is with Pentax DNGs produced in-camera. Several Pentax cameras have Samsung counterparts that also produce DNGs.

This detects which DNGs are produced by such Samsung cameras and allows `camconst.json` to override the black and white levels, just like how Pentax DNGs are handled.

The first Samsung camera to have an override is the GX20 (equivalent to the Pentax K20D). The white levels are derived from white frames provided in #7374. ISO 100 images have some areas that do not go all the way up to 4095 (true with and without LENR). Images of other ISOs go all the way to 4095 across the frame.