### PR TITLE
Automated builds for Windows ARM

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -335,3 +335,58 @@ jobs:
           tag_name: pre-dev-github-actions
           repository: RawTherapee/RawTherapee
           files: build/${{env.PUBLISH_NAME}}.exe
+
+  test-launch:
+    needs: build
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [release, debug]
+        arch: [x86_64, arm64]
+    env:
+      ARTIFACT_NAME: ${{ format('{0}_{1}_{2}', needs.build.outputs.ARTIFACT_NAME_PREFIX, matrix.arch, matrix.build_type) }}
+    steps:
+      - name: Download build artifact
+        id: download-build-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.ARTIFACT_NAME}}
+          path: build/${{env.ARTIFACT_NAME}}
+
+      - name: Launch CLI
+        working-directory: build/${{env.ARTIFACT_NAME}}
+        run: |
+          echo "Launching RawTherapee CLI."
+          ./rawtherapee-cli.exe
+
+      - name: Launch GUI
+        working-directory: build/${{env.ARTIFACT_NAME}}
+        run: |
+          STATUS_FILE="rawtherapee-status.txt"
+          SUCCESS_MESSAGE="success"
+          FAILURE_MESSAGE="failure"
+
+          echo "Launching RawTherapee GUI."
+          ./rawtherapee.exe && echo $SUCCESS_MESSAGE > $STATUS_FILE || echo $FAILURE_MESSAGE > $STATUS_FILE &
+
+          echo "Waiting 10 seconds for RawTherapee to start."
+          sleep 10
+
+          echo "Checking if RawTherapee launched successfully."
+          if [ -f "$STATUS_FILE" ]; then
+            $STATUS=$(cat "$STATUS_FILE")
+            if [ "$STATUS" == "$FAILURE_MESSAGE" ]; then
+              echo "RawTherapee failed to start."
+              exit 1
+            elif [ "$STATUS" == "$SUCCESS_MESSAGE" ]; then
+              echo "RawTherapee started successfully."
+            else
+              echo "Unknown status: $STATUS"
+              exit 1
+            fi
+          fi
+          echo "RawTherapee is launching or has launched successfully."

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
     permissions:
       contents: write
     defaults:
@@ -30,6 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [release, debug]
+        arch: [x86_64, arm64]
+    env:
+      MSYS2_ENV_NAME: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'MINGW64' }}
+      MSYS2_ENV_PREFIX: ${{ matrix.arch == 'arm64' && 'clangarm64' || 'mingw64' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -41,7 +45,7 @@ jobs:
         with:
           location: C:\msys2
           update: true
-          msystem: MINGW64
+          msystem: ${{env.MSYS2_ENV_NAME}}
           install: |
             git
             intltool
@@ -95,21 +99,21 @@ jobs:
           echo "Creating Lensfun directory in the build directory."
           mkdir -p 'build/${{matrix.build_type}}/share'
           echo "Copying Lensfun database to the build directory."
-          cp -R "/C/msys2/msys64/mingw64/var/lib/lensfun-updates/version_1" 'build/${{matrix.build_type}}/share/lensfun'
+          cp -R "/C/msys2/msys64/${{env.MSYS2_ENV_PREFIX}}/var/lib/lensfun-updates/version_1" 'build/${{matrix.build_type}}/share/lensfun'
 
       - name: Bundle dependencies
         run: |
           echo "Listing shared library dependencies."
           ldd "./build/${{matrix.build_type}}/rawtherapee.exe"
           echo "Finding DLLs to include."
-          DLLS=($(ldd "./build/${{matrix.build_type}}/rawtherapee.exe" | grep '/mingw64/bin/' | awk '{print($1)'}))
+          DLLS=($(ldd "./build/${{matrix.build_type}}/rawtherapee.exe" | grep "/${{env.MSYS2_ENV_PREFIX}}/bin/" | awk '{print($1)'}))
           echo "Required DLLs are: ${DLLS[*]}"
 
           echo "Getting workspace path."
           export BUILD_DIR="$(pwd)/build/${{matrix.build_type}}"
           echo "Build directory is '$BUILD_DIR'."
-          echo "Changing working directory to MSYS2 MINGW64."
-          cd "/C/msys2/msys64/mingw64"
+          echo "Changing working directory to MSYS2 ${{env.MSYS2_ENV_NAME}}."
+          cd "/C/msys2/msys64/${{env.MSYS2_ENV_PREFIX}}"
           echo "Copying DLLs and EXEs."
 
           cd ./bin
@@ -163,13 +167,13 @@ jobs:
       - name: Prepare artifact name
         run: |
           if [ '${{github.ref_type}}' == 'tag' ]; then
