### PR TITLE
Fixes issues using filters with recursive directories enabled

### DIFF
--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1258,9 +1258,8 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     openThm = tmb;
 
     fname = openThm->getFileName();
-    imageDirectory = "";
     if ( fPanel && fPanel->fileCatalog ) {
-        imageDirectory = fPanel->fileCatalog->lastSelectedDir();
+        fPanel->fileCatalog->saveResetState();
     }
     lastSaveAsFileName = removeExtension (Glib::path_get_basename (fname));
 
@@ -1894,7 +1893,7 @@ bool EditorPanel::handleShortcutKey (GdkEventKey* event)
 
                 case GDK_KEY_y: // synchronize filebrowser with image in Editor
                     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-                        fPanel->fileCatalog->selectImage (fname, imageDirectory, false);
+                        fPanel->fileCatalog->selectImage (fname, false);
                         return true;
                     }
 
@@ -1902,7 +1901,7 @@ bool EditorPanel::handleShortcutKey (GdkEventKey* event)
 
                 case GDK_KEY_x: // clear filters and synchronize filebrowser with image in Editor
                     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-                        fPanel->fileCatalog->selectImage (fname, imageDirectory, true);
+                        fPanel->fileCatalog->selectImage (fname, true);
                         return true;
                     }
 
@@ -2313,21 +2312,21 @@ bool EditorPanel::saveImmediately (const Glib::ustring &filename, const SaveForm
 void EditorPanel::openPreviousEditorImage()
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->openNextPreviousEditorImage (fname, imageDirectory, false, NAV_PREVIOUS);
+        fPanel->fileCatalog->openNextPreviousEditorImage (fname, NAV_PREVIOUS);
     }
 }
 
 void EditorPanel::openNextEditorImage()
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->openNextPreviousEditorImage (fname, imageDirectory, false, NAV_NEXT);
+        fPanel->fileCatalog->openNextPreviousEditorImage (fname, NAV_NEXT);
     }
 }
 
 void EditorPanel::syncFileBrowser()   // synchronize filebrowser with image in Editor
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->selectImage (fname, imageDirectory, false);
+        fPanel->fileCatalog->selectImage (fname, false);
     }
 }
 

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1258,7 +1258,7 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     openThm = tmb;
 
     fname = openThm->getFileName();
-    if ( fPanel && fPanel->fileCatalog ) {
+    if (fPanel && fPanel->fileCatalog) {
         fPanel->fileCatalog->saveResetState();
     }
     lastSaveAsFileName = removeExtension (Glib::path_get_basename (fname));

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -1258,6 +1258,10 @@ void EditorPanel::open (Thumbnail* tmb, rtengine::InitialImage* isrc)
     openThm = tmb;
 
     fname = openThm->getFileName();
+    imageDirectory = "";
+    if ( fPanel && fPanel->fileCatalog ) {
+        imageDirectory = fPanel->fileCatalog->lastSelectedDir();
+    }
     lastSaveAsFileName = removeExtension (Glib::path_get_basename (fname));
 
     previewHandler = new PreviewHandler ();
@@ -1890,7 +1894,7 @@ bool EditorPanel::handleShortcutKey (GdkEventKey* event)
 
                 case GDK_KEY_y: // synchronize filebrowser with image in Editor
                     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-                        fPanel->fileCatalog->selectImage (fname, false);
+                        fPanel->fileCatalog->selectImage (fname, imageDirectory, false);
                         return true;
                     }
 
@@ -1898,7 +1902,7 @@ bool EditorPanel::handleShortcutKey (GdkEventKey* event)
 
                 case GDK_KEY_x: // clear filters and synchronize filebrowser with image in Editor
                     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-                        fPanel->fileCatalog->selectImage (fname, true);
+                        fPanel->fileCatalog->selectImage (fname, imageDirectory, true);
                         return true;
                     }
 
