### PR TITLE
Enable all monitor color profiles

### DIFF
--- a/rtgui/preferences.cc
+++ b/rtgui/preferences.cc
@@ -955,12 +955,7 @@ Gtk::Widget* Preferences::getColorManPanel ()
 
     for (const auto& profile : profiles) {
         if (profile.find("file:") != 0) {
-            std::string fileis_RTv4 = profile.substr(0, 4);
-
-            if (fileis_RTv4 != "RTv4") {
-            //    printf("pro=%s \n", profile.c_str());
-                monProfile->append(profile);
-            }
+            monProfile->append(profile);
         }
     }
 


### PR DESCRIPTION
Enables all output color profiles as monitor color profiles in preferences.

@Desmis You added this monitor color profile setting ([diff](https://github.com/RawTherapee/RawTherapee/commit/c5c04769e4e55729d5d7bf8a2612df3554fdff53#diff-85efa9008f8fb6c39ff5dedf6e8626dae3961f0063408fa9f7bb1b59660e7670)) and introduced the if statement I removed in this PR. Let me know if this is safe to do?

Fixes #6908