### PR TITLE
Multiple small changes related to _refreshProgressBar - function

### DIFF
--- a/rtgui/filebrowser.h
+++ b/rtgui/filebrowser.h
@@ -130,7 +130,7 @@ protected:
     BatchPParamsChangeListener* bppcl;
     FileBrowserListener* tbl;
     BrowserFilter filter;
-    int numFiltered;
+    std::size_t numFiltered;
 
     void toTrashRequested   (std::vector<FileBrowserEntry*> tbe);
     void fromTrashRequested (std::vector<FileBrowserEntry*> tbe);
@@ -172,7 +172,7 @@ public:
     void applyPartialMenuItemActivated (ProfileStoreLabel *label);
 
     void applyFilter (const BrowserFilter& filter);
-    int getNumFiltered()
+    std::size_t getNumFiltered()
     {
         return numFiltered;
     }

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -139,7 +139,6 @@ FileCatalog::FileCatalog (CoarsePanel* cp, ToolBar* tb, FilePanel* filepanel) :
     filterPanel(nullptr),
     exportPanel(nullptr),
     previewsToLoad(0),
-    previewsLoaded(0),
     modifierKey(0),
     coarsePanel(cp),
     toolBar(tb)
@@ -678,7 +677,6 @@ void FileCatalog::dirSelected (const Glib::ustring& dirname, const Glib::ustring
 
         closeDir();
         previewsToLoad = 0;
-        previewsLoaded = 0;
 
         // if openfile exists, we have to open it first (it is a command line argument)
         if (!openfile.empty()) {
@@ -775,44 +773,43 @@ void FileCatalog::enableTabMode(bool enable)
 
 void FileCatalog::_refreshProgressBar ()
 {
-    // In tab mode, no progress bar at all
-    // Also mention that this progress bar only measures the FIRST pass (quick thumbnails)
-    // The second, usually longer pass is done multithreaded down in the single entries and is NOT measured by this
-    if (!inTabMode && (!previewsToLoad || std::floor(100.f * previewsLoaded / previewsToLoad) != std::floor(100.f * (previewsLoaded - 1) / previewsToLoad))) {
+    // This progress bar only measures the FIRST pass (quick thumbnails)
+    // The second, usually longer pass is NOT measured by this
+    const auto previewsLoaded = fileBrowser->getEntries().size();
+
+    if (!progressImage || !progressLabel) {
+        // create tab label once
+        Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
+        Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
+        setExpandAlignProperties (grid, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
+        progressImage = Gtk::manage(new RTImage("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR));
+        progressLabel = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER")));
 
         const auto& options = App::get().options();
-        if (!progressImage || !progressLabel) {
-            // create tab label once
-            Gtk::Notebook *nb = (Gtk::Notebook *)(filepanel->get_parent());
-            Gtk::Grid* grid = Gtk::manage(new Gtk::Grid());
-            setExpandAlignProperties (grid, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_CENTER);
-            progressImage = Gtk::manage(new RTImage("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR));
-            progressLabel = Gtk::manage(new Gtk::Label(M("MAIN_FRAME_FILEBROWSER")));
-            grid->attach_next_to(*progressImage, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-            grid->attach_next_to(*progressLabel, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
-            grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
-            grid->show_all();
-            if (options.mainNBVertical) {
-                progressLabel->set_angle(90);
-            }
-            if (nb) {
-                nb->set_tab_label(*filepanel, *grid);
-            }
+        grid->attach_next_to(*progressImage, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+        grid->attach_next_to(*progressLabel, options.mainNBVertical ? Gtk::POS_TOP : Gtk::POS_RIGHT, 1, 1);
+        grid->set_tooltip_markup(M("MAIN_FRAME_FILEBROWSER_TOOLTIP"));
+        grid->show_all();
+        if (options.mainNBVertical) {
+            progressLabel->set_angle(90);
         }
-        if (!previewsToLoad) {
-            progressImage->set_from_icon_name("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR);
-            int filteredCount = min(fileBrowser->getNumFiltered(), previewsLoaded);
-            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") +
-                                    (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " (")
-                                    + Glib::ustring::format(previewsLoaded) +
-                                    (filteredCount != previewsLoaded ? "]" : ")"));
-        } else {
-            progressImage->set_from_icon_name("magnifier", Gtk::ICON_SIZE_LARGE_TOOLBAR);
-            progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") + " ["
-                                    + Glib::ustring::format(previewsLoaded) + "/"
-                                    + Glib::ustring::format(previewsToLoad) + "]" );
-            filepanel->loadingThumbs("", (double)previewsLoaded / previewsToLoad);
+        if (nb) {
+            nb->set_tab_label(*filepanel, *grid);
         }
+    }
+    if (!previewsToLoad) {
+        progressImage->set_from_icon_name("folder-closed", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        const auto filteredCount = min(fileBrowser->getNumFiltered(), previewsLoaded);
+        progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") +
+                                (filteredCount != previewsLoaded ? " [" + Glib::ustring::format(filteredCount) + "/" : " [")
+                                + Glib::ustring::format(previewsLoaded) +
+                                (filteredCount != previewsLoaded ? "]" : "]"));
+    } else {
+        progressImage->set_from_icon_name("magnifier", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+        progressLabel->set_text(M("MAIN_FRAME_FILEBROWSER") + " ["
+                                + Glib::ustring::format(previewsLoaded) + " ("
+                                + Glib::ustring::format(previewsToLoad) + ")]" );
+        filepanel->loadingThumbs("", (double)previewsLoaded / (previewsLoaded + previewsToLoad));
     }
 }
 
@@ -878,7 +875,7 @@ void FileCatalog::previewReady (int dir_id, FileBrowserEntry* fdn)
                 dirEFS.expcomp.insert (cfs->expcomp);
             }
 
-            previewsLoaded++;
+            previewsToLoad--;
 
             _refreshProgressBar();
             return false;
@@ -1063,8 +1060,6 @@ void FileCatalog::deleteRequested(const std::vector<FileBrowserEntry*>& tbe, boo
                 Glib::ustring procfNameParamFile = Glib::ustring::compose ("%1.%2.out%3", BatchQueue::calcAutoFileNameBase(fname), options.saveFormatBatch.format, App::PARAM_FILE_EXTENSION);
                 ::g_remove (procfNameParamFile.c_str ());
             }
-
-            previewsLoaded--;
         }
 
         _refreshProgressBar();
@@ -1142,8 +1137,6 @@ void FileCatalog::copyMoveRequested(const std::vector<FileBrowserEntry*>& tbe, b
                         cacheMgr->renameEntry (src_fPath, tbe[i]->thumbnail->getMD5(), dest_fPath);
                         // remove from browser
                         fileBrowser->delEntry (src_fPath);
-
-                        previewsLoaded--;
                     } else {
                         src_file->copy(dest_file);
                     }
@@ -1824,14 +1817,9 @@ void FileCatalog::reparseDirectory ()
 
     for (const auto& toRemove : fileNamesToRemove) {
         delete fileBrowser->delEntry(toRemove);
-        --previewsLoaded;
     }
     for (const auto& toDelete : fileNamesToDel) {
         cacheMgr->deleteEntry(toDelete);
-    }
-
-    if (!fileNamesToDel.empty()) {
-        _refreshProgressBar();
     }
 
     // check if a new file has been added
@@ -1845,11 +1833,11 @@ void FileCatalog::reparseDirectory ()
     fileNameList = getFileList(&allDirs);
     for (const auto& newName : fileNameList) {
         if (oldNames.find(newName.collate_key()) == oldNames.end()) {
-            addFile(newName);
-            _refreshProgressBar();
+            addFile(newName);         
         }
     }
 
+    _refreshProgressBar();
     refreshDirectoryMonitors(allDirs);
 }
 

--- a/rtgui/filecatalog.h
+++ b/rtgui/filecatalog.h
@@ -143,9 +143,7 @@ private:
     FilterPanel* filterPanel;
     ExportPanel* exportPanel;
 
-    int previewsToLoad;
-    int previewsLoaded;
-
+    std::size_t previewsToLoad;
 
     std::vector<Glib::ustring> fileNameList;
     std::set<Glib::ustring> editedFiles;


### PR DESCRIPTION
* This PR changes the way the loaded images are tracked. In the dev, the additions are tracked manually. This PR changes the code so that the value is acquired from the container.
* Changes the progress bar visually:
Current progressbar:
![orig_all](https://github.com/user-attachments/assets/b91f3b46-5bd7-43cb-a7f4-14e318037758) ![orig_filtered](https://github.com/user-attachments/assets/25370631-66f6-4f6b-b338-63e7862b3797) ![orig_loading](https://github.com/user-attachments/assets/1e5e5444-4d58-416e-975b-575a5532d637)
From left to right; All files loaded, some files filtered, loading new files.
Proposed:
![new_all](https://github.com/user-attachments/assets/62e6b69d-b344-46f3-a81b-07685d932793) ![new_filtered](https://github.com/user-attachments/assets/0b68ed4e-e40b-4719-b748-d89f24ea097c) ![new_loading_countdown](https://github.com/user-attachments/assets/23eac90a-8daa-4846-b9b3-6e94d8142aca)
This change adds consistency to the way the brackets are used. Changes the way the `previewsToLoad` is displayed. The goal is to make it easier to register what is happening. In the dev, it is little inconvenient to calculate how many images are still to be loaded if the folder has more than a small amount of files.
Proposed look with horizontal bar:
![new_all_horizontal](https://github.com/user-attachments/assets/6db5ffd3-37e1-446f-bf8a-1b333a4bfc91)
![new_filtered_horizontal](https://github.com/user-attachments/assets/c0a89d0d-b199-4c3d-abd7-882ffc1ff025)
![new_loading_horizontal_countdown](https://github.com/user-attachments/assets/821be4ab-c84d-4be6-a821-0a6c63ad2c53)
Counting the "to be loaded images" down makes sense also, if my future PR, which changes the way events are handled gets accepted. However, this is also a matter of taste, and it is trivial to change the count down to `(previewsLoaded+previewsToLoad)` and is perfectly fine for me to do if this change gets opposition.
* The if in the `_refreshProgressBar` was causing the progress bar not updating when in the editor. This was buggy behavior for example when resetting the file catalog in the editor with X,Y or SHIFT+F3/F4 for example. I haven't found reasons to have it, but I think if there is a reason, the check could probably be more specific.
* Calling _refreshProgressBar inside a loop is not right. The progressbar is not getting redrawn until the execution returns back to the framework.

Additional note:
There is a bug when File Browser is processing a folder and user switches to another folder. The blue progress bar is left to a state all images minus one image. The bug happens because `if ( dir_id != selectedDirectoryId ) {` in `void FileCatalog::previewsFinishedUI(int dir_id)` is evaluated true for some reason. This bug is also present in dev and 5.12.

PS.
I closed this PR draft (and page) and opened it again by copy pasting old text. To my surprise, the images appeared correctly without reuploading. Please let me know if the images are missing and I'm seeing them just because of some caching reasons.