@@ -2309,21 +2313,21 @@ bool EditorPanel::saveImmediately (const Glib::ustring &filename, const SaveForm
 void EditorPanel::openPreviousEditorImage()
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->openNextPreviousEditorImage (fname, false, NAV_PREVIOUS);
+        fPanel->fileCatalog->openNextPreviousEditorImage (fname, imageDirectory, false, NAV_PREVIOUS);
     }
 }
 
 void EditorPanel::openNextEditorImage()
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->openNextPreviousEditorImage (fname, false, NAV_NEXT);
+        fPanel->fileCatalog->openNextPreviousEditorImage (fname, imageDirectory, false, NAV_NEXT);
     }
 }
 
 void EditorPanel::syncFileBrowser()   // synchronize filebrowser with image in Editor
 {
     if (!App::get().isSimpleEditor() && fPanel && !fname.empty()) {
-        fPanel->fileCatalog->selectImage (fname, false);
+        fPanel->fileCatalog->selectImage (fname, imageDirectory, false);
     }
 }
 

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -293,7 +293,6 @@ private:
 
     Thumbnail* openThm;  // may get invalid on external delete event
     Glib::ustring fname;  // must be saved separately
-    Glib::ustring imageDirectory;   ///< Needed when resetting file catalog to match the image opened in the editor. This value can be a substring of the full image path.
 
     int selectedFrame;
 

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -293,6 +293,7 @@ private:
 
     Thumbnail* openThm;  // may get invalid on external delete event
     Glib::ustring fname;  // must be saved separately
