### PR TITLE
Splash dialog: Workaround for appearing behind main window

### DIFF
--- a/rtgui/splash.cc
+++ b/rtgui/splash.cc
@@ -95,7 +95,7 @@ void SplashImage::get_preferred_width_for_height_vfunc (int height, int &minimum
     get_preferred_width_vfunc (minimum_width, natural_width);
 }
 
-Splash::Splash (Gtk::Window& parent) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, true)
+Splash::Splash (Gtk::Window& parent) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, false)
 {
 
     releaseNotesSW = nullptr;


### PR DESCRIPTION
Either there is a bug in GTK, a bug in certain window managers, or lack of support for some features in certain window managers that prevents the splash dialog from opening above the main window. The splash dialog is in modal mode, which prevents the main window from receiving user inputs. It can lead to situations where RawTherapee appears to be frozen after launching it for the first time.

Disabling modal mode allows user interactions with the main window. It is not a fix for the issue, but will reduce confusion for new users.