### PR TITLE
Adapted Olympus lens name improvement

### DIFF
--- a/rtengine/imagedata.cc
+++ b/rtengine/imagedata.cc
@@ -629,6 +629,22 @@ FramesData::FramesData(const Glib::ustring &fname, time_t ts) :
                     lens = validateUft8(lens);
                 }
             }
+        } else if (!make.compare(0, 7, "OLYMPUS")) {
+            if (find_exif_tag("Exif.OlympusEq.LensType")) {
+                const bool is_none = tag_values_equal<decltype(pos), long>(
+                    pos,
+                    {0L, 0L, 0L, 0L, 0L, 0L},
+                    [](const decltype(pos) &iter, std::size_t n) {
+                        return to_long(iter, n);
+                    });
+
+                lens = validateUft8(pos->print(&exif));
+
+                if (is_none || lens == pos->toString()) {
+                    // Lens type is "None" or cannot be interpreted by Exiv2.
+                    lens = "Unknown";
+                }
+            }
         } else if (!make.compare(0, 4, "SONY")) {
             // ExifTool prefers LensType2 over LensType (called
             // Exif.Sony2.LensID by Exiv2). Exiv2 doesn't support LensType2 yet,

--- a/rtengine/rtlensfun.cc
+++ b/rtengine/rtlensfun.cc
@@ -638,6 +638,9 @@ LFLens LFDatabase::findLens(const LFCamera &camera, const Glib::ustring &name, b
                 return bestCandidate;
             }
         }
+
+        // Tries to find the lens by name, possibly splitting the maker and
+        // model from the lens name.
         const auto find_lens_from_name = [](const lfDatabase *database, const lfCamera *cam, const Glib::ustring &lens_name) {
             auto found = database->FindLenses(cam, nullptr, lens_name.c_str());
             for (size_t pos = 0; !found && pos < lens_name.size(); ) {
@@ -660,15 +663,29 @@ LFLens LFDatabase::findLens(const LFCamera &camera, const Glib::ustring &name, b
             }
             return found;
         };
-        auto found = find_lens_from_name(data_, camera.data_, name);
-        if (!found) {
-            // Some names have white-space around the dash(s) while Lensfun does
-            // not have any.
-            const auto formatted_name = trimDashWhitespace(name.raw());
-            if (name != formatted_name) {
-                found = find_lens_from_name(data_, camera.data_, formatted_name);
+
+        // Find the lens, starting with the mount, then trying without the mount
+        // if no match is found. The latter is necessary for certain adapted
+        // lenses.
+        const lfLens **found = nullptr;
+        lfCamera camera_without_mount(*(camera.data_));
+        camera_without_mount.SetMount(nullptr);
+        const lfCamera *camera_without_mount_ptr = &camera_without_mount;
+        for (auto camera_data : {camera.data_, camera_without_mount_ptr}) {
+            if (!found) {
+                found = find_lens_from_name(data_, camera_data, name);
+            }
+            if (!found) {
+                // Some names have white-space around the dash(s) while Lensfun
+                // does not have any.
+                const auto formatted_name = trimDashWhitespace(name.raw());
+                if (name != formatted_name) {
+                    found = find_lens_from_name(data_, camera_data, formatted_name);
+                }
             }
         }
+
+        // Finally, handle the case of fixed-lens cameras.
         if (!found && camera && camera.isFixedLens()) {
             found = data_->FindLenses(camera.data_, nullptr, "");
         }

--- a/rtengine/rtlensfun.cc
+++ b/rtengine/rtlensfun.cc
@@ -668,7 +668,8 @@ LFLens LFDatabase::findLens(const LFCamera &camera, const Glib::ustring &name, b
         // if no match is found. The latter is necessary for certain adapted
         // lenses.
         const lfLens **found = nullptr;
-        lfCamera camera_without_mount(*(camera.data_));
+        lfCamera camera_without_mount;
+        camera_without_mount = *(camera.data_);
         camera_without_mount.SetMount(nullptr);
         const lfCamera *camera_without_mount_ptr = &camera_without_mount;
         for (auto camera_data : {camera.data_, camera_without_mount_ptr}) {


### PR DESCRIPTION
`Exif.OlympusEq.LensType` provides a better name for adapted Olympus lenses and gives the same name in other cases.

Lensfun does not recognize that Four Thirds lenses can be adapted to micro Four Thirds cameras, so I added an extra search with the mount information removed if there is no matching lens found with the lens mount.

Closes #7406.