### PR TITLE
Allow the About dialog to steal modality from the Preferences dialog

### DIFF
--- a/rtgui/rtwindow.cc
+++ b/rtgui/rtwindow.cc
@@ -420,7 +420,7 @@ void RTWindow::on_realize ()
         // Update the version parameter with the right value
         options.version = App::VERSION;
 
-        splash = new Splash (*this);
+        splash = new Splash (*this, false);
         splash->set_transient_for (*this);
         splash->signal_delete_event().connect ( sigc::mem_fun (*this, &RTWindow::splashClosed) );
 

--- a/rtgui/splash.cc
+++ b/rtgui/splash.cc
@@ -92,7 +92,7 @@ void SplashImage::get_preferred_width_for_height_vfunc (int height, int &minimum
     get_preferred_width_vfunc (minimum_width, natural_width);
 }
 
-Splash::Splash (Gtk::Window& parent) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, false)
+Splash::Splash (Gtk::Window& parent, bool modal) : Gtk::Dialog(M("GENERAL_ABOUT"), parent, modal)
 {
 
     releaseNotesSW = nullptr;

--- a/rtgui/splash.h
+++ b/rtgui/splash.h
@@ -49,7 +49,7 @@ private:
     Gtk::ScrolledWindow* releaseNotesSW;
 
 public:
-    explicit Splash (Gtk::Window& parent);
+    explicit Splash (Gtk::Window& parent, bool modal = true);
 
     bool hasReleaseNotes()
     {


### PR DESCRIPTION
The preferences dialog is created in modal mode. If the About dialog is created by the Preferences dialog in non-modal mode, it cannot be accessed while the Preferences windows is still open. Changes in this PR allows the About dialog to be created in modal mode when opened from the Preferences dialog, and in non-modal mode when created during program startup.

Fixes #7535