### PR TITLE
Fixes an issue when toggling the directory recusion button at the top bar

### DIFF
--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1662,7 +1662,19 @@ void FileCatalog::categoryButtonToggled (Gtk::ToggleButton* b, bool isMouseClick
 void FileCatalog::showRecursiveToggled()
 {
     App::get().mut_options().browseRecursive = bRecursive->get_active();
-    reparseDirectory();
+
+    // Killing background threads can sometimes block the UI for a long time,
+    // This may be a spot where giving the user information is needed.
+    previewLoader->removeAllJobs();
+    thumbImageUpdater->removeAllJobs();
+
+    idle_register.add(
+        [this]() -> bool
+        {
+            dirSelected(selectedDirectory, "");
+            return false;
+        }
+    );
 }
 
 BrowserFilter FileCatalog::getFilter ()


### PR DESCRIPTION
If directory recursion is enabled and while the file catalog is still processing thumbnails and the recursion toggle button is toggled, the file browser keeps filling with thumbnails that belong to the previous set of files.

This PR changes the reparseDirectory call to selectDirectory call, which allows the File Browser to start from a clean starting point. When I tried to achieve this with reparseDirectory, it got messy and there were issues with the File Browser ending up in an inconsistent state if the button was stressed.

Joining the background threads can take a long time in worst case scenarios (threads creating the good previews can be very slow to join, while initial thumbnail generation is generally fast). However, the delay happens as a direct response to user request, and the request is also something the users can intuitively believe takes a long time, so I believe users are able to bear with it. However, it may be useful to let users know why the UI is unresponsive and for that reason I have left a comment for a place where I believe this information could be conveniently passed.

For the same reason, I have added code that joins the background threads and then makes the call to selectDirectory as an idle_register callback. Even though, the same manipulation of the background threads is executed as part of the selectDirectory call. I tested and I didn't find bad behavior when selecting another directory while waiting for the toggle button to finish. It just switched to the other directory as soon as the UI became responsive again.