+    Glib::ustring imageDirectory;   ///< Needed when resetting file catalog to match the image opened in the editor. This value can be a substring of the full image path.
 
     int selectedFrame;
 

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -2229,69 +2229,36 @@ void FileCatalog::toggleRightPanel()
 
 void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
 {
+    if (clearFilters) { // clear all filters
+        Query->set_text("");
+        categoryButtonToggled(bFilterClear, false);
 
-    Glib::ustring dirname = Glib::path_get_dirname(fname);
-
-    if (!dirname.empty()) {
-        BrowsePath->set_text(dirname);
-
-
-        if (clearFilters) { // clear all filters
-            Query->set_text("");
-            categoryButtonToggled(bFilterClear, false);
-
-            // disable exif filters
-            if (filterPanel->isEnabled()) {
-                filterPanel->setEnabled (false);
-            }
-        }
-
-        if (BrowsePath->get_text() != selectedDirectory) {
-            // reload or refresh thumbs and select image
-            buttonBrowsePathPressed ();
-            // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
-            imageToSelect_fname = fname;
-        } else {
-            // FileCatalog::filterChanged ();//this will be replaced by queue_draw() in fileBrowser->selectImage
-            fileBrowser->selectImage(fname);
-            imageToSelect_fname = "";
+        // disable exif filters
+        if (filterPanel->isEnabled()) {
+            filterPanel->setEnabled (false);
         }
     }
+
+    fileBrowser->selectImage(fname);
+    imageToSelect_fname = "";
 }
 
 
 void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, bool clearFilters, eRTNav nextPrevious)
 {
+    if (clearFilters) { // clear all filters
+        Query->set_text("");
+        categoryButtonToggled(bFilterClear, false);
 
-    Glib::ustring dirname = Glib::path_get_dirname(fname);
-
-    if (!dirname.empty()) {
-        BrowsePath->set_text(dirname);
-
-
-        if (clearFilters) { // clear all filters
-            Query->set_text("");
-            categoryButtonToggled(bFilterClear, false);
-
-            // disable exif filters
-            if (filterPanel->isEnabled()) {
-                filterPanel->setEnabled (false);
-            }
-        }
-
-        if (BrowsePath->get_text() != selectedDirectory) {
-            // reload or refresh thumbs and select image
-            buttonBrowsePathPressed ();
-            // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
-            refImageForOpen_fname = fname;
-            actionNextPrevious = nextPrevious;
-        } else {
-            // FileCatalog::filterChanged ();//this was replace by queue_draw() in fileBrowser->selectImage
-            fileBrowser->openNextPreviousEditorImage(fname, nextPrevious);
-            refImageForOpen_fname = "";
-            actionNextPrevious = NAV_NONE;
+        // disable exif filters
+        if (filterPanel->isEnabled()) {
+            filterPanel->setEnabled (false);
         }
     }
+
+    fileBrowser->openNextPreviousEditorImage(fname, nextPrevious);
+    refImageForOpen_fname = "";
+    actionNextPrevious = NAV_NONE;
 }
 
 bool FileCatalog::handleShortcutKey (GdkEventKey* event)

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1795,6 +1795,29 @@ void FileCatalog::filterChanged ()
     _refreshProgressBar();
 }
 
+void FileCatalog::saveResetState ()
+{
+    resetData.directory = selectedDirectory;
+    resetData.recursive = App::get().options().browseRecursive;
+}
+
+bool FileCatalog::restoreResetState ()
+{
+    if (resetData.directory.empty() || resetData.directory == selectedDirectory) { 
+        return false;
+    }
+
+    // Set recursive option
+    App::get().mut_options().browseRecursive = resetData.recursive;
+    bRecursive->set_active(resetData.recursive);
+
+    // Change directory
+    BrowsePath->set_text(resetData.directory);
+    buttonBrowsePathPressed ();
+
+    return true;
+}
+
 void FileCatalog::reparseDirectory ()
 {
 
@@ -2227,10 +2250,8 @@ void FileCatalog::toggleRightPanel()
 }
 
 
-void FileCatalog::selectImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters)
+void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
 {
-    if ( directory.empty() ) return;
-
     if (clearFilters) { // clear all filters
         Query->set_text("");
         categoryButtonToggled(bFilterClear, false);
@@ -2241,12 +2262,11 @@ void FileCatalog::selectImage (Glib::ustring fname, Glib::ustring directory, boo
         }
     }
 
-    if ( directory != selectedDirectory ) {
-        // Special case, when the user opens an image to the editor, travels directories in the file browser
-        // and then wants to return to the directory of the file that is opened in the editor.
-        BrowsePath->set_text(directory);
-        // reload or refresh thumbs and select image
-        buttonBrowsePathPressed ();
+    if ( restoreResetState() ) {
+        // Directory was changed -
+        // If the user has traversed around directories in the File Browser and now wants to
+        // reset the file catalog to the directory of the opened image with X or Y key
+        //
         // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
         imageToSelect_fname = fname;
     } else {
@@ -2256,27 +2276,12 @@ void FileCatalog::selectImage (Glib::ustring fname, Glib::ustring directory, boo
 }
 
 
-void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters, eRTNav nextPrevious)
+void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, eRTNav nextPrevious)
 {
-    if ( directory.empty() ) return;
-
-    if (clearFilters) { // clear all filters
-        Query->set_text("");
-        categoryButtonToggled(bFilterClear, false);
-
-        // disable exif filters
-        if (filterPanel->isEnabled()) {
-            filterPanel->setEnabled (false);
-        }
-    }
-
-    if ( directory != selectedDirectory ) {
-        // Special case, when the user opens an image to the editor, travels directories in the file browser
-        // and then wants to continue with SHIFT+F4/F3
-        BrowsePath->set_text(directory);
-        // reload or refresh thumbs and select image
-        buttonBrowsePathPressed ();
-        // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
+    if ( restoreResetState() ) {
+        // Directory was changed -
+        // If the user has traversed around directories in the File Browser and now wants to
+        // continue from the image opened in the editor with SHIFT+F3/F4 keys
         refImageForOpen_fname = fname;
         actionNextPrevious = nextPrevious;
     } else {

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1803,19 +1803,23 @@ void FileCatalog::saveResetState ()
 
 bool FileCatalog::restoreResetState ()
 {
-    if (resetData.directory.empty() || resetData.directory == selectedDirectory) { 
-        return false;
+    //
+    // BUG --   If the filmstrip is empty before the reset, it will not reset back to a fully working state.
+    //          User needs to flip to File Browser and back to make it work correctly.
+
+    if (resetData.recursive != App::get().options().browseRecursive) {
+        App::get().mut_options().browseRecursive = resetData.recursive;
+        bRecursive->set_active(resetData.recursive);
     }
 
-    // Set recursive option
-    App::get().mut_options().browseRecursive = resetData.recursive;
-    bRecursive->set_active(resetData.recursive);
+    if (resetData.directory != selectedDirectory) {
+        BrowsePath->set_text(resetData.directory);
+        buttonBrowsePathPressed ();
 
-    // Change directory
-    BrowsePath->set_text(resetData.directory);
-    buttonBrowsePathPressed ();
+        return true;
+    }
 
-    return true;
+    return false;
 }
 
 void FileCatalog::reparseDirectory ()
@@ -2262,7 +2266,7 @@ void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
         }
     }
 
-    if ( restoreResetState() ) {
+    if (restoreResetState()) {
         // Directory was changed -
         // If the user has traversed around directories in the File Browser and now wants to
         // reset the file catalog to the directory of the opened image with X or Y key
@@ -2278,7 +2282,7 @@ void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
 
 void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, eRTNav nextPrevious)
 {
-    if ( restoreResetState() ) {
+    if (restoreResetState()) {
         // Directory was changed -
         // If the user has traversed around directories in the File Browser and now wants to
         // continue from the image opened in the editor with SHIFT+F3/F4 keys

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -2227,8 +2227,10 @@ void FileCatalog::toggleRightPanel()
 }
 
 
-void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
+void FileCatalog::selectImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters)
 {
+    if ( directory.empty() ) return;
+
     if (clearFilters) { // clear all filters
         Query->set_text("");
         categoryButtonToggled(bFilterClear, false);
@@ -2239,13 +2241,25 @@ void FileCatalog::selectImage (Glib::ustring fname, bool clearFilters)
         }
     }
 
-    fileBrowser->selectImage(fname);
-    imageToSelect_fname = "";
+    if ( directory != selectedDirectory ) {
+        // Special case, when the user opens an image to the editor, travels directories in the file browser
+        // and then wants to return to the directory of the file that is opened in the editor.
+        BrowsePath->set_text(directory);
+        // reload or refresh thumbs and select image
+        buttonBrowsePathPressed ();
+        // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
+        imageToSelect_fname = fname;
+    } else {
+        fileBrowser->selectImage(fname);
+        imageToSelect_fname = "";
+    }
 }
 
 
-void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, bool clearFilters, eRTNav nextPrevious)
+void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters, eRTNav nextPrevious)
 {
+    if ( directory.empty() ) return;
+
     if (clearFilters) { // clear all filters
         Query->set_text("");
         categoryButtonToggled(bFilterClear, false);
@@ -2256,9 +2270,20 @@ void FileCatalog::openNextPreviousEditorImage (Glib::ustring fname, bool clearFi
         }
     }
 
-    fileBrowser->openNextPreviousEditorImage(fname, nextPrevious);
-    refImageForOpen_fname = "";
-    actionNextPrevious = NAV_NONE;
+    if ( directory != selectedDirectory ) {
+        // Special case, when the user opens an image to the editor, travels directories in the file browser
+        // and then wants to continue with SHIFT+F4/F3
+        BrowsePath->set_text(directory);
+        // reload or refresh thumbs and select image
+        buttonBrowsePathPressed ();
+        // the actual selection of image will be handled asynchronously at the end of FileCatalog::previewsFinishedUI
+        refImageForOpen_fname = fname;
+        actionNextPrevious = nextPrevious;
+    } else {
+        fileBrowser->openNextPreviousEditorImage(fname, nextPrevious);
+        refImageForOpen_fname = "";
+        actionNextPrevious = NAV_NONE;
+    }
 }
 
 bool FileCatalog::handleShortcutKey (GdkEventKey* event)

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1658,7 +1658,14 @@ void FileCatalog::categoryButtonToggled (Gtk::ToggleButton* b, bool isMouseClick
 
 void FileCatalog::showRecursiveToggled()
 {
-    App::get().mut_options().browseRecursive = bRecursive->get_active();
+    bool state = bRecursive->get_active();
+
+    if (state == App::get().options().browseRecursive) {
+        // avoid unnecessary calls to dirSelected; this can happen when file catalog is reset to an older state
+        return;
+    }
+
+    App::get().mut_options().browseRecursive = state;
 
     // Killing background threads can sometimes block the UI for a long time,
     // This may be a spot where giving the user information is needed.
@@ -1803,23 +1810,30 @@ void FileCatalog::saveResetState ()
 
 bool FileCatalog::restoreResetState ()
 {
-    //
-    // BUG --   If the filmstrip is empty before the reset, it will not reset back to a fully working state.
-    //          User needs to flip to File Browser and back to make it work correctly.
+    bool ret = false;
 
     if (resetData.recursive != App::get().options().browseRecursive) {
-        App::get().mut_options().browseRecursive = resetData.recursive;
+        // I think the program flow here needs to be explained:
+        // The App::get().mut_options().browseRecursive is indeed set by the signal of the toggle button "showRecursiveToggled()"
+        // However, the signal is handled only after the execution returns to the framework. The "buttonBrowsePathPressed()"
+        // on the other hand instantly executes "DirBrowser::selectDir". If the recursive value is not set when this executes, the
+        // directory might not contain the image of the "refImageForOpen_fname" variable or the one next to it that is supposed to
+        // be opened.
+        if (resetData.directory != selectedDirectory) {
+            // this can be set only when "DirBrowser::selectDir" is called regardless of the recursive toggle or the toggle will get blocked
+            App::get().mut_options().browseRecursive = resetData.recursive;
+        }
         bRecursive->set_active(resetData.recursive);
+        ret = true;
     }
 
     if (resetData.directory != selectedDirectory) {
         BrowsePath->set_text(resetData.directory);
         buttonBrowsePathPressed ();
-
-        return true;
+        ret = true;
     }
 
-    return false;
+    return ret;
 }
 
 void FileCatalog::reparseDirectory ()

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -62,14 +62,13 @@ private:
     };
 
     /**
-    * @brief DirectoryResetInfo
-    * Data that is used to reset the file catalog contents if user presses Y,X or SHIFT+F3/F4
-    */
+     * @brief Data that is used to reset the file catalog contents if user presses Y,X or SHIFT+F3/F4
+     */
     struct DirectoryResetInfo {
-        DirectoryResetInfo() : recursive(false) {}
-
-        bool          recursive;    ///< If recursive directories is enabled
-        Glib::ustring directory;    ///< The value of selectedDirectory
+        DirectoryResetInfo() :
+            recursive(false) {}
+        bool          recursive;
+        Glib::ustring directory;
     };
 
     FilePanel* filepanel;
@@ -267,7 +266,7 @@ public:
     bool capture_event(GdkEventButton* event);
     void filterChanged ();
 
-    void saveResetState (); 
+    void saveResetState ();
     bool restoreResetState ();
 
     void on_realize() override;

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -61,9 +61,21 @@ private:
         Glib::ustring filePath;
     };
 
+    /**
+    * @brief DirectoryResetInfo
+    * Data that is used to reset the file catalog contents if user uses Y,X or SHIFT+F3/F4
+    */
+    struct DirectoryResetInfo {
+        DirectoryResetInfo() : recursive(false) {}
+
+        bool          recursive;    ///< If recursive directories is enabled
+        Glib::ustring directory;    ///< The value of selectedDirectory
+    };
+
     FilePanel* filepanel;
     Gtk::Box* hBox;
     Glib::ustring selectedDirectory;
+    DirectoryResetInfo resetData;
     int selectedDirectoryId;
     bool enabled;
     bool inTabMode;  // Tab mode has e.g. different progress bar handling
@@ -254,7 +266,9 @@ public:
     void showRecursiveToggled();
     bool capture_event(GdkEventButton* event);
     void filterChanged ();
-    void runFilterDialog ();
+
+    void saveResetState (); 
+    bool restoreResetState ();
 
     void on_realize() override;
     void reparseDirectory ();
@@ -284,8 +298,8 @@ public:
     {
         fileBrowser->openPrevImage();
     }
-    void selectImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters);
-    void openNextPreviousEditorImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters, eRTNav nextPrevious);
+    void selectImage (Glib::ustring fname, bool clearFilters);
+    void openNextPreviousEditorImage (Glib::ustring fname, eRTNav nextPrevious);
 
     bool handleShortcutKey (GdkEventKey* event);
     bool handleShortcutKeyRelease(GdkEventKey *event);

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -284,8 +284,8 @@ public:
     {
         fileBrowser->openPrevImage();
     }
-    void selectImage (Glib::ustring fname, bool clearFilters);
-    void openNextPreviousEditorImage (Glib::ustring fname, bool clearFilters, eRTNav nextPrevious);
+    void selectImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters);
+    void openNextPreviousEditorImage (Glib::ustring fname, Glib::ustring directory, bool clearFilters, eRTNav nextPrevious);
 
     bool handleShortcutKey (GdkEventKey* event);
     bool handleShortcutKeyRelease(GdkEventKey *event);

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -63,7 +63,7 @@ private:
 
     /**
     * @brief DirectoryResetInfo
-    * Data that is used to reset the file catalog contents if user uses Y,X or SHIFT+F3/F4
+    * Data that is used to reset the file catalog contents if user presses Y,X or SHIFT+F3/F4
     */
     struct DirectoryResetInfo {
         DirectoryResetInfo() : recursive(false) {}

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -311,7 +311,7 @@ private:
                 [] (gpointer data) -> gboolean {
                     Data *d = static_cast<Data *> (data);
                     d->filecatalog->openRequested (d->entries);
-                    d->filecatalog->selectImage (d->lastfilename, true);
+                    d->filecatalog->selectImage (d->lastfilename, d->filecatalog->lastSelectedDir(), true);
                     delete d;
                     return FALSE;
                 };

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -311,7 +311,7 @@ private:
                 [] (gpointer data) -> gboolean {
                     Data *d = static_cast<Data *> (data);
                     d->filecatalog->openRequested (d->entries);
-                    d->filecatalog->selectImage (d->lastfilename, d->filecatalog->lastSelectedDir(), true);
+                    d->filecatalog->selectImage (d->lastfilename, true);
                     delete d;
                     return FALSE;
                 };

--- a/rtgui/main.cc
+++ b/rtgui/main.cc
@@ -311,7 +311,6 @@ private:
                 [] (gpointer data) -> gboolean {
                     Data *d = static_cast<Data *> (data);
                     d->filecatalog->openRequested (d->entries);
-                    d->filecatalog->selectImage (d->lastfilename, true);
                     delete d;
                     return FALSE;
                 };


### PR DESCRIPTION
When recursive directories is enabled and the user chooses to view files based on filters such as stars or colors and the files are in different directories, there are several issues.

When the user chooses to open an image from the root directory, he filmstrip has all the filtered correctly. However, if the user chooses to open a file that is not in the root directory, using F4/F3, SHIFT+F4/SHIFT+F3 or by mouse, the current directory is changed and the filmstrip is updated for that. After this, if the user chooses the File Browser view, that current directory has been changed there also.

This PR removes the functionality that changes the file catalog directory when opening an image from a subdirectory.

I tried searching for the origin of the functionality and I couldn't find it. I assume it has just always been there and because it was never executed before the recursive directories was implemented, it didn't bother anyone.

Additionally, the F4/SHIFT+F4 and F3/SHIFT+F3 do the same thing. They are implemented in different places and could theoretically work differently, I just don't know any case, where the File Browser contents and the filmstrip on top of the editor has different contents. I don't think it is currently even possible for them to have different contents.