### PR TITLE
Abstract profile - Contrast enhancement - reduction of gamut artifacts in deep shadows

### DIFF
--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -3408,7 +3408,7 @@ void ImProcFunctions::calckoe (const float* WavCoeffs, float gradw, float tloww,
 }
 
 
-// Copyright 6-2024 - Jacques Desmis <jdesmis@gmail.com>
+// Copyright 6-2024 modified 1-2026 - Jacques Desmis <jdesmis@gmail.com>
 void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, const procparams::WaveletParams & waparams, const procparams::ColorManagementParams & cmparams, const WavOpacityCurveWL & cmOpacityCurveWL, int skip, int &level_hr, int &maxlevpo, bool &wavcurvecont)
 {
     wavcurvecont = false;
@@ -3420,6 +3420,30 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
             }
         }
     }
+    //This modification significantly reduces potential artifacts caused by increased local contrast due to wavelets. It has virtually no visible effect on the resulting image, other than the absorption of the artifacts.
+    const std::unique_ptr<LabImage> lab2(new LabImage(lab->W, lab->H));//New variable Lab, which will be used for wavelet decomposition.
+
+    constexpr float artifact_minimum = 3000.f;//The threshold below which wavelet decomposition is not performed, and therefore no contrast enhancement is achieved, to avoid artifacts due to proximity to the gamut limit.
+    constexpr float artifact_minimum_low = 10.f;//Very low replacement value, but without impact on the decomposition, except for some proximity of wavelets.
+    constexpr float artifact_minimum_lowab = 0.f;//With 0, we are necessarily within the gamut
+
+#ifdef _OPENMP
+        #pragma omp parallel for if (multiThread)
+#endif
+    for(int i=0; i < lab->H; i++){
+        for(int j=0; j < lab->W; j++){
+            if(lab->L[i][j] > artifact_minimum) {
+                lab2->L[i][j] = lab->L[i][j];
+                lab2->a[i][j] = lab->a[i][j];
+                lab2->b[i][j] = lab->b[i][j];
+            } else {
+                lab2->L[i][j] = artifact_minimum_low;
+                lab2->a[i][j] = artifact_minimum_lowab;
+                lab2->b[i][j] = artifact_minimum_lowab;
+            }
+        }
+    }
+
 
     if(wavcurvecont && cmparams.wavExp) {//enable curve and expander
 #ifdef _OPENMP
@@ -3468,8 +3492,8 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
                 level_br = wavelet_lev - 3;//-3
                 level_hr = wavelet_lev - 2;//-2
             } else if(pyrwav == 2) {
-                level_bl = 0;//0
-                level_hl = 0;//1
+                level_bl = 1;//0
+                level_hl = 1;//0
                 level_br = wavelet_lev - 3;//-2
                 level_hr = wavelet_lev - 1;//-1
                 if(!cmparams.wsmoothcie) {
@@ -3540,7 +3564,7 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
             int maxlvl = wavelet_level;
             maxlevpo = maxlvl;
             //decomposition wavelet , we can change Daublen (moment wavelet) in Tab - Wavelet Levels with subsampling = 1
-            std::unique_ptr<wavelet_decomposition> wdspot = std::unique_ptr<wavelet_decomposition>(new wavelet_decomposition(lab->L[0], width, height, maxlvl, 1, skip, numThreads, DaubLen));
+            std::unique_ptr<wavelet_decomposition> wdspot = std::unique_ptr<wavelet_decomposition>(new wavelet_decomposition(lab2->L[0], width, height, maxlvl, 1, skip, numThreads, DaubLen));
             if (wdspot->memory_allocation_failed()) {//probably if not enough memory.
                 return;
             }
@@ -3736,7 +3760,21 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
                 }
             }
             //reconstruct lab
-            wdspot->reconstruct(lab->L[0], 1.f);
+            wdspot->reconstruct(lab2->L[0], 1.f);
+
+//Of course, we only retrieve the lab2 part that was used for the decomposition
+#ifdef _OPENMP
+        #pragma omp parallel for if (multiThread)
+#endif            
+            for(int i=0; i < lab->H; i++){
+                for(int j=0; j < lab->W; j++){
+                    if(lab->L[i][j] > artifact_minimum) {
+                        lab->L[i][j] = lab2->L[i][j];
+                        lab->a[i][j] = lab2->a[i][j];
+                        lab->b[i][j] = lab2->b[i][j];
+                    }
+                }
+            }
 
 
     }

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -3420,32 +3420,35 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
             }
         }
     }
-    //This modification significantly reduces potential artifacts caused by increased local contrast due to wavelets. It has virtually no visible effect on the resulting image, other than the absorption of the artifacts.
-    const std::unique_ptr<LabImage> lab2(new LabImage(lab->W, lab->H));//New variable Lab, which will be used for wavelet decomposition.
 
