### PR TITLE
Fixes use after free bug in the CacheManager::deleteEntry

### DIFF
--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -170,20 +170,11 @@ void CacheManager::deleteEntry (const Glib::ustring& fname)
 
     auto thumbnail = iterator->second;
 
-    // decrease reference count;
-    // this will call back into CacheManager,
-    // so we release the lock for it
-    {
-        lock.release ();
-        thumbnail->decreaseRef ();
-        lock.acquire ();
-    }
-
-    // check again if in the editor,
-    // the thumbnail still exists,
-    // if not, delete it
-    if (openEntries.count (fname) == 0) {
+    if (thumbnail->decreaseRefCacheMgr () == 0) {
+        // If the ref count is not zero, it is open in the editor and the thumbnail can not be deleted.
+        openEntries.erase (fname);
         deleteFiles (fname, thumbnail->getMD5 (), true, true);
+        delete thumbnail;
     }
 }
 

--- a/rtgui/thumbnail.cc
+++ b/rtgui/thumbnail.cc
@@ -812,6 +812,17 @@ void Thumbnail::decreaseRef ()
     cachemgr->closeThumbnail (this);
 }
 
+int Thumbnail::decreaseRefCacheMgr ()
+{
+    MyMutex::MyLock lock(mutex);
+
+    if ( ref == 0 ) {
+        return 0;
+    }
+
+    return --ref;
+}
+
 void Thumbnail::getThumbnailSize(int &w, int &h, const rtengine::procparams::ProcParams *pparams)
 {
     MyMutex::MyLock lock(mutex);

--- a/rtgui/thumbnail.h
+++ b/rtgui/thumbnail.h
@@ -190,6 +190,7 @@ public:
 
     void            increaseRef ();
     void            decreaseRef ();
+    int             decreaseRefCacheMgr (); ///< Special version used by the CacheManager
 
     void            updateCache (bool updatePParams = true, bool updateCacheImageData = true);
     void            saveThumbnail ();


### PR DESCRIPTION
There is a use after free bug in the CacheManager::deleteEntry:

When deleteEntry is called, the execution is directed to the Thumbnail::decreaseRef ();, which calls back to the CacheManager::closeThumbnail. In CacheManager::closeThumbnail the thumbnail is deleted if the reference count goes to zero. Then execution returns back to the CacheManager::deleteEntry, where the thumbnail->getMD5 is called using a pointer to a now deleted Thumbnail object.