### PR TITLE
RL deconvolution octagons fix

### DIFF
--- a/rtengine/ipsharpen.cc
+++ b/rtengine/ipsharpen.cc
@@ -174,7 +174,7 @@ BENCHFUN
 #endif
     for (int i = 0; i < H; i++) {
         for(int j = 0; j < W; j++) {
-            tmpI[i][j] = max(luminance[i][j], 0.f);
+            tmpI[i][j] = luminance[i][j] = max(luminance[i][j], 0.f);
         }
     }
 


### PR DESCRIPTION
Remove negative values from the input, which cause numerical instability.