-    constexpr float artifact_minimum = 3000.f;//The threshold below which wavelet decomposition is not performed, and therefore no contrast enhancement is achieved, to avoid artifacts due to proximity to the gamut limit.
-    constexpr float artifact_minimum_low = 10.f;//Very low replacement value, but without impact on the decomposition, except for some proximity of wavelets.
-    constexpr float artifact_minimum_lowab = 0.f;//With 0, we are necessarily within the gamut
+
+    if(wavcurvecont && cmparams.wavExp) {//enable curve and expander
+        //This modification significantly reduces potential artifacts caused by increased local contrast due to wavelets. It has virtually no visible effect on the resulting image, other than the absorption of the artifacts.
+        const std::unique_ptr<LabImage> lab2(new LabImage(lab->W, lab->H));//New variable Lab, which will be used for wavelet decomposition.
+
+        constexpr float artifact_minimum = 3000.f;//The threshold below which wavelet decomposition is not performed, and therefore no contrast enhancement is achieved, to avoid artifacts due to proximity to the gamut limit.
+        constexpr float artifact_minimum_low = 10.f;//Very low replacement value, but without impact on the decomposition, except for some proximity of wavelets.
+        constexpr float artifact_minimum_lowab = 0.f;//With 0, we are necessarily within the gamut
 
 #ifdef _OPENMP
         #pragma omp parallel for if (multiThread)
 #endif
-    for(int i=0; i < lab->H; i++){
-        for(int j=0; j < lab->W; j++){
-            if(lab->L[i][j] > artifact_minimum) {
-                lab2->L[i][j] = lab->L[i][j];
-                lab2->a[i][j] = lab->a[i][j];
-                lab2->b[i][j] = lab->b[i][j];
-            } else {
-                lab2->L[i][j] = artifact_minimum_low;
-                lab2->a[i][j] = artifact_minimum_lowab;
-                lab2->b[i][j] = artifact_minimum_lowab;
+        for (int i = 0; i < lab->H; i++){
+            for (int j = 0; j < lab->W; j++){
+                if(lab->L[i][j] > artifact_minimum) {
+                    lab2->L[i][j] = lab->L[i][j];
+                    lab2->a[i][j] = lab->a[i][j];
+                    lab2->b[i][j] = lab->b[i][j];
+                } else {
+                    lab2->L[i][j] = artifact_minimum_low;
+                    lab2->a[i][j] = artifact_minimum_lowab;
+                    lab2->b[i][j] = artifact_minimum_lowab;
+                }
             }
         }
-    }
-
-
-    if(wavcurvecont && cmparams.wavExp) {//enable curve and expander
+    
+    
+    
 #ifdef _OPENMP
         const int numThreads = omp_get_max_threads();
 #else
@@ -3766,8 +3769,8 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
 #ifdef _OPENMP
         #pragma omp parallel for if (multiThread)
 #endif            
-            for(int i=0; i < lab->H; i++){
-                for(int j=0; j < lab->W; j++){
+            for (int i = 0; i < lab->H; i++){
+                for (int j = 0; j < lab->W; j++){
                     if(lab->L[i][j] > artifact_minimum) {
                         lab->L[i][j] = lab2->L[i][j];
                         lab->a[i][j] = lab2->a[i][j];

--- a/rtengine/ipwavelet.cc
+++ b/rtengine/ipwavelet.cc
@@ -3492,8 +3492,8 @@ void ImProcFunctions::complete_local_contrast (LabImage * lab, LabImage * dst, c
                 level_br = wavelet_lev - 3;//-3
                 level_hr = wavelet_lev - 2;//-2
             } else if(pyrwav == 2) {
-                level_bl = 1;//0
-                level_hl = 1;//0
+                level_bl = 0;//0
+                level_hl = 0;//0
                 level_br = wavelet_lev - 3;//-2
                 level_hr = wavelet_lev - 1;//-1
                 if(!cmparams.wsmoothcie) {


### PR DESCRIPTION
Developing Game Changer allowed me to test numerous modules. I was surprised by the appearance of artifacts when, for certain images with high dynamic range, I reset the GHS Stretch factor (D) to 0.001 (and sometimes with (D)quite high) . These artifacts are invisible to the naked eye, but visible when the 'Soft proffing' is set to a small profile (sRGB...).

I initially thought it was either a calculation error for the GHS Black Point Linear, or flawed reasoning on my part in calculating it...

Ultimately, that's not it... GHS because when the Stretch factor (D) is at 0.001 and the Dynamic Range is high, it makes blacks blacker... and therefore very close to the limits of the gamut.

In this case, if we increase the local contrast with wavelets (Contrast enhancement in Abstract profile), the artifacts are amplified... Of course, they are not visible without soft proofing (or you really have to know it's there...).

The local contract algorithm (even though I really dislike this catch-all term) is very complex. 
I've implemented a simple solution that doesn't require much processing time and works more than adequately. In summary, below a certain threshold where shadows are already deep, the decomposition will be performed on parts that are known to remain within the gamut. During reconstruction, after wavelets are applied, the initial, unaltered data is recovered. 

I tried with very strong contrast enhancement settings, and the artifacts almost completely disappeared. The final image shows no visible differences in contrast. The differences in very low light (Lab L < 3) are minimal, imperceptible.... and of course, virtually no artifacts left at all.

You might wonder why the constant artifact_minimum = 3000.f, why artifact_minimum_low = 10, and why artifact_minimum_lowab=0.
* 3000 represents on the Lab scale in RT which goes from 0 to 32768; approximately 9 on the usual 0-100 scale
* 10 is a very smal value, and 0 is zero. With these values Wavelets It doesn't decompose, everything is flat.

* 3000 This allows Wavelet to work with negative values ​​of the transform, which are higher and propagate further from the area concerned as the level of decomposition is higher.
<img width="1211" height="542" alt="image" src="https://github.com/user-attachments/assets/17f0157f-38a7-467b-8ef7-340a188a11a7" />
So ultimately, at the user level, it's almost only the areas where L (Lab scale 0..100) is less than 3 – provided there is 'relief' involved

The problem of highlights is simpler, we can create a 2nd RT-Spot with inverse GHS, and/or we have tools in both GHS and Abstract Profile to control this phenomenon.


I had a review done by Copilot.

@kaesa 
Could you have a look... 

Thank you