-            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.build_type}}"
+            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.arch}}_${{matrix.build_type}}"
           else
             echo "Getting RawTherapee version."
             export VERSION="$(grep -m 1 '^Version: .*$' './build/${{matrix.build_type}}/AboutThisBuild.txt' | sed 's/^Version: \(.\+\)$/\1/')"
             echo "Version is '$VERSION'."
             FILTERED_VERSION="$(echo "$VERSION" | sed 's/[^A-z0-9_.-]//g')"
-            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_${FILTERED_VERSION}_win64_${{matrix.build_type}}"
+            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_${FILTERED_VERSION}_win64_${{matrix.arch}}_${{matrix.build_type}}"
           fi
           echo "Artifact name is '$ARTIFACT_NAME'."
 
@@ -209,7 +213,7 @@ jobs:
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         run: |
           echo "Setting publish name."
-          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.build_type}}"
+          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.arch}}_${{matrix.build_type}}"
           echo "Publish name is '$PUBLISH_NAME'."
           if [ "$ARTIFACT_NAME" != "$PUBLISH_NAME" ]; then
             echo "Renaming ZIP file."
@@ -250,7 +254,7 @@ jobs:
           echo "Ref name is '$REF_NAME_FILTERED'."
 
           echo "Setting publish name."
-          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.build_type}}"
+          PUBLISH_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.arch}}_${{matrix.build_type}}"
           echo "Publish name is '$PUBLISH_NAME'."
           if [ "$ARTIFACT_NAME" != "$PUBLISH_NAME" ]; then
             echo "Renaming ZIP file."

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,8 +21,6 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
-    permissions:
-      contents: write
     defaults:
       run:
         shell: msys2 {0}
@@ -34,6 +32,9 @@ jobs:
     env:
       MSYS2_ENV_NAME: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'MINGW64' }}
       MSYS2_ENV_PREFIX: ${{ matrix.arch == 'arm64' && 'clangarm64' || 'mingw64' }}
