### PR TITLE
Workaround for Windows workflow Lensfun error

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Include Lensfun
         run: |
           echo "Updating Lensfun database."
-          PYTHONPATH=/mingw64/lib/site-packages lensfun-update-data  # Workaround for lensfun path mismatch
+          PYTHONPATH=/${{env.MSYS2_ENV_PREFIX}}/lib/site-packages lensfun-update-data  # Workaround for lensfun path mismatch
           echo "Creating Lensfun directory in the build directory."
           mkdir -p 'build/${{matrix.build_type}}/share'
           echo "Copying Lensfun database to the build directory."

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Include Lensfun
         run: |
           echo "Updating Lensfun database."
-          lensfun-update-data
+          PYTHONPATH=/mingw64/lib/site-packages lensfun-update-data  # Workaround for lensfun path mismatch
           echo "Creating Lensfun directory in the build directory."
           mkdir -p 'build/${{matrix.build_type}}/share'
           echo "Copying Lensfun database to the build directory."


### PR DESCRIPTION
The latest version of MSYS2's Lensfun package installs the `lensfun` Python module in a new location (\<prefix>/lib/site-packages instead of \<prefix>/lib/python\<version>/site-packages) outside of the default paths used by Python (., \<prefix>/lib/python\<version>.zip, \<prefix>/lib/python\<version>, \<prefix>/lib/python\<version>/lib-dynload and \<prefix>/lib/python\<version>/site-packages). This provides a temporary workaround by adding the new directory to the Python path when invoking `lensfun-update-data`.

I see no issues with merging this immediately, but please inform me if there is a concern.