### PR TITLE
Fixes Thumbnail reference counting issues when deleting files

### DIFF
--- a/rtgui/cachemanager.cc
+++ b/rtgui/cachemanager.cc
@@ -178,11 +178,11 @@ void CacheManager::deleteEntry (const Glib::ustring& fname)
     }
 }
 
-void CacheManager::clearFromCache (const Glib::ustring& fname, bool purge) const
+void CacheManager::clearFromCache (const Glib::ustring& fname, const Glib::ustring& md5, bool purge) const
 {
     MyMutex::MyLock lock (mutex);
 
-    deleteFiles (fname, getMD5 (fname), true, purge);
+    deleteFiles (fname, md5, true, purge);
 }
 
 void CacheManager::renameEntry (const std::string& oldfilename, const std::string& oldmd5, const std::string& newfilename)

--- a/rtgui/cachemanager.h
+++ b/rtgui/cachemanager.h
@@ -60,7 +60,7 @@ public:
     void clearAll () const;
     void clearImages () const;
     void clearProfiles () const;
-    void clearFromCache (const Glib::ustring& fname, bool purge) const;
+    void clearFromCache (const Glib::ustring& fname, const Glib::ustring& md5, bool purge) const;
     static std::string getMD5 (const Glib::ustring& fname);
 
     Glib::ustring    getCacheFileName (const Glib::ustring& subDir,

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1042,10 +1042,11 @@ void FileCatalog::deleteRequested(const std::vector<FileBrowserEntry*>& tbe, boo
     if (msd.run() == Gtk::RESPONSE_YES) {
         for (unsigned int i = 0; i < tbe.size(); i++) {
             const auto fname = tbe[i]->filename;
+            const auto md5 = tbe[i]->thumbnail->getMD5();
             // remove from browser
             delete fileBrowser->delEntry (fname);
             // remove from cache
-            cacheMgr->clearFromCache (fname, true);
+            cacheMgr->clearFromCache (fname, md5, true);
             // delete from file system
             ::g_remove (fname.c_str ());
             // delete paramfile if found
@@ -1396,8 +1397,9 @@ void FileCatalog::clearFromCacheRequested(const std::vector<FileBrowserEntry*>& 
 
     for (unsigned int i = 0; i < tbe.size(); i++) {
         Glib::ustring fname = tbe[i]->filename;
+        Glib::ustring md5 = tbe[i]->thumbnail->getMD5();
         // remove from cache
-        cacheMgr->clearFromCache (fname, leavenotrace);
+        cacheMgr->clearFromCache (fname, md5, leavenotrace);
     }
 }
 
@@ -1809,12 +1811,11 @@ void FileCatalog::reparseDirectory ()
 
     // check if a thumbnailed file has been deleted or is not in a directory of interest
     const std::vector<ThumbBrowserEntryBase*>& t = fileBrowser->getEntries();
-    std::vector<Glib::ustring> fileNamesToDel;
     std::vector<Glib::ustring> fileNamesToRemove;
 
     for (const auto& entry : t) {
         if (!Glib::file_test(entry->filename, Glib::FILE_TEST_EXISTS)) {
-            fileNamesToDel.push_back(entry->filename);
+            cacheMgr->clearFromCache(entry->filename, entry->thumbnail->getMD5(), true);
             fileNamesToRemove.push_back(entry->filename);
         }
         else if (!App::get().options().browseRecursive && Glib::path_get_dirname(entry->filename) != selectedDirectory) {
@@ -1826,11 +1827,8 @@ void FileCatalog::reparseDirectory ()
         delete fileBrowser->delEntry(toRemove);
         --previewsLoaded;
     }
-    for (const auto& toDelete : fileNamesToDel) {
-        cacheMgr->clearFromCache(toDelete, true);
-    }
 
-    if (!fileNamesToDel.empty()) {
+    if (!fileNamesToRemove.empty()) {
         _refreshProgressBar();
     }
 

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -1045,7 +1045,7 @@ void FileCatalog::deleteRequested(const std::vector<FileBrowserEntry*>& tbe, boo
             // remove from browser
             delete fileBrowser->delEntry (fname);
             // remove from cache
-            cacheMgr->deleteEntry (fname);
+            cacheMgr->clearFromCache (fname, true);
             // delete from file system
             ::g_remove (fname.c_str ());
             // delete paramfile if found
@@ -1827,7 +1827,7 @@ void FileCatalog::reparseDirectory ()
         --previewsLoaded;
     }
     for (const auto& toDelete : fileNamesToDel) {
-        cacheMgr->deleteEntry(toDelete);
+        cacheMgr->clearFromCache(toDelete, true);
     }
 
     if (!fileNamesToDel.empty()) {


### PR DESCRIPTION
### This PR changes two things
The calls to `CacheManager::deleteEntry` messes `Thumbnail` manual reference counting. This PR changes those two calls to `CacheManager::clearFromCache`. So that the cached files will be deleted, but the `Thumbnails`s are left alone.

Also, notice that previously cached files were not deleted, if the file was open in the editor or it was opened in the editor. After this change, the cached files are always deleted if the image file is deleted.

### Steps to reproduce
1. Have an image in the File Browser
2. Choose to add the image to the processing queue using the mouse right button menu.
3. Delete the image
4. Switch to Processing queue and click the x on the corner to remove the thumbnail.

On my tests the program seems to go in deadlock. Or maybe not. It is essentially a use after free bug so anything should be possible, but the `Thumbnail`s are heavily mutexed, so maybe it indeed just locks up.

### Longer explanation

A short while ago I noticed the batch processing has Thumbnail reference counting issue. I started looking into it and obviously I was able to fix the problems by adding an extra `Thumbnail::incrementRef` call. The trouble began when I couldn't find the right place to decrement. I eventually proceeded to surround debug printing with all thumbnail reference manipulations to map out who was doing what. Then I found out, the calls to  `CacheManager::deleteEntry` are wrong. 

Here are three scenarios with reference counting and file deletion:
1. Image is open only in File Browser. The image is deleted. The `Thumbnail` references go to zero already on the call to `fileBrowser->delEntry (fname);` after that, the code calls the  `CacheManager::deleteEntry`  which will merely clear cache files if existing and otherwise return as a no-op. Because it can no longer find the `Thumbnail` from the internal container. -- There are no ill effects.
5. Image is open in file browser and then opened in editor. Opening the image to the editor increments the reference count twice, because for some reason, registering as a listener to the `Thumbnail`, also increments the reference count. When the image is deleted, there are still two references before the call to  `CacheManager::deleteEntry`. So the `Thumbnail` survives with the lifeline of having the listener interface increment the references too. -- The program continues with no ill effects. [The editor never ever decrements the references, so once an image has been opened in the editor, its `Thumbnail` will exist the entire execution of the program.]
6. Image is open in File Browser, then added to the Processing queue, then deleted. Unfortunately, in this case the call to `CacheManager::deleteEntry` will decrement the reference count to zero and the `Thumbnail` will get deleted while the processing queue still needs a valid pointer.

In my previous PR #7554, I erroneously claimed the bad path is executed always, when files are deleted. This is not true. I was basing my analysis on reading the code. In reality, it requires very specific conditions for the bad path to be actually executed.