### PR TITLE
Fixes Thumbnail reference counting when loading images

### DIFF
--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1256,7 +1256,6 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
 
     // initialize everything
     openThm = tmb;
-    openThm->increaseRef ();
 
     fname = openThm->getFileName();
     lastSaveAsFileName = removeExtension (Glib::path_get_basename (fname));

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -989,16 +989,17 @@ void FileCatalog::refreshHeight ()
 void FileCatalog::_openImage(const std::vector<Thumbnail*>& tmb)
 {
     if (enabled && listener) {
-        bool continueToLoad = true;
-
-        for (size_t i = 0; i < tmb.size() && continueToLoad; i++) {
-            // Open the image here, and stop if in Single Editor mode, or if an image couldn't
-            // be opened, would it be because the file doesn't exist or because of lack of RAM
-            if( !(listener->fileSelected (tmb[i])) && !App::get().options().tabbedUI ) {
-                continueToLoad = false;
+        for (size_t i = 0; i < tmb.size(); i++) {
+            // fileSelected does not complete with a fully loaded image, but it does do some preliminary checks
+            if (!listener->fileSelected(tmb[i])) {
+                tmb[i]->decreaseRef();
+            } else if (!App::get().options().tabbedUI) {
+                // allow only one image in single editor mode
+                for (++i; i < tmb.size(); i++) {
+                    tmb[i]->decreaseRef();
+                }
+                break;
             }
-
-            tmb[i]->decreaseRef ();
         }
     }
 }

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -250,10 +250,11 @@ bool FilePanel::fileSelected (Thumbnail* thm)
 
     // Check if it's already open BEFORE loading the file
     if (App::get().options().tabbedUI && parent->selectEditorPanel(thm->getFileName())) {
+        thm->decreaseRef();
         return true;
     }
 
-    // try to open the file
+    // Check if the image is already being opened and set the image loading status if it is not
     bool loading = thm->imageLoad( true );
 
     if( !loading ) {
@@ -298,6 +299,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
     }
 
     const auto& options = App::get().options();
+    bool decThumbRef = false;
 
     // The purpose of the pendingLoads vector is to open tabs in the same order as the loads where initiated. It has no effect on single editor mode.
     while (pendingLoads.size() > 0 && pendingLoads.front()->complete) {
@@ -322,6 +324,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
                         Glib::ustring msg_ = Glib::ustring("<b>") + M("MAIN_MSG_CANNOTLOAD") + " \"" + escapeHtmlChars(thm->getFileName()) + "\" .\n" + M("MAIN_MSG_TOOMANYOPENEDITORS") + "</b>";
                         Gtk::MessageDialog msgd (*parent, msg_, true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
                         msgd.run ();
+                        decThumbRef = true;
                         goto MAXGDIHANDLESREACHED;
                     }
 #endif
@@ -343,6 +346,7 @@ bool FilePanel::imageLoaded( Thumbnail* thm, ProgressConnector<rtengine::Initial
             Glib::ustring msg_ = Glib::ustring("<b>") + M("MAIN_MSG_CANNOTLOAD") + " \"" + escapeHtmlChars(thm->getFileName()) + "\" .\n</b>";
             Gtk::MessageDialog msgd (*parent, msg_, true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
             msgd.run ();
+            decThumbRef = true;
         }
 #ifdef _WIN32
 MAXGDIHANDLESREACHED:
@@ -362,6 +366,9 @@ MAXGDIHANDLESREACHED:
     pendingLoadMutex.unlock();
 
     thm->imageLoad( false );
+    if (decThumbRef) {
+        thm->decreaseRef();
+    }
 
     return false; // MUST return false from idle function
 }


### PR DESCRIPTION
When images are opened from the file browser, the actual loading is delegated to a working thread. There is a time between initiating the loading and finishing the loading, when the thumbnail is reference counted only for the `FileBrowser`. During this time, the thumbnail can get destroyed. Because the thumbnail is passed as a pointer, which is not nulled when the thumbnail disappears underneath, the issues that happen can be various. I found this bug while figuring out weird program abort while the invalidated thumbnail was trying to acquire mutex lock.

Steps to reproduce with 5.12
1. Open directory tree with recursion enabled.
2. Double click on thumbnail that is not located at the root of the directory tree to open it
3. Very quickly click on the recursion icon on top bar to clear the thumbnail from the file browser.

These changes fix the reference counting for the moment. At least on this part. However, I think the program has outgrown in complexity from the original `Thumbnail` resource management implementation. At the moment, keeping track of the increase/decrease calls is very tedious and error prone. See `CacheManager::getEntry` and `~FileBrowserEntry` for an example, where at first glance the numbers don't match.