### PR TITLE
CacheManager::clearFromCache is missing a mutex lock

### DIFF
--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -189,6 +189,8 @@ void CacheManager::deleteEntry (const Glib::ustring& fname)
 
 void CacheManager::clearFromCache (const Glib::ustring& fname, bool purge) const
 {
+    MyMutex::MyLock lock (mutex);
+
     deleteFiles (fname, getMD5 (fname), true, purge);
 }
 


### PR DESCRIPTION
`CacheManager::clearFromCache` is missing a mutex lock. This function is called from `FileCatalog::clearFromCacheRequested`, which is called from `FileBrowser::menuItemActivated` if a user selects images in the file browser, right clicks and chooses either one of the options from the "Cache" submenu.