### PR TITLE
macOS: update bundle jxl-cms handler

### DIFF
--- a/tools/osx/macosx_bundle.sh
+++ b/tools/osx/macosx_bundle.sh
@@ -221,7 +221,7 @@ ModifyInstallNames 2>&1
 cp ${LOCAL_PREFIX}/lib/libpng16.16.dylib "${CONTENTS}/Frameworks/libpng16.16.dylib"
 
 # Copy libjxl_cms to the app bundle
-cp ${LOCAL_PREFIX}/lib/libjxl_cms.0.10.dylib "${CONTENTS}/Frameworks/libjxl_cms.0.10.dylib"
+cp ${LOCAL_PREFIX}/lib/libjxl_cms.*.dylib "${CONTENTS}/Frameworks"
 
 # Copy graphite to Frameworks
 cp ${LOCAL_PREFIX}/lib/libgraphite2.3.dylib "${CONTENTS}/Frameworks"


### PR DESCRIPTION
Should fix #7387 regarding bundle not catching the JXL-cms sub-dependency.