+    outputs:
+      ARTIFACT_NAME_PREFIX: ${{ steps.prepare-artifact-name.outputs.ARTIFACT_NAME_PREFIX }}
+      REF_NAME_FILTERED: ${{ steps.prepare-artifact-name.outputs.REF_NAME_FILTERED }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -153,7 +154,7 @@ jobs:
           echo -e '[Settings]\ngtk-button-images=1' > "$BUILD_DIR/share/gtk-3.0/settings.ini"
 
       - name: Create installer
-        if: ${{matrix.build_type == 'release' && (github.ref_type == 'tag' || github.ref_name == 'dev')}}
+        if: ${{matrix.build_type == 'release'}}
         working-directory: build/${{matrix.build_type}}
         shell: pwsh
         run: |
@@ -165,22 +166,28 @@ jobs:
           iscc /F"installer" "WindowsInnoSetup.iss"
 
       - name: Prepare artifact name
+        id: prepare-artifact-name
         run: |
           if [ '${{github.ref_type}}' == 'tag' ]; then
-            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_win64_${{matrix.arch}}_${{matrix.build_type}}"
+            ARTIFACT_NAME_PREFIX="RawTherapee_${REF_NAME_FILTERED}_win64"
           else
             echo "Getting RawTherapee version."
             export VERSION="$(grep -m 1 '^Version: .*$' './build/${{matrix.build_type}}/AboutThisBuild.txt' | sed 's/^Version: \(.\+\)$/\1/')"
             echo "Version is '$VERSION'."
             FILTERED_VERSION="$(echo "$VERSION" | sed 's/[^A-z0-9_.-]//g')"
-            ARTIFACT_NAME="RawTherapee_${REF_NAME_FILTERED}_${FILTERED_VERSION}_win64_${{matrix.arch}}_${{matrix.build_type}}"
+            ARTIFACT_NAME_PREFIX="RawTherapee_${REF_NAME_FILTERED}_${FILTERED_VERSION}_win64"
           fi
+          ARTIFACT_NAME="${ARTIFACT_NAME_PREFIX}_${{matrix.arch}}_${{matrix.build_type}}"
           echo "Artifact name is '$ARTIFACT_NAME'."
 
           echo "Recording artifact name."
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> "$(cygpath -u $GITHUB_ENV)"
           echo "Recording RawTherapee version."
           echo "RT_VERSION=$VERSION" >> "$(cygpath -u $GITHUB_ENV)"
+
+          echo "Saving artifact name and filtered ref name to outputs."
+          echo "ARTIFACT_NAME_PREFIX=$ARTIFACT_NAME_PREFIX" >> "$(cygpath -u $GITHUB_OUTPUT)"
+          echo "REF_NAME_FILTERED=$REF_NAME_FILTERED" >> "$(cygpath -u $GITHUB_OUTPUT)"
 
           echo "Renaming artifact."
           mv './build/${{matrix.build_type}}' "./build/$ARTIFACT_NAME"
@@ -189,13 +196,6 @@ jobs:
             mv './build/installer.exe' "./build/$ARTIFACT_NAME.exe"
           fi
 
-      - name: Create ZIP archive
-        shell: cmd
-        working-directory: ./build
-        run: |
-          echo "Zipping artifact."
-          7z a -tzip "%ARTIFACT_NAME%.zip" "./%ARTIFACT_NAME%"
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -203,13 +203,61 @@ jobs:
           path: build\${{env.ARTIFACT_NAME}}
 
       - name: Upload installer
-        if: ${{matrix.build_type == 'release' && (github.ref_type == 'tag' || github.ref_name == 'dev')}}
+        if: ${{matrix.build_type == 'release'}}
         uses: actions/upload-artifact@v4
         with:
           name: ${{env.ARTIFACT_NAME}}.exe
           path: build\${{env.ARTIFACT_NAME}}.exe
 
+  publish:
+    needs: build
+    runs-on: 'windows-latest'
+    permissions:
+      contents: write
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [release, debug]
+        arch: [x86_64, arm64]
+    env:
+      ARTIFACT_NAME: ${{ format('{0}_{1}_{2}', needs.build.outputs.ARTIFACT_NAME_PREFIX, matrix.arch, matrix.build_type) }}
+      REF_NAME_FILTERED: ${{needs.build.outputs.REF_NAME_FILTERED}}
+    steps:
+      - name: Initialize
+        id: initialize
+        if: ${{github.ref_type == 'tag' || github.ref_name == 'dev' || (github.event_name == 'pull_request' && contains(fromJSON(env.publish_pre_dev_labels), github.event.pull_request.head.label))}}
+        run: |
+          echo "Proceeding with job."
+
+      - name: Download build artifact
+        id: download-build-artifact
+        if: ${{steps.initialize.outcome == 'success'}}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.ARTIFACT_NAME}}
+          path: build/${{env.ARTIFACT_NAME}}
+
+      - name: Download installer
+        id: download-installer
+        if: ${{steps.download-build-artifact.outcome == 'success' && matrix.build_type == 'release'}}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{env.ARTIFACT_NAME}}.exe
+          path: build
+
+      - name: Create ZIP archive
+        if: ${{steps.download-build-artifact.outcome == 'success'}}
+        shell: cmd
+        working-directory: ./build
+        run: |
+          echo "Zipping artifact."
+          7z a -tzip "%ARTIFACT_NAME%.zip" "./%ARTIFACT_NAME%"
+
       - name: Prepare for publishing
+        id: prepare-for-publishing
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         run: |
           echo "Setting publish name."
@@ -231,7 +279,7 @@ jobs:
 
       - name: Publish artifacts
         uses: softprops/action-gh-release@v2
-        if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
+        if: ${{steps.prepare-for-publishing.outcome == 'success'}}
         with:
           tag_name: nightly-github-actions
           files: |
@@ -240,7 +288,7 @@ jobs:
 
       - name: Publish installer
         uses: softprops/action-gh-release@v2
-        if: ${{matrix.build_type == 'release' && (github.ref_type == 'tag' || github.ref_name == 'dev')}}
+        if: ${{steps.prepare-for-publishing.outcome == 'success' && matrix.build_type == 'release'}}
         with:
           tag_name: nightly-github-actions
           files: build/${{env.PUBLISH_NAME}}.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '[]'
+  publish_pre_dev_labels: '["RawTherapee:windows-arm"]'
 
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  publish_pre_dev_labels: '["RawTherapee:windows-arm"]'
+  publish_pre_dev_labels: '[]'
 
 
 jobs:

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -103,7 +103,7 @@ macro(rt_fetch_content)
     FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG 40626af88bd7df9a5fb80be7b25ac85b122d6c21 # 11.2.0
+        GIT_TAG e424e3f2e607da02742f73db84873b8084fc714c # 12.0.0
         GIT_SHALLOW ON
     )
 


### PR DESCRIPTION
This adds Windows ARM builds using the new `windows-11-arm` runner, which is currently in public beta. Build artifacts now have the architecture in the name. For example,
x86: `RawTherapee_dev_win64_x86_64_release.exe`
ARM: `RawTherapee_dev_win64_arm64_release.exe`

I do not have an ARM device with Windows, so I cannot test.

Closes #7484.