### PR TITLE
Manage Gamut Compression constant in one place

### DIFF
--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -34,7 +34,6 @@ using namespace rtengine::procparams;
 
 namespace
 {
-// clang-format off
 
 struct ListItem
 {
@@ -44,6 +43,7 @@ struct ListItem
     const std::array<const double, 3> thresholdDefault; ///< { th_c, th_m, th_y }
 };
 
+// clang-format off
 const std::array<ListItem, 7> COLORSPACE_LIST_ITEMS = {{
     {0,  "rec2020",    "TP_COMPRESSGAMUT_REC2020",   { 0.815, 0.803, 0.880} },
     {1,  "prophoto",   "TP_COMPRESSGAMUT_PROPHOTO",  { 0.815, 0.803, 0.880} },
@@ -53,8 +53,8 @@ const std::array<ListItem, 7> COLORSPACE_LIST_ITEMS = {{
     {5,  "acesp1",     "TP_COMPRESSGAMUT_ACESP1",    { 0.815, 0.803, 0.880} },
     {6,  "beta",       "TP_COMPRESSGAMUT_BETA",      { 0.90 , 0.95 , 0.95} }
 }};
-
 // clang-format on
+
 }
 
 const Glib::ustring Compressgamut::TOOL_NAME = "compressgamut";

--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -59,7 +59,7 @@ const std::array<ListItem, 7> COLORSPACE_LIST_ITEMS = {{
 
 const Glib::ustring Compressgamut::TOOL_NAME = "compressgamut";
 
-Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPRESSGAMUT_LABEL"), false, true)
+Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPRESSGAMUT_LABEL"), true, true)
 {
     auto m = ProcEventMapper::getInstance();
     EvcgColorspace = m->newEvent(COMPR, "HISTORY_MSG_CG_COLORSPACE");//FIRST to reinit histogram

--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -32,6 +32,29 @@
 using namespace rtengine;
 using namespace rtengine::procparams;
 
+namespace
+{
+    struct ListItem
+    {
+        const int       ID;                 ///< The row number in the combobox
+        const char*     pp3Name;
+        const char*     translationName;
+        const double    limits_th_c[4];
+        const double    limits_th_m[4];
+        const double    limits_th_y[4];
+    };
+
+    ListItem ColorspaceListItems[] = {              
+        {   0,  "rec2020",    "TP_COMPRESSGAMUT_REC2020",   {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
+        {   1,  "prophoto",   "TP_COMPRESSGAMUT_PROPHOTO",  {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
+        {   2,  "adobe",      "TP_COMPRESSGAMUT_ADOBE",     {0., 1., 0.001, 0.79}, {0., 1., 0.001, 0.82}, {0., 1., 0.001, 0.85} },
+        {   3,  "srgb",       "TP_COMPRESSGAMUT_SRGB",      {0., 1., 0.001, 0.51}, {0., 1., 0.001, 0.82}, {0., 1., 0.001, 0.82} },
+        {   4,  "dcip3",      "TP_COMPRESSGAMUT_DCIP3",     {0., 1., 0.001, 0.68}, {0., 1., 0.001, 0.89}, {0., 1., 0.001, 0.95} },
+        {   5,  "acesp1",     "TP_COMPRESSGAMUT_ACESP1",    {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
+        {   6,  "beta",       "TP_COMPRESSGAMUT_BETA",      {0., 1., 0.001, 0.90}, {0., 1., 0.001, 0.95}, {0., 1., 0.001, 0.95} },
+    };
+}
+
 const Glib::ustring Compressgamut::TOOL_NAME = "compressgamut";
 
 Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPRESSGAMUT_LABEL"), false, true)
@@ -58,13 +81,9 @@ Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPR
     Gtk::Box *iVBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
    
     colorspace = Gtk::manage(new MyComboBoxText());
-    colorspace->append(M("TP_COMPRESSGAMUT_REC2020"));
-    colorspace->append(M("TP_COMPRESSGAMUT_PROPHOTO"));
-    colorspace->append(M("TP_COMPRESSGAMUT_ADOBE"));
-    colorspace->append(M("TP_COMPRESSGAMUT_SRGB"));
-    colorspace->append(M("TP_COMPRESSGAMUT_DCIP3"));
-    colorspace->append(M("TP_COMPRESSGAMUT_ACESP1"));
-    colorspace->append(M("TP_COMPRESSGAMUT_BETA"));
+    for (auto item : ColorspaceListItems) {
+        colorspace->append(M(item.translationName));
+    }
     colorspace->set_active(3);
     iVBox->pack_start(*colorspace);
     iFrame->add(*iVBox);
@@ -241,20 +260,10 @@ void Compressgamut::read (const ProcParams* pp, const ParamsEdited* pedited)
 
     colorspaceconn.block (true);
 
-    if (pp->cg.colorspace == "rec2020") {
-        colorspace->set_active(0);
-    } else if (pp->cg.colorspace == "prophoto") {
-        colorspace->set_active(1);
-    } else if (pp->cg.colorspace == "adobe") {
-        colorspace->set_active(2);
-     } else if (pp->cg.colorspace == "srgb") {
-        colorspace->set_active(3);
-    } else if (pp->cg.colorspace == "dcip3") {
-        colorspace->set_active(4);
-    } else if (pp->cg.colorspace == "acesp1") {
-        colorspace->set_active(5);
-    } else if (pp->cg.colorspace == "beta") {
-        colorspace->set_active(6);    
+    for (auto item : ColorspaceListItems) {
+        if (pp->cg.colorspace == item.pp3Name) {
+            colorspace->set_active(item.ID);
+        }
     }
     colorspaceconn.block (false);
 
@@ -307,22 +316,11 @@ void Compressgamut::write (ProcParams* pp, ParamsEdited* pedited)
     pp->cg.rolloff = rolloff->get_active();
     pp->cg.enabled = getEnabled();
 
-    if (colorspace->get_active_row_number() == 0) {
-        pp->cg.colorspace = "rec2020";
-    } else if (colorspace->get_active_row_number() == 1){
-        pp->cg.colorspace = "prophoto";
-    } else if (colorspace->get_active_row_number() == 2){
-        pp->cg.colorspace = "adobe";
-    } else if (colorspace->get_active_row_number() == 3){
-        pp->cg.colorspace = "srgb";
-    } else if (colorspace->get_active_row_number() == 4){
-        pp->cg.colorspace = "dcip3";
-    } else if (colorspace->get_active_row_number() == 5){
-        pp->cg.colorspace = "acesp1";
-    } else if (colorspace->get_active_row_number() == 6){
-        pp->cg.colorspace = "beta";
+    for (auto item : ColorspaceListItems) {
+        if (item.ID == colorspace->get_active_row_number()) {
+            pp->cg.colorspace = item.pp3Name;
+        }
     }
-
 
     if (pedited) {
         pedited->cg.th_c          = th_c->getEditedState ();
@@ -347,45 +345,26 @@ void Compressgamut::updategamutGUI()
 {
     // Update default slider value GUI according to colorspace
     // Only for Working profile = Rec2020
-/* Calculating the 'Threshold' values ​​is anything but straightforward. Of course, one might say, "Just match them with the colors in ColorChecker24." But there are many unknown parameters:
-* What is the actual illuminant and its temperature and green settings?
-* The image colors may have been compressed using "Maximum limits," but there's no guarantee they're within the new, reduced gamut.
-* Differences in white points, such as the atypical white point of DCI-P3, complicate matters.
+    /* Calculating the 'Threshold' values ​​is anything but straightforward. Of course, one might say, "Just match them with the colors in ColorChecker24." But there are many unknown parameters:
+    * What is the actual illuminant and its temperature and green settings?
+    * The image colors may have been compressed using "Maximum limits," but there's no guarantee they're within the new, reduced gamut.
+    * Differences in white points, such as the atypical white point of DCI-P3, complicate matters.
 
-* Furthermore, what about the necessary color adaptation, both at this stage of compression and at the stage implied by the output temperature (see CIECAM)?
+    * Furthermore, what about the necessary color adaptation, both at this stage of compression and at the stage implied by the output temperature (see CIECAM)?
 
-Therefore, these parameters correspond roughly to the ratio of the distances between the white point of the Working Profile, 
-* The white point of the "Target compression gamut" corrected by chromatic adaptation and the Yellow, Magenta, and Cyan values ​​of the primary color triangle.
-* These calculated values ​​are for 'normal' cases where the illuminants are not exhaustive, and the colors to be recovered are within reasonable limits.
-* In other cases, the 3 Threshold sliders need to be adjusted (often lowered). Pay attention to the artifacts.
-*/
+    Therefore, these parameters correspond roughly to the ratio of the distances between the white point of the Working Profile, 
+    * The white point of the "Target compression gamut" corrected by chromatic adaptation and the Yellow, Magenta, and Cyan values ​​of the primary color triangle.
+    * These calculated values ​​are for 'normal' cases where the illuminants are not exhaustive, and the colors to be recovered are within reasonable limits.
+    * In other cases, the 3 Threshold sliders need to be adjusted (often lowered). Pay attention to the artifacts.
+    */
 
-
-
-   
-        if (colorspace->get_active_row_number() == 2){//Adobe D65
-            th_c->setLimits(0., 1., 0.001, 0.79);
-            th_m->setLimits(0., 1., 0.001, 0.82);
-            th_y->setLimits(0., 1., 0.001, 0.85);
- 
-        } else if (colorspace->get_active_row_number() == 3){//srgb D65
-            th_c->setLimits(0., 1., 0.001, 0.51);
-            th_m->setLimits(0., 1., 0.001, 0.82);
-            th_y->setLimits(0., 1., 0.001, 0.82);
-        } else if (colorspace->get_active_row_number() == 4){//dci-p3 - WP 0.314 0.351 
-            th_c->setLimits(0., 1., 0.001, 0.68);
-            th_m->setLimits(0., 1., 0.001, 0.89);
-            th_y->setLimits(0., 1., 0.001, 0.9);
-        } else if (colorspace->get_active_row_number() == 6){//beta RGB D50
-            th_c->setLimits(0., 1., 0.001, 0.90);
-            th_m->setLimits(0., 1., 0.001, 0.95);
-            th_y->setLimits(0., 1., 0.001, 0.95);
-        } else {
-            th_c->setLimits(0., 1., 0.001, 0.815);
-            th_m->setLimits(0., 1., 0.001, 0.803);
-            th_y->setLimits(0., 1., 0.001, 0.880);
+    for (auto item : ColorspaceListItems) {
+        if (colorspace->get_active_row_number() == item.ID) {
+            th_c->setLimits(item.limits_th_c[0], item.limits_th_c[1], item.limits_th_c[2], item.limits_th_c[3]);
+            th_m->setLimits(item.limits_th_m[0], item.limits_th_m[1], item.limits_th_m[2], item.limits_th_m[3]);
+            th_y->setLimits(item.limits_th_y[0], item.limits_th_y[1], item.limits_th_y[2], item.limits_th_y[3]);
         }
-
+    }
 }
 
 
@@ -548,7 +527,7 @@ void Compressgamut::rolloff_change()
 
 void Compressgamut::colorspaceChanged()
 {
-     updategamutGUI(); 
+    updategamutGUI(); 
     if (listener && getEnabled()) {
         listener->panelChanged(EvcgColorspace, colorspace->get_active_text());
     }

--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -34,25 +34,27 @@ using namespace rtengine::procparams;
 
 namespace
 {
-    struct ListItem
-    {
-        const int       ID;                 ///< The row number in the combobox
-        const char*     pp3Name;
-        const char*     translationName;
-        const double    limits_th_c[4];
-        const double    limits_th_m[4];
-        const double    limits_th_y[4];
-    };
+// clang-format off
 
-    ListItem ColorspaceListItems[] = {              
-        {   0,  "rec2020",    "TP_COMPRESSGAMUT_REC2020",   {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
-        {   1,  "prophoto",   "TP_COMPRESSGAMUT_PROPHOTO",  {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
-        {   2,  "adobe",      "TP_COMPRESSGAMUT_ADOBE",     {0., 1., 0.001, 0.79}, {0., 1., 0.001, 0.82}, {0., 1., 0.001, 0.85} },
-        {   3,  "srgb",       "TP_COMPRESSGAMUT_SRGB",      {0., 1., 0.001, 0.51}, {0., 1., 0.001, 0.82}, {0., 1., 0.001, 0.82} },
-        {   4,  "dcip3",      "TP_COMPRESSGAMUT_DCIP3",     {0., 1., 0.001, 0.68}, {0., 1., 0.001, 0.89}, {0., 1., 0.001, 0.95} },
-        {   5,  "acesp1",     "TP_COMPRESSGAMUT_ACESP1",    {0., 1., 0.001, 0.815}, {0., 1., 0.001, 0.803}, {0., 1., 0.001, 0.880} },   // default limits
-        {   6,  "beta",       "TP_COMPRESSGAMUT_BETA",      {0., 1., 0.001, 0.90}, {0., 1., 0.001, 0.95}, {0., 1., 0.001, 0.95} },
-    };
+struct ListItem
+{
+    const int                   ID;                     ///< The row number in the combobox
+    const char*                 pp3Name;
+    const char*                 translationName;
+    const std::array<const double, 3> thresholdDefault; ///< { th_c, th_m, th_y }
+};
+
+const std::array<ListItem, 7> COLORSPACE_LIST_ITEMS = {{
+    {0,  "rec2020",    "TP_COMPRESSGAMUT_REC2020",   { 0.815, 0.803, 0.880} },
+    {1,  "prophoto",   "TP_COMPRESSGAMUT_PROPHOTO",  { 0.815, 0.803, 0.880} },
+    {2,  "adobe",      "TP_COMPRESSGAMUT_ADOBE",     { 0.79 , 0.82 , 0.85} },
+    {3,  "srgb",       "TP_COMPRESSGAMUT_SRGB",      { 0.51 , 0.82 , 0.82} },
+    {4,  "dcip3",      "TP_COMPRESSGAMUT_DCIP3",     { 0.68 , 0.89 , 0.9} },
+    {5,  "acesp1",     "TP_COMPRESSGAMUT_ACESP1",    { 0.815, 0.803, 0.880} },
+    {6,  "beta",       "TP_COMPRESSGAMUT_BETA",      { 0.90 , 0.95 , 0.95} }
+}};
+
+// clang-format on
 }
 
 const Glib::ustring Compressgamut::TOOL_NAME = "compressgamut";
@@ -81,7 +83,7 @@ Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPR
     Gtk::Box *iVBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
    
     colorspace = Gtk::manage(new MyComboBoxText());
-    for (auto item : ColorspaceListItems) {
+    for (const auto& item : COLORSPACE_LIST_ITEMS) {
         colorspace->append(M(item.translationName));
     }
     colorspace->set_active(3);
@@ -260,7 +262,7 @@ void Compressgamut::read (const ProcParams* pp, const ParamsEdited* pedited)
 
     colorspaceconn.block (true);
 
-    for (auto item : ColorspaceListItems) {
+    for (const auto& item : COLORSPACE_LIST_ITEMS) {
         if (pp->cg.colorspace == item.pp3Name) {
             colorspace->set_active(item.ID);
             break;
@@ -268,9 +270,7 @@ void Compressgamut::read (const ProcParams* pp, const ParamsEdited* pedited)
     }
     colorspaceconn.block (false);
 
-
-    updategamutGUI(); 
-
+    updThrDefaults = (pp->icm.workingProfile == "Rec2020") ? true : false;
 
     th_c->setValue(pp->cg.th_c);
     th_m->setValue(pp->cg.th_m);
@@ -317,7 +317,7 @@ void Compressgamut::write (ProcParams* pp, ParamsEdited* pedited)
     pp->cg.rolloff = rolloff->get_active();
     pp->cg.enabled = getEnabled();
 
-    for (auto item : ColorspaceListItems) {
+    for (const auto& item : COLORSPACE_LIST_ITEMS) {
         if (item.ID == colorspace->get_active_row_number()) {
             pp->cg.colorspace = item.pp3Name;
             break;
@@ -347,6 +347,8 @@ void Compressgamut::updategamutGUI()
 {
     // Update default slider value GUI according to colorspace
     // Only for Working profile = Rec2020
+    if (!updThrDefaults) return;
+
     /* Calculating the 'Threshold' values ​​is anything but straightforward. Of course, one might say, "Just match them with the colors in ColorChecker24." But there are many unknown parameters:
     * What is the actual illuminant and its temperature and green settings?
     * The image colors may have been compressed using "Maximum limits," but there's no guarantee they're within the new, reduced gamut.
@@ -360,11 +362,11 @@ void Compressgamut::updategamutGUI()
     * In other cases, the 3 Threshold sliders need to be adjusted (often lowered). Pay attention to the artifacts.
     */
 
-    for (auto item : ColorspaceListItems) {
+    for (const auto& item : COLORSPACE_LIST_ITEMS) {
         if (colorspace->get_active_row_number() == item.ID) {
-            th_c->setLimits(item.limits_th_c[0], item.limits_th_c[1], item.limits_th_c[2], item.limits_th_c[3]);
-            th_m->setLimits(item.limits_th_m[0], item.limits_th_m[1], item.limits_th_m[2], item.limits_th_m[3]);
-            th_y->setLimits(item.limits_th_y[0], item.limits_th_y[1], item.limits_th_y[2], item.limits_th_y[3]);
+            th_c->setValue (item.thresholdDefault[0]);
+            th_m->setValue (item.thresholdDefault[1]);
+            th_y->setValue (item.thresholdDefault[2]);
             break;
         }
     }

--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -263,6 +263,7 @@ void Compressgamut::read (const ProcParams* pp, const ParamsEdited* pedited)
     for (auto item : ColorspaceListItems) {
         if (pp->cg.colorspace == item.pp3Name) {
             colorspace->set_active(item.ID);
+            break;
         }
     }
     colorspaceconn.block (false);
@@ -319,6 +320,7 @@ void Compressgamut::write (ProcParams* pp, ParamsEdited* pedited)
     for (auto item : ColorspaceListItems) {
         if (item.ID == colorspace->get_active_row_number()) {
             pp->cg.colorspace = item.pp3Name;
+            break;
         }
     }
 
@@ -363,6 +365,7 @@ void Compressgamut::updategamutGUI()
             th_c->setLimits(item.limits_th_c[0], item.limits_th_c[1], item.limits_th_c[2], item.limits_th_c[3]);
             th_m->setLimits(item.limits_th_m[0], item.limits_th_m[1], item.limits_th_m[2], item.limits_th_m[3]);
             th_y->setLimits(item.limits_th_y[0], item.limits_th_y[1], item.limits_th_y[2], item.limits_th_y[3]);
+            break;
         }
     }
 }

--- a/rtgui/tools/compressgamut.h
+++ b/rtgui/tools/compressgamut.h
@@ -46,6 +46,7 @@ protected:
     bool lastAutodc;
     bool lastAutodm;
     bool lastAutody;
+    bool updThrDefaults;    ///< Threshold defaults only available for the Rec2020 working profile
 
     MyComboBoxText *colorspace;
     sigc::connection colorspaceconn;


### PR DESCRIPTION
This PR make changes to the Gamut Compression tool so that some constants that were formerly spread around the source file are now all handled in one place. Also, fixes an issue where the threshold defaults were being applied to images that had different working profile than the Rec2020, which is the requirement for these defaults.

This PR is a continuation to the PR #7550 previously created by @desmis.

Additional notes:
* Requesting review and comments from @digitalcarp.