### PR TITLE
Fix for #7604 - minor bug in writing history

### DIFF
--- a/rtgui/tools/tonecurve.cc
+++ b/rtgui/tools/tonecurve.cc
@@ -670,8 +670,10 @@ void ToneCurve::adjusterChanged(Adjuster* a, double newval)
 
     if (a == expcomp) {
         costr = Glib::ustring::format(std::setw(3), std::fixed, std::setprecision(2), a->getValue());
+    } else if (a==hlth) {
+        costr = Glib::ustring::format(std::fixed, std::setprecision(2), a->getValue());
     } else {
-        costr = Glib::ustring::format((int)a->getValue());
+        costr = Glib::ustring::format(a->getIntValue());
     }
 
     if (a == expcomp) {


### PR DESCRIPTION
Fixes history bug with "Highlight reconstruction" -> "Inpaint Opposed" -> "Gain threshold" . Value written to history was truncated to int, while users expect floating point with 2 digit precision. Issue 7604

Fixes #7604