### PR TITLE
Add Auto-Enable Feature for Tool Interactions

### DIFF
--- a/rtgui/guiutils.cc
+++ b/rtgui/guiutils.cc
@@ -15,6 +15,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
+#include <algorithm>
 #include <cairomm/cairomm.h>
 #include "rtengine/rt_math.h"
 
@@ -1089,7 +1090,7 @@ void MyScrolledToolbar::get_preferred_height_vfunc (int &minimumHeight, int &nat
     }
 }
 
-MyComboBoxText::MyComboBoxText (bool has_entry) : Gtk::ComboBoxText(has_entry)
+MyComboBoxText::MyComboBoxText (bool has_entry) : Gtk::ComboBoxText(has_entry), toolPanel(nullptr)
 {
     minimumWidth = naturalWidth = RTScalable::scalePixelSize(70);
     Gtk::CellRendererText* cellRenderer = dynamic_cast<Gtk::CellRendererText*>(get_first_cell());
@@ -1140,8 +1141,85 @@ void MyComboBoxText::get_preferred_width_for_height_vfunc (int height, int &mini
     minimum_width = rtengine::max(minimumWidth, RTScalable::scalePixelSize(10));
 }
 
-
-MyComboBox::MyComboBox ()
+ToolAutoEnable::ToolAutoEnable() : autoEnableTool(true) {}
+void ToolAutoEnable::setAutoEnableTool(bool autoEnable)
+{
+    autoEnableTool = autoEnable;
+}
+bool ToolAutoEnable::getAutoEnableTool() const
+{
+    return autoEnableTool;
+}
+void ToolAutoEnable::addSecondaryExpander(MyExpander* expander)
+{
+    if (std::find(secondaryExpanders.begin(), secondaryExpanders.end(), expander) == secondaryExpanders.end()) {
+        secondaryExpanders.push_back(expander);
+    }
+}
+void ToolAutoEnable::addSecondaryPanel(FoldableToolPanel* panel)
+{
+    if (std::find(secondaryPanels.begin(), secondaryPanels.end(), panel) == secondaryPanels.end()) {
+        secondaryPanels.push_back(panel);
+    }
+}
+void registerExpanders(Gtk::Container* container, std::vector<MyExpander*> expanders)
+{
+    for (Gtk::Widget* child : container->get_children()) {
+        if (auto* host = dynamic_cast<ToolAutoEnable*>(child)) {
+            for (MyExpander* e : expanders) {
+                host->addSecondaryExpander(e);
+            }
+        } else if (auto* exp = dynamic_cast<MyExpander*>(child)) {
+            auto childExpanders = expanders;
+            if (exp->getUseEnabled()) {
+                childExpanders.push_back(exp);
+            }
+            registerExpanders(exp, std::move(childExpanders));
+        } else if (auto* sub = dynamic_cast<Gtk::Container*>(child)) {
+            registerExpanders(sub, expanders);
+        }
+    }
+}
+void registerPanels(Gtk::Container* container, FoldableToolPanel* parent)
+{
+    for (Gtk::Widget* child : container->get_children()) {
+        if (auto* host = dynamic_cast<ToolAutoEnable*>(child)) {
+            host->addSecondaryPanel(parent);
+        } else if (auto* sub = dynamic_cast<Gtk::Container*>(child)) {
+            registerPanels(sub, parent);
+        }
+    }
+}
+void ToolAutoEnable::tryEnableTool()
+{
+    if (!autoEnableTool) {
+        return;
+    }
+    if (!canEnableTool()) {
+        return;
+    }
+    if (auto* fp = getToolPanel()) {
+        fp->enableTool();
+    }
+    for (MyExpander* expander : secondaryExpanders) {
+        if (expander->getUseEnabled() && !expander->getEnabled()) {
+            expander->setEnabled(true);
+        }
+    }
+    for (FoldableToolPanel* panel : secondaryPanels) {
+        panel->enableTool();
+    }
+}
+void MyComboBoxText::setToolPanel(FoldableToolPanel* panel)
+{
+    toolPanel = panel;
+}
+void MyComboBoxText::on_changed()
+{
+    tryEnableTool();
+    Gtk::ComboBoxText::on_changed();
+}
+MyComboBox::MyComboBox () : toolPanel(nullptr)
 {
     minimumWidth = naturalWidth = RTScalable::scalePixelSize(70);
 }
@@ -1186,8 +1264,16 @@ void MyComboBox::get_preferred_width_for_height_vfunc (int height, int &minimum_
     natural_width = rtengine::max(naturalWidth, RTScalable::scalePixelSize(10));
     minimum_width = rtengine::max(minimumWidth, RTScalable::scalePixelSize(10));
 }
-
-MySpinButton::MySpinButton ()
+void MyComboBox::setToolPanel(FoldableToolPanel* panel)
+{
+    toolPanel = panel;
+}
+void MyComboBox::on_changed()
+{
+    tryEnableTool();
+    Gtk::ComboBox::on_changed();
+}
+MySpinButton::MySpinButton () : toolPanel(nullptr)
 {
     Gtk::Border border;
     border.set_bottom(0);
@@ -1199,6 +1285,16 @@ MySpinButton::MySpinButton ()
     set_wrap(false);
     set_alignment(Gtk::ALIGN_END);
     set_update_policy(Gtk::SpinButtonUpdatePolicy::UPDATE_IF_VALID); // Avoid updating text if input is not a numeric
+}
+
+void MySpinButton::setToolPanel(FoldableToolPanel* panel)
+{
+    toolPanel = panel;
+}
+
+void MySpinButton::on_value_changed()
+{
+    Gtk::SpinButton::on_value_changed();
 }
 
 void MySpinButton::updateSize()
@@ -1238,6 +1334,7 @@ bool MySpinButton::on_key_press_event (GdkEventKey* event)
         return false; // Event is propagated further
     } else {
         if (event->keyval == GDK_KEY_comma || event->keyval == GDK_KEY_KP_Decimal) {
+            tryEnableTool();
             set_text(get_text() + ".");
             set_position(get_text().length()); // When setting text, cursor position is reset at text start. Avoiding this with this code
             return true; // Event is not propagated further
@@ -1251,6 +1348,7 @@ bool MySpinButton::on_scroll_event (GdkEventScroll* event)
 {
     // If Shift is pressed, the widget is modified
     if (event->state & GDK_SHIFT_MASK) {
+        tryEnableTool();
         Gtk::SpinButton::on_scroll_event(event);
         return true;
     }
@@ -1259,6 +1357,46 @@ bool MySpinButton::on_scroll_event (GdkEventScroll* event)
     return false;
 }
 
+bool MySpinButton::on_button_press_event (GdkEventButton* event)
+{
+  tryEnableTool();
+  Gtk::SpinButton::on_button_press_event(event);
+  return true;
+}
+MyCheckButton::MyCheckButton() : toolPanel(nullptr), enableOnlyWhenActivated(false)
+{
+}
+MyCheckButton::MyCheckButton(const Glib::ustring& label, bool mnemonic) : Gtk::CheckButton(label, mnemonic), toolPanel(nullptr), enableOnlyWhenActivated(false)
+{
+}
+void MyCheckButton::setToolPanel(FoldableToolPanel* panel)
+{
+    toolPanel = panel;
+}
+void MyCheckButton::setEnableOnlyWhenActivated(bool onlyWhenActivated)
+{
+    enableOnlyWhenActivated = onlyWhenActivated;
+}
+bool MyCheckButton::canEnableTool() const
+{
+    return !enableOnlyWhenActivated || get_active();
+}
+void MyCheckButton::on_toggled()
+{
+    tryEnableTool();
+    Gtk::CheckButton::on_toggled();
+}
+MyButton::MyButton() : toolPanel(nullptr) {}
+MyButton::MyButton(const Glib::ustring& label) : Gtk::Button(label), toolPanel(nullptr) {}
+void MyButton::setToolPanel(FoldableToolPanel* panel)
+{
+    toolPanel = panel;
+}
+void MyButton::on_pressed()
+{
+    tryEnableTool();
+    Gtk::Button::on_pressed();
+}
 bool MyHScale::on_scroll_event (GdkEventScroll* event)
 {
 

--- a/rtgui/guiutils.h
+++ b/rtgui/guiutils.h
@@ -18,9 +18,11 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <type_traits>
+#include <vector>
 
 #include <gtkmm.h>
 
@@ -48,6 +50,7 @@ struct CropParams;
 class Adjuster;
 class RTImage;
 class ToolPanel;
+class FoldableToolPanel;
 
 Glib::ustring escapeHtmlChars(const Glib::ustring &src);
 bool removeIfThere (Gtk::Container* cont, Gtk::Widget* w, bool increference = true);
@@ -343,6 +346,27 @@ public:
     void updateVScrollbars(bool hide);
 };
 
+class FoldableToolPanel;
+
+class ToolAutoEnable
+{
+    bool autoEnableTool;
+    std::vector<MyExpander*> secondaryExpanders;
+    std::vector<FoldableToolPanel*> secondaryPanels;
+protected:
+    virtual FoldableToolPanel* getToolPanel() const = 0;
+    virtual bool canEnableTool() const { return true; }
+    void tryEnableTool();
+public:
+    ToolAutoEnable();
+    virtual ~ToolAutoEnable() = default;
+    void setAutoEnableTool(bool autoEnable);
+    bool getAutoEnableTool() const;
+    void addSecondaryExpander(MyExpander* expander);
+    void addSecondaryPanel(FoldableToolPanel* panel);
+};
+void registerExpanders(Gtk::Container* container, std::vector<MyExpander*> expanders = {});
+void registerPanels(Gtk::Container* container, FoldableToolPanel* parent);
 
 /**
  * @brief subclass of Gtk::ScrolledWindow in order to handle the scrollwheel
@@ -375,24 +399,27 @@ public:
 /**
  * @brief subclass of Gtk::ComboBox in order to handle the scrollwheel
  */
-class MyComboBox : public Gtk::ComboBox
+class MyComboBox : public Gtk::ComboBox, public ToolAutoEnable
 {
     int naturalWidth, minimumWidth;
 
     bool on_scroll_event (GdkEventScroll* event) override;
     void get_preferred_width_vfunc (int &minimum_width, int &natural_width) const override;
     void get_preferred_width_for_height_vfunc (int height, int &minimum_width, int &natural_width) const override;
-
+    void on_changed() override;
+    FoldableToolPanel* toolPanel;
+    FoldableToolPanel* getToolPanel() const override { return toolPanel; }
 public:
     MyComboBox ();
 
     void setPreferredWidth (int minimum_width, int natural_width);
+    void setToolPanel(FoldableToolPanel* panel);
 };
 
 /**
  * @brief subclass of Gtk::ComboBoxText in order to handle the scrollwheel
  */
-class MyComboBoxText final : public Gtk::ComboBoxText
+class MyComboBoxText final : public Gtk::ComboBoxText, public ToolAutoEnable
 {
     int naturalWidth, minimumWidth;
     sigc::connection myConnection;
@@ -400,30 +427,71 @@ class MyComboBoxText final : public Gtk::ComboBoxText
     bool on_scroll_event (GdkEventScroll* event) override;
     void get_preferred_width_vfunc (int &minimum_width, int &natural_width) const override;
     void get_preferred_width_for_height_vfunc (int height, int &minimum_width, int &natural_width) const override;
-
+    void on_changed() override;
+    FoldableToolPanel* toolPanel;
+    FoldableToolPanel* getToolPanel() const override { return toolPanel; }
 public:
     explicit MyComboBoxText (bool has_entry = false);
 
     void setPreferredWidth (int minimum_width, int natural_width);
     void connect(const sigc::connection &connection) { myConnection = connection; }
     void block(bool blocked) { myConnection.block(blocked); }
+    void setToolPanel(FoldableToolPanel* panel);
 };
 
 /**
  * @brief subclass of Gtk::SpinButton in order to handle the scrollwheel
  */
-class MySpinButton final : public Gtk::SpinButton
+class MySpinButton final : public Gtk::SpinButton, public ToolAutoEnable
 {
-
 protected:
     bool on_scroll_event (GdkEventScroll* event) override;
+    bool on_button_press_event (GdkEventButton* event) override;
     bool on_key_press_event (GdkEventKey* event) override;
+    void on_value_changed() override;
+    FoldableToolPanel* getToolPanel() const override { return toolPanel; }
+private:
+    FoldableToolPanel* toolPanel;
 
 public:
     MySpinButton ();
     void updateSize();
+    void setToolPanel(FoldableToolPanel* panel);
 };
 
+/**
+ * @brief subclass of Gtk::CheckButton in order to handle auto-enable
+ */
+class MyCheckButton final : public Gtk::CheckButton, public ToolAutoEnable
+{
+protected:
+    void on_toggled() override;
+    FoldableToolPanel* getToolPanel() const override { return toolPanel; }
+    bool canEnableTool() const override;
+private:
+    FoldableToolPanel* toolPanel;
+    bool enableOnlyWhenActivated;
+public:
+    MyCheckButton();
+    explicit MyCheckButton(const Glib::ustring& label, bool mnemonic = false);
+    void setToolPanel(FoldableToolPanel* panel);
+    void setEnableOnlyWhenActivated(bool onlyWhenActivated);
+};
+/**
+ * @brief subclass of Gtk::Button in order to handle auto-enable
+ */
+class MyButton final : public Gtk::Button, public ToolAutoEnable
+{
+protected:
+    void on_pressed() override;
+    FoldableToolPanel* getToolPanel() const override { return toolPanel; }
+private:
+    FoldableToolPanel* toolPanel;
+public:
+    MyButton();
+    explicit MyButton(const Glib::ustring& label);
+    void setToolPanel(FoldableToolPanel* panel);
+};
 /**
  * @brief subclass of Gtk::Scale in order to handle the scrollwheel
  */

--- a/rtgui/labgrid.cc
+++ b/rtgui/labgrid.cc
@@ -87,15 +87,17 @@ LabGridArea::LabGridArea(rtengine::ProcEvent evt, const Glib::ustring &msg, bool
     evt(evt), evtMsg(msg),
     litPoint(NONE),
     low_a(0.f), high_a(0.f), low_b(0.f), high_b(0.f), gre_x(0.f), gre_y(0.f), whi_x(0.f), whi_y(0.f), me_x(0.f), me_y(0.f),
-      
+
     defaultLow_a(0.f), defaultHigh_a(0.f), defaultLow_b(0.f), defaultHigh_b(0.f), defaultgre_x(0.f), defaultgre_y(0.f), defaultwhi_x(0.f), defaultwhi_y(0.f), defaultme_x(0.f), defaultme_y(0.f),
     listener(nullptr),
+    parentTool(nullptr),
     edited(false),
     isDragged(false),
     low_enabled(enable_low),
     ciexy_enabled(ciexy),
     ghs_enabled(ghs),
-    mous_enabled(mous)
+    mous_enabled(mous),
+    autoEnableTool(true)
     
 
 {
@@ -190,7 +192,10 @@ void LabGridArea::setListener(ToolPanelListener *l)
 {
     listener = l;
 }
-
+void LabGridArea::setParentTool(FoldableToolPanel *tool)
+{
+    parentTool = tool;
+}
 
 void LabGridArea::on_style_updated ()
 {
@@ -552,6 +557,9 @@ bool LabGridArea::on_draw(const ::Cairo::RefPtr<Cairo::Context> &cr)
 bool LabGridArea::on_button_press_event(GdkEventButton *event)
 {
     if (event->button == 1  && mous_enabled) {
+      if (autoEnableTool && parentTool) {
+          parentTool->enableTool();
+      }
       if (!ciexy_enabled && !ghs_enabled) {
         if (event->type == GDK_2BUTTON_PRESS) {
             switch (litPoint) {
@@ -738,7 +746,14 @@ void LabGridArea::setmousEnabled(bool yes)
         queue_draw();
     }
 }
-
+void LabGridArea::setAutoEnableTool(bool autoEnable)
+{
+    autoEnableTool = autoEnable;
+}
+bool LabGridArea::getAutoEnableTool() const
+{
+    return autoEnableTool;
+}
 
 //-----------------------------------------------------------------------------
 // LabGrid

--- a/rtgui/labgrid.h
+++ b/rtgui/labgrid.h
@@ -125,6 +125,7 @@ private:
     double defaultme_y;
 
     ToolPanelListener *listener;
+    FoldableToolPanel *parentTool;
     bool edited;
     bool isDragged;
     sigc::connection delayconn;
@@ -134,6 +135,7 @@ private:
     bool ciexy_enabled;
     bool ghs_enabled;
     bool mous_enabled;
+    bool autoEnableTool;
 
     bool notifyListener();
     void getLitPoint();
@@ -149,6 +151,7 @@ public:
     bool getEdited() const;
     void reset(bool toInitial);
     void setListener(ToolPanelListener *l);
+    void setParentTool(FoldableToolPanel *tool);
 
     bool lowEnabled() const;
     void setLowEnabled(bool yes);
@@ -158,6 +161,8 @@ public:
     void setghsEnabled(bool yes);
     bool mousEnabled() const;
     void setmousEnabled(bool yes);
+    void setAutoEnableTool(bool autoEnable);
+    bool getAutoEnableTool() const;
  
     bool on_draw(const ::Cairo::RefPtr<Cairo::Context> &cr) override;
     void on_style_updated () override;
@@ -194,6 +199,7 @@ public:
     bool getEdited() const { return grid.getEdited(); }
     void reset(bool toInitial) { grid.reset(toInitial); }
     void setListener(ToolPanelListener *l) { grid.setListener(l); }
+    void setParentTool(FoldableToolPanel *tool) { grid.setParentTool(tool); }
     bool lowEnabled() const { return grid.lowEnabled(); }
     void setLowEnabled(bool yes) { grid.setLowEnabled(yes); }
     bool ciexyEnabled() const { return grid.ciexyEnabled(); }
@@ -202,5 +208,7 @@ public:
     void setghsEnabled(bool yes) { grid.setghsEnabled(yes); }
     bool mousEnabled() const { return grid.mousEnabled(); }
     void setmousEnabled(bool yes) { grid.setmousEnabled(yes); }
+    void setAutoEnableTool(bool autoEnable) { grid.setAutoEnableTool(autoEnable); }
+    bool getAutoEnableTool() const { return grid.getAutoEnableTool(); }
 
 };

--- a/rtgui/toolpanel.cc
+++ b/rtgui/toolpanel.cc
@@ -152,6 +152,9 @@ void FoldableToolPanel::setEnabled(bool isEnabled)
 }
 void FoldableToolPanel::enableTool()
 {
+    if (!listener) {
+        return;
+    }
     if (!getEnabled()) {
         setEnabled(true);
         enabledChanged();

--- a/rtgui/toolpanel.cc
+++ b/rtgui/toolpanel.cc
@@ -150,7 +150,13 @@ void FoldableToolPanel::setEnabled(bool isEnabled)
     lastEnabled = isEnabled;
     enaConn.block (false);
 }
-
+void FoldableToolPanel::enableTool()
+{
+    if (!getEnabled()) {
+        setEnabled(true);
+        enabledChanged();
+    }
+}
 void FoldableToolPanel::setEnabledTooltipMarkup(Glib::ustring tooltipMarkup)
 {
     if (exp) {

--- a/rtgui/toolpanel.h
+++ b/rtgui/toolpanel.h
@@ -174,8 +174,8 @@ protected:
     sigc::connection enaConn;
     void foldThemAll (GdkEventButton* event);
     void enabled_toggled();
-
 public:
+    void enableTool();
 
     FoldableToolPanel(Gtk::Box* content, Glib::ustring toolName, Glib::ustring UILabel, bool need11 = false, bool useEnabled = false);
 

--- a/rtgui/tools/blackwhite.cc
+++ b/rtgui/tools/blackwhite.cc
@@ -52,6 +52,7 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
     metHBox->pack_start (*metLabel, Gtk::PACK_SHRINK);
    
 	method = Gtk::manage (new MyComboBoxText ());
+    method->setToolPanel(this);
     method->append (M("TP_BWMIX_MET_DESAT"));
     method->append (M("TP_BWMIX_MET_LUMEQUAL"));
     method->append (M("TP_BWMIX_MET_CHANMIX"));
@@ -123,6 +124,7 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
 
     settingHBox->pack_start (*settingLabel, Gtk::PACK_SHRINK);
     setting = Gtk::manage (new MyComboBoxText ());
+    setting->setToolPanel(this);
     setting->append (M("TP_BWMIX_SET_NORMCONTAST"));
     setting->append (M("TP_BWMIX_SET_HIGHCONTAST"));
     setting->append (M("TP_BWMIX_SET_LUMINANCE"));
@@ -153,7 +155,8 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
     enabledccSep = Gtk::manage (new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
     mixerVBox->pack_start (*enabledccSep);
 
-    enabledcc = Gtk::manage (new Gtk::CheckButton (M("TP_BWMIX_CC_ENABLED")));
+    enabledcc = Gtk::manage (new MyCheckButton (M("TP_BWMIX_CC_ENABLED")));
+    enabledcc->setToolPanel(this);
 
     enabledcc->set_active (true);
     enabledcc->set_tooltip_markup (M("TP_BWMIX_CC_TOOLTIP"));
@@ -173,6 +176,7 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
     Gtk::Label *filterLabel = Gtk::manage (new Gtk::Label (M("TP_BWMIX_FILTER") + ":"));
     filterHBox->pack_start (*filterLabel, Gtk::PACK_SHRINK);
     filter = Gtk::manage (new MyComboBoxText ());
+    filter->setToolPanel(this);
     filter->append (M("TP_BWMIX_FILTER_NONE"));
     filter->append (M("TP_BWMIX_FILTER_RED"));
     filter->append (M("TP_BWMIX_FILTER_REDYELLOW"));
@@ -237,6 +241,7 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
     algoHBox->pack_start (*alLabel, Gtk::PACK_SHRINK);
 
     algo = Gtk::manage (new MyComboBoxText ());
+    algo->setToolPanel(this);
     algo->append (M("TP_BWMIX_ALGO_LI"));
     algo->append (M("TP_BWMIX_ALGO_SP"));
     algo->set_active (1);
@@ -321,6 +326,7 @@ BlackWhite::BlackWhite (): FoldableToolPanel(this, TOOL_NAME, M("TP_BWMIX_LABEL"
     bottomMilestonesbw.push_back( GradientMilestone(1., 1., 1., 1.) );
 
     beforeCurveMode = Gtk::manage (new MyComboBoxText ());
+    beforeCurveMode->setToolPanel(this);
     beforeCurveMode->append (M("TP_BWMIX_TCMODE_STANDARD"));
     beforeCurveMode->append (M("TP_BWMIX_TCMODE_WEIGHTEDSTD"));
     beforeCurveMode->append (M("TP_BWMIX_TCMODE_FILMLIKE"));

--- a/rtgui/tools/blackwhite.h
+++ b/rtgui/tools/blackwhite.h
@@ -135,7 +135,7 @@ private:
     Gtk::Image *imgIcon[11];
 
     Gtk::Separator* enabledccSep;
-    Gtk::CheckButton* enabledcc;
+    MyCheckButton* enabledcc;
     bool lastEnabledcc, lastAuto;
     sigc::connection enaccconn, tcmodeconn, tcmodeconn2, autoconn, neutralconn;
 

--- a/rtgui/tools/colorappearance.cc
+++ b/rtgui/tools/colorappearance.cc
@@ -1929,7 +1929,6 @@ void ColorAppearance::adjusterChanged(Adjuster* a, double newval)
 
 void ColorAppearance::adjusterAutoToggled(Adjuster* a, bool newval)
 {
-    enableTool();
     if (multiImage) {
         if (degree->getAutoInconsistent()) {
             degree->setAutoInconsistent (false);

--- a/rtgui/tools/colorappearance.cc
+++ b/rtgui/tools/colorappearance.cc
@@ -167,6 +167,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     genVBox->set_spacing (2);
 
     complexmethod = Gtk::manage (new MyComboBoxText ());
+    complexmethod->setToolPanel(this);
     complexmethod->append(M("TP_WAVELET_COMPNORMAL"));
     complexmethod->append(M("TP_WAVELET_COMPEXPERT"));
     complexmethodconn = complexmethod->signal_changed().connect(sigc::mem_fun(*this, &ColorAppearance::complexmethodChanged));
@@ -178,6 +179,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     genVBox->pack_start (*complexHBox, Gtk::PACK_SHRINK);
 
     modelmethod = Gtk::manage (new MyComboBoxText ());
+    modelmethod->setToolPanel(this);
     modelmethod->append(M("TP_COLORAPP_MOD02"));//Old CIECAM02
     modelmethod->append(M("TP_COLORAPP_MOD16"));//new CIECAM16
     modelmethodconn = modelmethod->signal_changed().connect(sigc::mem_fun(*this, &ColorAppearance::modelmethodChanged));
@@ -188,7 +190,8 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     modelHBox->pack_start(*modelmethod);
     genVBox->pack_start (*modelHBox, Gtk::PACK_SHRINK);
 
-    catmethod = Gtk::manage (new MyComboBoxText ());//The choice of basic method is either 
+    catmethod = Gtk::manage (new MyComboBoxText ());//The choice of basic method is either
+    catmethod->setToolPanel(this);
     catmethod->append(M("TP_COLORAPP_CATCLASSIC"));//Classical (recommended),
     catmethod->append(M("TP_COLORAPP_CATSYMGEN")); //Symmetrical (allows for very good color matching)
     catmethod->append(M("TP_COLORAPP_CATSYMSPE")); //Or Mixed. In all three cases, the CIECAM characterizing values ​​such as absolute luminance, color matching, surround, etc., are different.
@@ -232,6 +235,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     Gtk::Label* surrLabel1 = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_SURROUNDSRC") + ":"));//surround scene
     surrHBox1->pack_start (*surrLabel1, Gtk::PACK_SHRINK);
     surrsrc = Gtk::manage (new MyComboBoxText ());
+    surrsrc->setToolPanel(this);
     surrsrc->append (M ("TP_COLORAPP_SURROUND_AVER"));//standard creates a slight lighting effect
     surrsrc->append (M ("TP_COLORAPP_SURROUND_DIM"));
     surrsrc->append (M ("TP_COLORAPP_SURROUND_DARK"));
@@ -247,6 +251,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     Gtk::Label* wbmLab = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_MODEL") + ":"));//white point model - The default balance point is D50, but D65 can be selected. In this case, the viewing temperature will be set to 6504K.
     wbmHBox->pack_start (*wbmLab, Gtk::PACK_SHRINK);
     wbmodel = Gtk::manage (new MyComboBoxText ());
+    wbmodel->setToolPanel(this);
     wbmodel->append (M ("TP_COLORAPP_WBRT"));
     wbmodel->append (M ("TP_COLORAPP_WBCAM"));
     wbmodel->append (M ("TP_COLORAPP_FREE"));
@@ -262,6 +267,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     Gtk::Label* illumLab = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_ILLUM") + ":"));//Choice of illuminant in non-standard cases
     illumHBox->pack_start (*illumLab, Gtk::PACK_SHRINK);
     illum = Gtk::manage (new MyComboBoxText ());
+    illum->setToolPanel(this);
     illum->append (M ("TP_COLORAPP_ILA"));
     illum->append (M ("TP_COLORAPP_IL41"));
     illum->append (M ("TP_COLORAPP_IL50"));
@@ -329,6 +335,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     Gtk::Label* alLabel = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_ALGO") + ":"));
     alHBox->pack_start (*alLabel, Gtk::PACK_SHRINK);
     algo = Gtk::manage (new MyComboBoxText ());//I chose 4 possible combinations of the 6 variables... we can imagine others, but that will complicate the code
+    algo->setToolPanel(this);
     algo->append (M ("TP_COLORAPP_ALGO_JC"));
     algo->append (M ("TP_COLORAPP_ALGO_JS"));
     algo->append (M ("TP_COLORAPP_ALGO_QM"));
@@ -444,6 +451,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     p2VBox->pack_start (*pRGBFrame, Gtk::PACK_EXPAND_WIDGET, 4);
 
     toneCurveMode = Gtk::manage (new MyComboBoxText ());
+    toneCurveMode->setToolPanel(this);
     toneCurveMode->append (M ("TP_COLORAPP_TCMODE_LIGHTNESS"));
     toneCurveMode->append (M ("TP_COLORAPP_TCMODE_BRIGHTNESS"));
     toneCurveMode->set_active (0);
@@ -457,6 +465,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     tcmodeconn = toneCurveMode->signal_changed().connect ( sigc::mem_fun (*this, &ColorAppearance::curveMode1Changed), true );
 
     toneCurveMode2 = Gtk::manage (new MyComboBoxText ());//curve type selection Lighness or brightness
+    toneCurveMode2->setToolPanel(this);
     toneCurveMode2->append (M ("TP_COLORAPP_TCMODE_LIGHTNESS"));
     toneCurveMode2->append (M ("TP_COLORAPP_TCMODE_BRIGHTNESS"));
     toneCurveMode2->set_active (0);
@@ -470,6 +479,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     tcmode2conn = toneCurveMode2->signal_changed().connect ( sigc::mem_fun (*this, &ColorAppearance::curveMode2Changed), true );
 
     toneCurveMode3 = Gtk::manage (new MyComboBoxText ());//curve type selection chroma, saturation, colorfullness
+    toneCurveMode3->setToolPanel(this);
     toneCurveMode3->append (M ("TP_COLORAPP_TCMODE_CHROMA"));
     toneCurveMode3->append (M ("TP_COLORAPP_TCMODE_SATUR"));
     toneCurveMode3->append (M ("TP_COLORAPP_TCMODE_COLORF"));
@@ -609,6 +619,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     Gtk::Label* surrLabel = Gtk::manage (new Gtk::Label (M ("TP_COLORAPP_SURROUND") + ":"));
     surrHBox->pack_start (*surrLabel, Gtk::PACK_SHRINK);
     surround = Gtk::manage (new MyComboBoxText ());
+    surround->setToolPanel(this);
     surround->append (M ("TP_COLORAPP_SURROUND_AVER"));//standard
     surround->append (M ("TP_COLORAPP_SURROUND_DIM"));
     surround->append (M ("TP_COLORAPP_SURROUND_DARK"));
@@ -624,7 +635,7 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     // ------------------------ Lab Gamut control
 
 
-    gamut = Gtk::manage (new Gtk::CheckButton (M ("TP_COLORAPP_GAMUT")));
+    gamut = Gtk::manage (new MyCheckButton (M ("TP_COLORAPP_GAMUT")));
     gamutconn = gamut->signal_toggled().connect ( sigc::mem_fun (*this, &ColorAppearance::gamut_toggled) );
     pack_start (*gamut, Gtk::PACK_SHRINK);
 
@@ -692,6 +703,8 @@ ColorAppearance::ColorAppearance () : FoldableToolPanel (this, TOOL_NAME, M ("TP
     tempsc->setAdjusterListener  (this);
     greensc->setAdjusterListener  (this);
 
+
+    gamut->setToolPanel(this);
 
     show_all();
 }
@@ -1916,6 +1929,7 @@ void ColorAppearance::adjusterChanged(Adjuster* a, double newval)
 
 void ColorAppearance::adjusterAutoToggled(Adjuster* a, bool newval)
 {
+    enableTool();
     if (multiImage) {
         if (degree->getAutoInconsistent()) {
             degree->setAutoInconsistent (false);
@@ -2036,7 +2050,6 @@ void ColorAppearance::enabledChanged ()
 
 void ColorAppearance::surrsrcChanged ()
 {
-
     if (listener && (multiImage || getEnabled()) ) {
         listener->panelChanged (EvCATsurr, surrsrc->get_active_text ());
     }
@@ -2045,7 +2058,6 @@ void ColorAppearance::surrsrcChanged ()
 
 void ColorAppearance::surroundChanged ()
 {
-
     if (listener && (multiImage || getEnabled()) ) {
         listener->panelChanged (EvCATMethodsur, surround->get_active_text ());
     }

--- a/rtgui/tools/colorappearance.h
+++ b/rtgui/tools/colorappearance.h
@@ -172,7 +172,7 @@ private:
 
     //Adjuster* edge;
     Gtk::CheckButton* surrsource;
-    Gtk::CheckButton* gamut;
+    MyCheckButton* gamut;
 //   Gtk::CheckButton* badpix;
     Gtk::CheckButton* datacie;
     Gtk::CheckButton* tonecie;

--- a/rtgui/tools/colortoning.cc
+++ b/rtgui/tools/colortoning.cc
@@ -223,9 +223,10 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     p1VBox = Gtk::manage ( new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
     p1VBox->set_spacing(2);
 
-    autosat = Gtk::manage (new Gtk::CheckButton (M("TP_COLORTONING_AUTOSAT")));
-    autosat->set_active (true);
-    autosatConn  = autosat->signal_toggled().connect( sigc::mem_fun(*this, &ColorToning::autosatChanged) );
+    autosat = Gtk::manage (new CheckBox (M("TP_COLORTONING_AUTOSAT"), multiImage));
+    autosat->setValue (true);
+    autosat->setCheckBoxListener(this);
+    autosat->setEnableOnlyWhenActivated(true);
     //satFrame->set_label_widget(*autosat);
 
     p1VBox->pack_start (*autosat, Gtk::PACK_SHRINK, 2);
@@ -330,11 +331,11 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     pack_start (*neutrHBox);
 
     //--------------------- Keep luminance checkbox -------------------
-    lumamode = Gtk::manage (new Gtk::CheckButton (M("TP_COLORTONING_LUMAMODE")));
+    lumamode = Gtk::manage (new CheckBox (M("TP_COLORTONING_LUMAMODE"), multiImage));
     lumamode->set_tooltip_markup (M("TP_COLORTONING_LUMAMODE_TOOLTIP"));
-    lumamode->set_active (false);
+    lumamode->setValue (false);
     lumamode->show ();
-    lumamodeConn = lumamode->signal_toggled().connect( sigc::mem_fun(*this, &ColorToning::lumamodeChanged) );
+    lumamode->setCheckBoxListener(this);
 
     pack_start (*lumamode);
 
@@ -618,10 +619,10 @@ void ColorToning::read (const ProcParams* pp, const ParamsEdited* pedited)
         set_inconsistent (multiImage && !pedited->colorToning.enabled);
         colorShape->setUnChanged (!pedited->colorToning.colorCurve);
         opacityShape->setUnChanged (!pedited->colorToning.opacityCurve);
-        autosat->set_inconsistent (!pedited->colorToning.autosat);
+        autosat->setEdited(pedited->colorToning.autosat);
         clshape->setUnChanged  (!pedited->colorToning.clcurve);
         cl2shape->setUnChanged  (!pedited->colorToning.cl2curve);
-        lumamode->set_inconsistent (!pedited->colorToning.lumamode);
+        lumamode->setEdited(pedited->colorToning.lumamode);
 
         labgrid->setEdited(pedited->colorToning.labgridALow || pedited->colorToning.labgridBLow || pedited->colorToning.labgridAHigh || pedited->colorToning.labgridBHigh);
 
@@ -642,21 +643,14 @@ void ColorToning::read (const ProcParams* pp, const ParamsEdited* pedited)
 
     setEnabled (pp->colorToning.enabled);
 
-    autosatConn.block (true);
-    autosat->set_active (pp->colorToning.autosat);
-    autosatConn.block (false);
-    lastautosat = pp->colorToning.autosat;
+    autosat->setValue(pp->colorToning.autosat);
 
     satProtectionThreshold->setValue (pp->colorToning.satProtectionThreshold);
     saturatedOpacity->setValue (pp->colorToning.saturatedOpacity);
     hlColSat->setValue<int> (pp->colorToning.hlColSat);
     shadowsColSat->setValue<int> (pp->colorToning.shadowsColSat);
     strength->setValue (pp->colorToning.strength);
-    lumamodeConn.block (true);
-    lumamode->set_active (pp->colorToning.lumamode);
-    lumamodeConn.block (false);
-
-    lastLumamode = pp->colorToning.lumamode;
+    lumamode->setValue(pp->colorToning.lumamode);
 
     labgrid->setParams(pp->colorToning.labgridALow / ColorToningParams::LABGRID_CORR_MAX, pp->colorToning.labgridBLow / ColorToningParams::LABGRID_CORR_MAX, pp->colorToning.labgridAHigh / ColorToningParams::LABGRID_CORR_MAX, pp->colorToning.labgridBHigh / ColorToningParams::LABGRID_CORR_MAX, 0, 0, 0, 0, 0, 0, false);
 
@@ -719,11 +713,11 @@ void ColorToning::write (ProcParams* pp, ParamsEdited* pedited)
     pp->colorToning.opacityCurve = opacityShape->getCurve ();
     pp->colorToning.clcurve      = clshape->getCurve ();
     pp->colorToning.cl2curve     = cl2shape->getCurve ();
-    pp->colorToning.lumamode     = lumamode->get_active();
+    pp->colorToning.lumamode     = lumamode->getLastActive();
 
     pp->colorToning.hlColSat               = hlColSat->getValue<int> ();
     pp->colorToning.shadowsColSat          = shadowsColSat->getValue<int> ();
-    pp->colorToning.autosat                = autosat->get_active();
+    pp->colorToning.autosat                = autosat->getLastActive();
     pp->colorToning.satProtectionThreshold = satProtectionThreshold->getIntValue();
     pp->colorToning.saturatedOpacity       = saturatedOpacity->getIntValue();
     pp->colorToning.strength               = strength->getIntValue();
@@ -760,12 +754,12 @@ void ColorToning::write (ProcParams* pp, ParamsEdited* pedited)
         pedited->colorToning.twocolor   = twocolor->get_active_text() != M("GENERAL_UNCHANGED");
 
         pedited->colorToning.enabled       = !get_inconsistent();
-        pedited->colorToning.autosat       = !autosat->get_inconsistent();
+        pedited->colorToning.autosat       = autosat->getEdited();
         pedited->colorToning.colorCurve    = !colorShape->isUnChanged ();
         pedited->colorToning.opacityCurve  = !opacityShape->isUnChanged ();
         pedited->colorToning.clcurve       = !clshape->isUnChanged ();
         pedited->colorToning.cl2curve      = !cl2shape->isUnChanged ();
-        pedited->colorToning.lumamode      = !lumamode->get_inconsistent();
+        pedited->colorToning.lumamode      = lumamode->getEdited();
 
         pedited->colorToning.hlColSat      = hlColSat->getEditedState ();
         pedited->colorToning.shadowsColSat = shadowsColSat->getEditedState ();
@@ -800,32 +794,6 @@ void ColorToning::write (ProcParams* pp, ParamsEdited* pedited)
         pp->colorToning.twocolor = "Separ";
     } else if (twocolor->get_active_row_number() == 3) {
         pp->colorToning.twocolor = "Two";
-    }
-}
-
-void ColorToning::lumamodeChanged ()
-{
-    enableTool();
-
-    if (batchMode) {
-        if (lumamode->get_inconsistent()) {
-            lumamode->set_inconsistent (false);
-            lumamodeConn.block (true);
-            lumamode->set_active (false);
-            lumamodeConn.block (false);
-        } else if (lastLumamode) {
-            lumamode->set_inconsistent (true);
-        }
-
-        lastLumamode = lumamode->get_active ();
-    }
-
-    if (listener && getEnabled()) {
-        if (lumamode->get_active ()) {
-            listener->panelChanged (EvColorToningLumamode, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged (EvColorToningLumamode, M("GENERAL_DISABLED"));
-        }
     }
 }
 
@@ -1032,7 +1000,7 @@ void ColorToning::methodChanged ()
             balance->hide();
 
 //          satLimiterSep->show();
-            if(autosat->get_active()) {
+            if(autosat->getLastActive()) {
                 saturatedOpacity->set_sensitive(false);
                 satProtectionThreshold->set_sensitive(false);
                 satProtectionThreshold->show();
@@ -1072,7 +1040,7 @@ void ColorToning::methodChanged ()
             autosat->show();
             p1Frame->show();
 
-            if(autosat->get_active()) {
+            if(autosat->getLastActive()) {
                 saturatedOpacity->set_sensitive(false);
                 satProtectionThreshold->set_sensitive(false);
                 satProtectionThreshold->show();
@@ -1106,7 +1074,7 @@ void ColorToning::methodChanged ()
 
             autosat->show();
 
-            if(autosat->get_active()) {
+            if(autosat->getLastActive()) {
                 saturatedOpacity->set_sensitive(false);
                 satProtectionThreshold->set_sensitive(false);
                 satProtectionThreshold->show();
@@ -1300,40 +1268,32 @@ void ColorToning::enabledChanged ()
     }
 }
 
-void ColorToning::autosatChanged ()
+void ColorToning::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-
-    if (batchMode) {
-        if (autosat->get_inconsistent()) {
-            autosat->set_inconsistent (false);
-            autosatConn.block (true);
-            autosat->set_active (false);
-            autosatConn.block (false);
-        } else if (lastautosat) {
-            autosat->set_inconsistent (true);
-        }
-
-        lastautosat = autosat->get_active ();
+    if (!listener) {
+        return;
     }
 
-    if (listener) {
-        if (autosat->get_active()) {
+    if (c == lumamode) {
+        if (getEnabled()) {
+            listener->panelChanged(
+                EvColorToningLumamode,
+                c->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        }
+    } else if (c == autosat) {
+        if (c->getLastActive()) {
             if (getEnabled()) {
-                listener->panelChanged (EvColorToningautosat, M("GENERAL_ENABLED"));
+                listener->panelChanged(EvColorToningautosat, M("GENERAL_ENABLED"));
             }
-
-            enableTool();
             saturatedOpacity->set_sensitive(false);
             satProtectionThreshold->set_sensitive(false);
         } else {
             if (getEnabled()) {
-                listener->panelChanged (EvColorToningautosat, M("GENERAL_DISABLED"));
+                listener->panelChanged(EvColorToningautosat, M("GENERAL_DISABLED"));
             }
-
             saturatedOpacity->set_sensitive(true);
             satProtectionThreshold->set_sensitive(true);
         }
-
     }
 }
 

--- a/rtgui/tools/colortoning.cc
+++ b/rtgui/tools/colortoning.cc
@@ -354,6 +354,7 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
 //    EvColorToningLabGridValue = m->newEvent(RGBCURVE, "HISTORY_MSG_COLORTONING_LABGRID_VALUE");
     EvColorToningLabGridValue = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_COLORTONING_LABGRID_VALUE");
     labgrid = Gtk::manage(new LabGrid(EvColorToningLabGridValue, M("TP_COLORTONING_LABGRID_VALUES")));
+    labgrid->setParentTool(this);
     pack_start(*labgrid, Gtk::PACK_EXPAND_WIDGET, 4);
     //------------------------------------------------------------------------
 
@@ -421,6 +422,7 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     labRegionBox->pack_start(*hb, true, true);
 
     labRegionAB = Gtk::manage(new LabGrid(EvLabRegionAB, M("TP_COLORTONING_LABREGION_ABVALUES"), false));
+    labRegionAB->setParentTool(this);
     labRegionBox->pack_start(*labRegionAB);
 
     labRegionSaturation = Gtk::manage(new Adjuster(M("TP_COLORTONING_LABREGION_SATURATION"), -100, 100, 1, 0));
@@ -1529,6 +1531,9 @@ void ColorToning::labRegionCopyPressed()
 
 void ColorToning::labRegionShowMaskChanged()
 {
+    if (labRegionShowMask->get_active()) {
+        enableTool();
+    }
     if (listener) {
         listener->panelChanged(EvLabRegionShowMask, labRegionShowMask->get_active() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
     }

--- a/rtgui/tools/colortoning.cc
+++ b/rtgui/tools/colortoning.cc
@@ -44,6 +44,7 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     //---------------method
 
     method = Gtk::manage (new MyComboBoxText ());
+    method->setToolPanel(this);
     method->append (M("TP_COLORTONING_LAB"));
     method->append (M("TP_COLORTONING_RGBSLIDERS"));
     method->append (M("TP_COLORTONING_RGBCURVES"));
@@ -104,6 +105,7 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     //----------------------red green  blue yellow colours
 
     twocolor = Gtk::manage (new MyComboBoxText ());
+    twocolor->setToolPanel(this);
     twocolor->append (M("TP_COLORTONING_TWOSTD"));
     twocolor->append (M("TP_COLORTONING_TWOALL"));
     twocolor->append (M("TP_COLORTONING_TWOBY"));
@@ -443,6 +445,7 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
 
     hb = Gtk::manage(new Gtk::Box());
     labRegionChannel = Gtk::manage(new MyComboBoxText());
+    labRegionChannel->setToolPanel(this);
     labRegionChannel->append(M("TP_COLORTONING_LABREGION_CHANNEL_ALL"));
     labRegionChannel->append(M("TP_COLORTONING_LABREGION_CHANNEL_R"));
     labRegionChannel->append(M("TP_COLORTONING_LABREGION_CHANNEL_G"));
@@ -494,7 +497,9 @@ ColorToning::ColorToning () : FoldableToolPanel(this, TOOL_NAME, M("TP_COLORTONI
     labRegionMaskBlur->setAdjusterListener(this);
     labRegionBox->pack_start(*labRegionMaskBlur);
 
-    labRegionShowMask = Gtk::manage(new Gtk::CheckButton(M("TP_COLORTONING_LABREGION_SHOWMASK")));
+    labRegionShowMask = Gtk::manage(new MyCheckButton(M("TP_COLORTONING_LABREGION_SHOWMASK")));
+    labRegionShowMask->setToolPanel(this);
+    labRegionShowMask->setEnableOnlyWhenActivated(true);
     labRegionShowMask->signal_toggled().connect(sigc::mem_fun(*this, &ColorToning::labRegionShowMaskChanged));
     labRegionBox->pack_start(*labRegionShowMask, Gtk::PACK_SHRINK, 4);
 
@@ -800,6 +805,7 @@ void ColorToning::write (ProcParams* pp, ParamsEdited* pedited)
 
 void ColorToning::lumamodeChanged ()
 {
+    enableTool();
 
     if (batchMode) {
         if (lumamode->get_inconsistent()) {
@@ -1316,6 +1322,7 @@ void ColorToning::autosatChanged ()
                 listener->panelChanged (EvColorToningautosat, M("GENERAL_ENABLED"));
             }
 
+            enableTool();
             saturatedOpacity->set_sensitive(false);
             satProtectionThreshold->set_sensitive(false);
         } else {
@@ -1531,9 +1538,6 @@ void ColorToning::labRegionCopyPressed()
 
 void ColorToning::labRegionShowMaskChanged()
 {
-    if (labRegionShowMask->get_active()) {
-        enableTool();
-    }
     if (listener) {
         listener->panelChanged(EvLabRegionShowMask, labRegionShowMask->get_active() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
     }

--- a/rtgui/tools/colortoning.h
+++ b/rtgui/tools/colortoning.h
@@ -166,7 +166,7 @@ private:
     FlatCurveEditor *labRegionChromaticityMask;
     FlatCurveEditor *labRegionLightnessMask;
     Adjuster *labRegionMaskBlur;
-    Gtk::CheckButton *labRegionShowMask;
+    MyCheckButton *labRegionShowMask;
     std::vector<rtengine::procparams::ColorToningParams::LabCorrectionRegion> labRegionData;
     int labRegionSelected;
     sigc::connection labRegionSelectionConn;

--- a/rtgui/tools/colortoning.h
+++ b/rtgui/tools/colortoning.h
@@ -10,6 +10,7 @@
 #include "guiutils.h"
 #include "toolpanel.h"
 #include "widgets/basic/adjuster.h"
+#include "widgets/basic/checkbox.h"
 #include "widgets/basic/thresholdadjuster.h"
 
 #include "rtengine/procparams.h"
@@ -27,7 +28,8 @@ class ColorToning final :
     public CurveListener,
     public ColorProvider,
     public ThresholdAdjusterListener,
-    public AdjusterListener
+    public AdjusterListener,
+    public CheckBoxListener
 {
 public:
     static const Glib::ustring TOOL_NAME;
@@ -54,12 +56,11 @@ public:
 
     void enabledChanged        () override;
     void curveChanged          (CurveEditor* ce) override;
-    void autosatChanged        ();
+    void checkBoxToggled       (CheckBox* c, CheckValue newval) override;
     void autoOpenCurve         () override;
     void methodChanged         ();
     void twocolorChanged       (bool changedbymethod);
     void twoColorChangedByGui  ();
-    void lumamodeChanged       ();
 
     void colorForValue         (double valX, double valY, enum ColorCaller::ElemType elemType, int callerId, ColorCaller* caller) override;
 
@@ -108,7 +109,7 @@ private:
     Adjuster* greenhigh;
     Adjuster* bluehigh;
     Adjuster* balance;
-    Gtk::CheckButton* autosat;
+    CheckBox* autosat;
     ThresholdAdjuster* shadowsColSat;
     ThresholdAdjuster* hlColSat;
     Adjuster* satProtectionThreshold;
@@ -125,12 +126,8 @@ private:
     Glib::ustring nextbalcolor;
     Glib::ustring balcolor;
     sigc::connection neutralconn, twocconn; //, neutralcurvesconn;
-    bool lastautosat;
-    sigc::connection autosatConn;
 
-    Gtk::CheckButton* lumamode;
-    bool lastLumamode;
-    sigc::connection lumamodeConn;
+    CheckBox* lumamode;
 
     rtengine::ProcEvent EvColorToningLabGridValue;
     LabGrid *labgrid;

--- a/rtgui/tools/compressgamut.cc
+++ b/rtgui/tools/compressgamut.cc
@@ -83,6 +83,7 @@ Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPR
     Gtk::Box *iVBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
    
     colorspace = Gtk::manage(new MyComboBoxText());
+    colorspace->setToolPanel(this);
     for (const auto& item : COLORSPACE_LIST_ITEMS) {
         colorspace->append(M(item.translationName));
     }
@@ -154,7 +155,8 @@ Compressgamut::Compressgamut () : FoldableToolPanel(this, TOOL_NAME, M("TP_COMPR
     pack_start(*limFrame, Gtk::PACK_SHRINK);
 
     // Aggressiveness of the compression curve Pwr
-    rolloff = Gtk::manage(new Gtk::CheckButton(M("TP_COMPRESSGAMUT_ROLLOFF")));
+    rolloff = Gtk::manage(new MyCheckButton(M("TP_COMPRESSGAMUT_ROLLOFF")));
+    rolloff->setToolPanel(this);
     pwr = Gtk::manage (new Adjuster (M("TP_COMPRESSGAMUT_PWR"), 0.2, 2.0, 0.01, 1.2));
     rolloffconn = rolloff->signal_toggled().connect (sigc::mem_fun (*this, &Compressgamut::rolloff_change));
 

--- a/rtgui/tools/compressgamut.h
+++ b/rtgui/tools/compressgamut.h
@@ -50,7 +50,7 @@ protected:
 
     MyComboBoxText *colorspace;
     sigc::connection colorspaceconn;
-    Gtk::CheckButton* rolloff;
+    MyCheckButton* rolloff;
     sigc::connection rolloffconn;
     bool lastrolloff;
     rtengine::ProcEvent EvcgColorspace;

--- a/rtgui/tools/crop.cc
+++ b/rtgui/tools/crop.cc
@@ -120,6 +120,7 @@ Crop::Crop():
     x = Gtk::manage (new MySpinButton ());
     setExpandAlignProperties(x, true, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
     x->set_width_chars(6);
+    x->setToolPanel(this);
 
     Gtk::Label* ylab = Gtk::manage (new Gtk::Label (M("TP_CROP_Y") + ":"));
     setExpandAlignProperties(ylab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -127,6 +128,7 @@ Crop::Crop():
     y = Gtk::manage (new MySpinButton ());
     setExpandAlignProperties(y, true, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
     y->set_width_chars(6);
+    y->setToolPanel(this);
 
     Gtk::Label* wlab = Gtk::manage (new Gtk::Label (M("TP_CROP_W") + ":"));
     setExpandAlignProperties(wlab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -134,6 +136,7 @@ Crop::Crop():
     w = Gtk::manage (new MySpinButton ());
     setExpandAlignProperties(w, true, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
     w->set_width_chars(6);
+    w->setToolPanel(this);
 
     Gtk::Label* hlab = Gtk::manage (new Gtk::Label (M("TP_CROP_H") + ":"));
     setExpandAlignProperties(hlab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
@@ -141,6 +144,7 @@ Crop::Crop():
     h = Gtk::manage (new MySpinButton ());
     setExpandAlignProperties(h, true, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
     h->set_width_chars(6);
+    h->setToolPanel(this);
 
     selectCrop = Gtk::manage (new Gtk::Button (M("TP_CROP_SELECTCROP")));
     setExpandAlignProperties(selectCrop, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
@@ -181,9 +185,11 @@ Crop::Crop():
     setExpandAlignProperties(ratiogrid, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
     ratio = Gtk::manage (new MyComboBoxText ());
+    ratio->setToolPanel(this);
     setExpandAlignProperties(ratio, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
     orientation = Gtk::manage (new MyComboBoxText ());
+    orientation->setToolPanel(this);
     setExpandAlignProperties(orientation, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
     customRatioLabel = Gtk::manage(new Gtk::Label(""));
@@ -199,6 +205,7 @@ Crop::Crop():
     setExpandAlignProperties(guidelab, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
     guide = Gtk::manage (new MyComboBoxText ());
+    guide->setToolPanel(this);
     setExpandAlignProperties(guide, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
 
     settingsgrid->attach (*fixr, 0, 0, 1, 1);

--- a/rtgui/tools/dehaze.cc
+++ b/rtgui/tools/dehaze.cc
@@ -52,7 +52,9 @@ Dehaze::Dehaze(): FoldableToolPanel(this, TOOL_NAME, M("TP_DEHAZE_LABEL"), false
     saturation->setAdjusterListener(this);
     saturation->show();
 
-    showDepthMap = Gtk::manage(new Gtk::CheckButton(M("TP_DEHAZE_SHOW_DEPTH_MAP")));
+    showDepthMap = Gtk::manage(new MyCheckButton(M("TP_DEHAZE_SHOW_DEPTH_MAP")));
+    showDepthMap->setToolPanel(this);
+    showDepthMap->setEnableOnlyWhenActivated(true);
     showDepthMap->signal_toggled().connect(sigc::mem_fun(*this, &Dehaze::showDepthMapChanged));
     showDepthMap->show();
     
@@ -147,7 +149,6 @@ void Dehaze::showDepthMapChanged()
 {
     if (listener) {
       if(showDepthMap->get_active()) {
-        enableTool();
         listener->panelChanged(EvDehazeShowDepthMap, M("GENERAL_ENABLED"));
       } else {
         listener->panelChanged(EvDehazeShowDepthMap, M("GENERAL_DISABLED"));

--- a/rtgui/tools/dehaze.cc
+++ b/rtgui/tools/dehaze.cc
@@ -146,7 +146,12 @@ void Dehaze::enabledChanged ()
 void Dehaze::showDepthMapChanged()
 {
     if (listener) {
-        listener->panelChanged(EvDehazeShowDepthMap, showDepthMap->get_active() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+      if(showDepthMap->get_active()) {
+        enableTool();
+        listener->panelChanged(EvDehazeShowDepthMap, M("GENERAL_ENABLED"));
+      } else {
+        listener->panelChanged(EvDehazeShowDepthMap, M("GENERAL_DISABLED"));
+      }
     }
 }
 

--- a/rtgui/tools/dehaze.h
+++ b/rtgui/tools/dehaze.h
@@ -30,7 +30,7 @@ private:
     Adjuster *strength;
     Adjuster *depth;
     Adjuster *saturation;
-    Gtk::CheckButton *showDepthMap;
+    MyCheckButton *showDepthMap;
 //    Gtk::CheckButton *luminance;
 
     rtengine::ProcEvent EvDehazeEnabled;

--- a/rtgui/tools/dirpyrdenoise.cc
+++ b/rtgui/tools/dirpyrdenoise.cc
@@ -63,6 +63,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     ctboxL->pack_start (*labmL, Gtk::PACK_SHRINK, 1);
 
     Lmethod = Gtk::manage (new MyComboBoxText ());
+    Lmethod->setToolPanel(this);
     Lmethod->append (M("CURVEEDITOR_CURVE"));
     Lmethod->append (M("GENERAL_SLIDER"));
     Lmethod->set_active(0);
@@ -99,6 +100,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     ctboxC->pack_start (*labmC, Gtk::PACK_SHRINK, 1);
 
     Cmethod = Gtk::manage (new MyComboBoxText ());
+    Cmethod->setToolPanel(this);
     Cmethod->append (M("TP_DIRPYRDENOISE_CHROMINANCE_MANUAL"));
     Cmethod->append (M("TP_DIRPYRDENOISE_CHROMINANCE_AUTOGLOBAL"));
     Cmethod->append (M("TP_DIRPYRDENOISE_CHROMINANCE_AMZ"));
@@ -113,6 +115,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     ctboxC2->set_tooltip_markup (M("TP_DIRPYRDENOISE_CHROMINANCE_METHODADVANCED_TOOLTIP"));
 
     C2method = Gtk::manage (new MyComboBoxText ());
+    C2method->setToolPanel(this);
     C2method->append (M("TP_DIRPYRDENOISE_CHROMINANCE_MANUAL"));
     C2method->append (M("TP_DIRPYRDENOISE_CHROMINANCE_AUTOGLOBAL"));
     C2method->append (M("TP_DIRPYRDENOISE_CHROMINANCE_PREVIEW"));
@@ -134,6 +137,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     hb1->set_tooltip_markup (M("TP_DIRPYRDENOISE_MAIN_COLORSPACE_TOOLTIP"));
 
     dmethod = Gtk::manage (new MyComboBoxText ());
+    dmethod->setToolPanel(this);
     dmethod->append (M("TP_DIRPYRDENOISE_MAIN_COLORSPACE_LAB"));
     dmethod->append (M("TP_DIRPYRDENOISE_MAIN_COLORSPACE_RGB"));
     dmethod->set_active(0);
@@ -182,6 +186,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     medianFrame->set_label_widget(*median);
 
     methodmed = Gtk::manage (new MyComboBoxText ());
+    methodmed->setToolPanel(this);
     methodmed->append (M("TP_DIRPYRDENOISE_MEDIAN_METHOD_LUMINANCE"));
     methodmed->append (M("TP_DIRPYRDENOISE_MEDIAN_METHOD_CHROMINANCE"));
     methodmed->append (M("TP_DIRPYRDENOISE_MEDIAN_METHOD_WEIGHTED"));
@@ -192,6 +197,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     methodmedconn = methodmed->signal_changed().connect ( sigc::mem_fun(*this, &DirPyrDenoise::methodmedChanged) );
 
     rgbmethod = Gtk::manage (new MyComboBoxText ());
+    rgbmethod->setToolPanel(this);
     rgbmethod->append (M("TP_DIRPYRDENOISE_TYPE_3X3SOFT"));
     rgbmethod->append (M("TP_DIRPYRDENOISE_TYPE_3X3"));
     rgbmethod->append (M("TP_DIRPYRDENOISE_TYPE_5X5SOFT"));
@@ -201,6 +207,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
 
 
     medmethod = Gtk::manage (new MyComboBoxText ());
+    medmethod->setToolPanel(this);
     medmethod->append (M("TP_DIRPYRDENOISE_TYPE_3X3SOFT"));
     medmethod->append (M("TP_DIRPYRDENOISE_TYPE_3X3"));
     medmethod->append (M("TP_DIRPYRDENOISE_TYPE_5X5SOFT"));
@@ -228,6 +235,7 @@ DirPyrDenoise::DirPyrDenoise () : FoldableToolPanel(this, TOOL_NAME, M("TP_DIRPY
     hb11->set_tooltip_markup (M("TP_DIRPYRDENOISE_MAIN_MODE_TOOLTIP"));
 
     smethod = Gtk::manage (new MyComboBoxText ());
+    smethod->setToolPanel(this);
     smethod->append (M("TP_DIRPYRDENOISE_MAIN_MODE_CONSERVATIVE"));
     smethod->append (M("TP_DIRPYRDENOISE_MAIN_MODE_AGGRESSIVE"));
     smethod->set_active(1);

--- a/rtgui/tools/dirpyrequalizer.cc
+++ b/rtgui/tools/dirpyrequalizer.cc
@@ -64,6 +64,7 @@ DirPyrEqualizer::DirPyrEqualizer () : FoldableToolPanel(this, TOOL_NAME, M("TP_D
     cdbox->pack_start (*labmcd, Gtk::PACK_SHRINK, 1);
 
     cbdlMethod = Gtk::manage (new MyComboBoxText ());
+    cbdlMethod->setToolPanel(this);
     cbdlMethod->append (M("TP_CBDL_BEF"));
     cbdlMethod->append (M("TP_CBDL_AFT"));
     cbdlMethod->set_active(0);
@@ -78,15 +79,17 @@ DirPyrEqualizer::DirPyrEqualizer () : FoldableToolPanel(this, TOOL_NAME, M("TP_D
     buttonBox1->set_homogeneous(true);
     pack_start(*buttonBox1);
 
-    Gtk::Button * lumacontrastMinusButton = Gtk::manage (new Gtk::Button(M("TP_DIRPYREQUALIZER_LUMACONTRAST_MINUS")));
+    MyButton * lumacontrastMinusButton = Gtk::manage (new MyButton(M("TP_DIRPYREQUALIZER_LUMACONTRAST_MINUS")));
+    lumacontrastMinusButton->setToolPanel(this);
     buttonBox1->pack_start(*lumacontrastMinusButton);
     lumacontrastMinusPressedConn = lumacontrastMinusButton->signal_pressed().connect( sigc::mem_fun(*this, &DirPyrEqualizer::lumacontrastMinusPressed));
 
-    Gtk::Button * lumaneutralButton = Gtk::manage (new Gtk::Button(M("TP_DIRPYREQUALIZER_LUMANEUTRAL")));
+    MyButton * lumaneutralButton = Gtk::manage (new MyButton(M("TP_DIRPYREQUALIZER_LUMANEUTRAL")));
     buttonBox1->pack_start(*lumaneutralButton);
     lumaneutralPressedConn = lumaneutralButton->signal_pressed().connect( sigc::mem_fun(*this, &DirPyrEqualizer::lumaneutralPressed));
 
-    Gtk::Button * lumacontrastPlusButton = Gtk::manage (new Gtk::Button(M("TP_DIRPYREQUALIZER_LUMACONTRAST_PLUS")));
+    MyButton * lumacontrastPlusButton = Gtk::manage (new MyButton(M("TP_DIRPYREQUALIZER_LUMACONTRAST_PLUS")));
+    lumacontrastPlusButton->setToolPanel(this);
     buttonBox1->pack_start(*lumacontrastPlusButton);
     lumacontrastPlusPressedConn = lumacontrastPlusButton->signal_pressed().connect( sigc::mem_fun(*this, &DirPyrEqualizer::lumacontrastPlusPressed));
 
@@ -146,7 +149,8 @@ DirPyrEqualizer::DirPyrEqualizer () : FoldableToolPanel(this, TOOL_NAME, M("TP_D
     pack_start(*skinprotect);
     skinprotect->set_tooltip_markup (M("TP_DIRPYREQUALIZER_SKIN_TOOLTIP"));
 
-    gamutlab = Gtk::manage (new Gtk::CheckButton (M("TP_DIRPYREQUALIZER_ARTIF")));
+    gamutlab = Gtk::manage (new MyCheckButton (M("TP_DIRPYREQUALIZER_ARTIF")));
+    gamutlab->setToolPanel(this);
     gamutlab->set_active (true);
     pack_start(*gamutlab);
     gamutlabConn = gamutlab->signal_toggled().connect( sigc::mem_fun(*this, &DirPyrEqualizer::gamutlabToggled) );

--- a/rtgui/tools/dirpyrequalizer.cc
+++ b/rtgui/tools/dirpyrequalizer.cc
@@ -433,7 +433,6 @@ void DirPyrEqualizer::lumaneutralPressed ()
 
 void DirPyrEqualizer::lumacontrastPlusPressed ()
 {
-    enableTool(); // Enable Tool if Disabled
     for (int i = 0; i < 6; i++) {
         double inc = 0.05 * (6 - i);
         multiplier[i]->setValue(multiplier[i]->getValue() + inc);
@@ -444,7 +443,6 @@ void DirPyrEqualizer::lumacontrastPlusPressed ()
 
 void DirPyrEqualizer::lumacontrastMinusPressed ()
 {
-    enableTool(); // Enable Tool if Disabled
     for (int i = 0; i < 6; i++) {
         double inc = -0.05 * (6 - i);
         multiplier[i]->setValue(multiplier[i]->getValue() + inc);

--- a/rtgui/tools/dirpyrequalizer.cc
+++ b/rtgui/tools/dirpyrequalizer.cc
@@ -420,7 +420,6 @@ void DirPyrEqualizer::gamutlabToggled ()
 
 void DirPyrEqualizer::lumaneutralPressed ()
 {
-
     for (int i = 0; i < 6; i++) {
         multiplier[i]->setValue(1.0);
         adjusterChanged(multiplier[i], 1.0);
@@ -430,7 +429,7 @@ void DirPyrEqualizer::lumaneutralPressed ()
 
 void DirPyrEqualizer::lumacontrastPlusPressed ()
 {
-
+    enableTool(); // Enable Tool if Disabled
     for (int i = 0; i < 6; i++) {
         double inc = 0.05 * (6 - i);
         multiplier[i]->setValue(multiplier[i]->getValue() + inc);
@@ -441,7 +440,7 @@ void DirPyrEqualizer::lumacontrastPlusPressed ()
 
 void DirPyrEqualizer::lumacontrastMinusPressed ()
 {
-
+    enableTool(); // Enable Tool if Disabled
     for (int i = 0; i < 6; i++) {
         double inc = -0.05 * (6 - i);
         multiplier[i]->setValue(multiplier[i]->getValue() + inc);

--- a/rtgui/tools/dirpyrequalizer.h
+++ b/rtgui/tools/dirpyrequalizer.h
@@ -34,7 +34,7 @@ class DirPyrEqualizer final :
 
 protected:
 
-    Gtk::CheckButton * gamutlab;
+    MyCheckButton * gamutlab;
     Adjuster* multiplier[6];
     Adjuster* threshold;
     Adjuster* skinprotect;

--- a/rtgui/tools/filmnegative.cc
+++ b/rtgui/tools/filmnegative.cc
@@ -224,7 +224,6 @@ FilmNegative::FilmNegative() :
 //    refInputLabel->set_justify(Gtk::Justification::JUSTIFY_CENTER);
 //    refInputLabel->set_line_wrap(true);
 
-
     colorSpace->append(M("TP_FILMNEGATIVE_COLORSPACE_INPUT"));
     colorSpace->append(M("TP_FILMNEGATIVE_COLORSPACE_WORKING"));
     setExpandAlignProperties(colorSpace, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
@@ -238,6 +237,7 @@ FilmNegative::FilmNegative() :
     pack_start(*csGrid);
 
     colorSpace->set_active((int)ColorSpace::WORKING);
+    colorSpace->setToolPanel(this);
     colorSpace->signal_changed().connect(sigc::mem_fun(*this, &FilmNegative::colorSpaceChanged));
     colorSpace->show();
 

--- a/rtgui/tools/filmnegative.cc
+++ b/rtgui/tools/filmnegative.cc
@@ -548,6 +548,7 @@ bool FilmNegative::mouseOver(int modifierKey)
 
 bool FilmNegative::button1Pressed(int modifierKey)
 {
+    enableTool();
     EditDataProvider* const provider = getEditProvider();
 
     EditSubscriber::action = EditSubscriber::Action::NONE;

--- a/rtgui/tools/filmsimulation.cc
+++ b/rtgui/tools/filmsimulation.cc
@@ -66,7 +66,7 @@ FilmSimulation::FilmSimulation()
     :   FoldableToolPanel( this, TOOL_NAME, M("TP_FILMSIMULATION_LABEL"), false, true )
 {
     m_clutComboBox = Gtk::manage( new ClutComboBox(App::get().options().clutsDir) );
-
+    m_clutComboBox->setListener(this);
     int foundClutsCount = m_clutComboBox->foundClutsCount();
 
     if ( foundClutsCount == 0 ) {
@@ -86,7 +86,9 @@ FilmSimulation::FilmSimulation()
 void FilmSimulation::onClutSelected()
 {
     Glib::ustring currentClutFilename = m_clutComboBox->getSelectedClut();
-
+    if (!currentClutFilename.empty() && currentClutFilename != "NULL") {
+        m_clutComboBox->tryEnableTool();
+    }
     if ( getEnabled() && !currentClutFilename.empty() && listener && currentClutFilename != m_oldClutFilename ) {
         Glib::ustring clutName, dummy;
         HaldCLUT::splitClutFilename( currentClutFilename, clutName, dummy, dummy );
@@ -210,7 +212,8 @@ std::unique_ptr<ClutComboBox::ClutModel> ClutComboBox::cm2;
 
 ClutComboBox::ClutComboBox(const Glib::ustring &path):
     MyComboBox(),
-    batchMode(false)
+    batchMode(false),
+    listener(nullptr)
 {
     if (!cm) {
         cm.reset(new ClutModel(path));
@@ -464,4 +467,15 @@ Gtk::TreeIter ClutComboBox::findRowByClutFilename( Gtk::TreeModel::Children chil
     }
 
     return result;
+}
+void ClutComboBox::setListener(FoldableToolPanel* l)
+{
+    listener = l;
+}
+void ClutComboBox::tryEnableTool()
+{
+    if (!listener) {
+        return;
+    }
+    listener->enableTool();
 }

--- a/rtgui/tools/filmsimulation.h
+++ b/rtgui/tools/filmsimulation.h
@@ -20,6 +20,8 @@ public:
     Glib::ustring getSelectedClut();
     void setSelectedClut( Glib::ustring filename );
     void setBatchMode(bool yes);
+    void setListener(FoldableToolPanel* listener);
+    void tryEnableTool();
 
     static void cleanup();
 
@@ -51,6 +53,7 @@ private:
     static std::unique_ptr<ClutModel> cm; // we use a shared TreeModel for all the combo boxes, to save time (no need to reparse the clut dir multiple times)...
     static std::unique_ptr<ClutModel> cm2; // ... except when options.multiDisplayMode (i.e. editors in their own window), where we need two. This is because we might have two combo boxes displayed at the same time in this case
     bool batchMode;
+    FoldableToolPanel* listener;
 };
 
 class FilmSimulation : public ToolParamBlock, public AdjusterListener, public FoldableToolPanel

--- a/rtgui/tools/framing.cc
+++ b/rtgui/tools/framing.cc
@@ -357,6 +357,7 @@ void Framing::setupFramingMethodGui()
     combos->set_row_spacing(ROW_SPACING);
 
     framingMethod = Gtk::manage(new MyComboBoxText());
+    framingMethod->setToolPanel(this);
     for (auto label : FRAMING_METHODS) {
         framingMethod->append(M(label));
     }
@@ -369,6 +370,7 @@ void Framing::setupFramingMethodGui()
 
     aspectRatioLabel = createGridLabel("TP_FRAMING_ASPECT_RATIO");
     aspectRatio = Gtk::manage(new MyComboBoxText());
+    aspectRatio->setToolPanel(this);
     aspectRatioData->fillCombo(aspectRatio);
     aspectRatio->set_hexpand();
     aspectRatio->set_halign(Gtk::ALIGN_FILL);
@@ -378,6 +380,7 @@ void Framing::setupFramingMethodGui()
 
     orientationLabel = createGridLabel("TP_FRAMING_ORIENTATION");
     orientation = Gtk::manage(new MyComboBoxText());
+    orientation->setToolPanel(this);
     for (auto label : ORIENTATION) {
         orientation->append(M(label));
     }
@@ -392,11 +395,14 @@ void Framing::setupFramingMethodGui()
     width = DimensionGui(this, "TP_FRAMING_FRAMED_WIDTH");
     width.setRange(Resize::MIN_SIZE, Resize::MAX_SCALE * imgWidth);
     width.setValue(imgWidth);
+    width.value->setToolPanel(this);
     height = DimensionGui(this, "TP_FRAMING_FRAMED_HEIGHT");
     height.setRange(Resize::MIN_SIZE, Resize::MAX_SCALE * imgHeight);
     height.setValue(imgHeight);
+    height.value->setToolPanel(this);
 
-    allowUpscaling = Gtk::manage(new Gtk::CheckButton(M("TP_FRAMING_ALLOW_UPSCALING")));
+    allowUpscaling = Gtk::manage(new MyCheckButton(M("TP_FRAMING_ALLOW_UPSCALING")));
+    allowUpscaling->setToolPanel(this);
     pack_start(*allowUpscaling);
 
     updateFramingMethodGui();
@@ -419,6 +425,7 @@ void Framing::setupBorderSizeGui()
     combos->set_row_spacing(ROW_SPACING);
 
     borderSizeMethod = Gtk::manage(new MyComboBoxText());
+    borderSizeMethod->setToolPanel(this);
     for (auto label : BORDER_SIZE_METHODS) {
         borderSizeMethod->append(M(label));
     }
@@ -431,6 +438,7 @@ void Framing::setupBorderSizeGui()
 
     basisLabel = createGridLabel("TP_FRAMING_BASIS");
     basis = Gtk::manage(new MyComboBoxText());
+    basis->setToolPanel(this);
     for (auto label : BORDER_SIZE_BASIS) {
         basis->append(M(label));
     }
@@ -448,7 +456,8 @@ void Framing::setupBorderSizeGui()
 
     minSizeFrame = Gtk::manage(new Gtk::Frame());
     minSizeFrame->set_label_align(FRAME_LABEL_ALIGN_X, FRAME_LABEL_ALIGN_Y);
-    minSizeEnabled = Gtk::manage(new Gtk::CheckButton(M("TP_FRAMING_LIMIT_MINIMUM")));
+    minSizeEnabled = Gtk::manage(new MyCheckButton(M("TP_FRAMING_LIMIT_MINIMUM")));
+    minSizeEnabled->setToolPanel(this);
     minSizeFrame->set_label_widget(*minSizeEnabled);
 
     minSizeFrameContent = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
@@ -456,9 +465,11 @@ void Framing::setupBorderSizeGui()
     minWidth = DimensionGui(minSizeFrameContent, "TP_FRAMING_MIN_WIDTH");
     minWidth.setRange(0, imgWidth);
     minWidth.setValue(0);
+    minWidth.value->setToolPanel(this);
     minHeight = DimensionGui(minSizeFrameContent, "TP_FRAMING_MIN_HEIGHT");
     minHeight.setRange(0, imgHeight);
     minHeight.setValue(0);
+    minHeight.value->setToolPanel(this);
 
     minSizeFrame->add(*minSizeFrameContent);
     pack_start(*minSizeFrame);
@@ -466,9 +477,11 @@ void Framing::setupBorderSizeGui()
     absWidth = DimensionGui(this, "TP_FRAMING_ABSOLUTE_WIDTH");
     absWidth.setRange(0, imgWidth);
     absWidth.setValue(0);
+    absWidth.value->setToolPanel(this);
     absHeight = DimensionGui(this, "TP_FRAMING_ABSOLUTE_HEIGHT");
     absHeight.setRange(0, imgHeight);
     absHeight.setValue(0);
+    absHeight.value->setToolPanel(this);
 
     updateBorderSizeGui();
 

--- a/rtgui/tools/framing.h
+++ b/rtgui/tools/framing.h
@@ -124,7 +124,7 @@ private:
     sigc::connection orientationChanged;
     DimensionGui width;
     DimensionGui height;
-    Gtk::CheckButton* allowUpscaling;
+    MyCheckButton* allowUpscaling;
     sigc::connection allowUpscalingConnection;
 
     // Border sizing
@@ -136,7 +136,7 @@ private:
     Adjuster* relativeBorderSize;
     Gtk::Frame* minSizeFrame;
     Gtk::Box* minSizeFrameContent;
-    Gtk::CheckButton* minSizeEnabled;
+    MyCheckButton* minSizeEnabled;
     sigc::connection minSizeEnabledConnection;
     DimensionGui minWidth;
     DimensionGui minHeight;

--- a/rtgui/tools/gradient.cc
+++ b/rtgui/tools/gradient.cc
@@ -338,6 +338,7 @@ void Gradient::setEditProvider (EditDataProvider* provider)
 void Gradient::editToggled ()
 {
     if (edit->get_active()) {
+        enableTool();
         subscribe();
     } else {
         releaseEdit();

--- a/rtgui/tools/icmpanel.cc
+++ b/rtgui/tools/icmpanel.cc
@@ -590,6 +590,7 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     pyrwavtrc->setAdjusterListener(this);
     residtrc->setAdjusterListener(this);
 
+
     trcmaxdata->set_line_wrap();
     trcmaxdata->set_justify(Gtk::Justification::JUSTIFY_CENTER);
     setExpandAlignProperties(trcmaxdata, true, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_START);
@@ -645,6 +646,7 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     primExp->setLevel (2);
 
     trcExp->add(*trcProfVBox, false);
+    registerExpanders(trcExp, {trcExp}); // walk full tree now that hierarchy is assembled
     trcExp->show_all();
     trcExp->set_expanded(false);
     trcExp->set_no_show_all();
@@ -2980,6 +2982,10 @@ void ICMPanel::wavExpChanged()
 
 void ICMPanel::fbwChanged()
 {
+    enableTool();
+    if (trcExp->getUseEnabled() && !trcExp->getEnabled()) {
+        trcExp->setEnabled(true);
+    }
     if (multiImage) {
         if (fbw->get_inconsistent()) {
             fbw->set_inconsistent(false);

--- a/rtgui/tools/icmpanel.cc
+++ b/rtgui/tools/icmpanel.cc
@@ -100,7 +100,7 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     EvICMwgamgain = m->newEvent(LUMINANCECURVE, "HISTORY_MSG_ICM_WGAMUTGAIN");
     auto& options = App::get().mut_options();
 
-    isBatchMode = lastToneCurve = lastApplyLookTable = lastApplyBaselineExposureOffset = lastApplyHueSatMap = false;
+    isBatchMode = false;
 
     ipDialog = Gtk::manage(new MyFileChooserButton(M("TP_ICM_INPUTDLGLABEL"), Gtk::FILE_CHOOSER_ACTION_OPEN));
     ipDialog->set_tooltip_text(M("TP_ICM_INPUTCUSTOM_TOOLTIP"));
@@ -177,24 +177,28 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     dcpIllGrid->attach_next_to(*dcpIllLabel, Gtk::POS_LEFT, 1, 1);
     dcpIllGrid->attach_next_to(*dcpIll, *dcpIllLabel, Gtk::POS_RIGHT, 1, 1);
 
-    ckbToneCurve = Gtk::manage(new Gtk::CheckButton(M("TP_ICM_TONECURVE")));
+    ckbToneCurve = Gtk::manage(new CheckBox(M("TP_ICM_TONECURVE"), multiImage));
     ckbToneCurve->set_sensitive(false);
     ckbToneCurve->set_tooltip_text(M("TP_ICM_TONECURVE_TOOLTIP"));
+    ckbToneCurve->setCheckBoxListener(this);
     setExpandAlignProperties(ckbToneCurve, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    ckbApplyLookTable = Gtk::manage(new Gtk::CheckButton(M("TP_ICM_APPLYLOOKTABLE")));
+    ckbApplyLookTable = Gtk::manage(new CheckBox(M("TP_ICM_APPLYLOOKTABLE"), multiImage));
     ckbApplyLookTable->set_sensitive(false);
     ckbApplyLookTable->set_tooltip_text(M("TP_ICM_APPLYLOOKTABLE_TOOLTIP"));
+    ckbApplyLookTable->setCheckBoxListener(this);
     setExpandAlignProperties(ckbApplyLookTable, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    ckbApplyHueSatMap = Gtk::manage(new Gtk::CheckButton(M("TP_ICM_APPLYHUESATMAP")));
+    ckbApplyHueSatMap = Gtk::manage(new CheckBox(M("TP_ICM_APPLYHUESATMAP"), multiImage));
     ckbApplyHueSatMap->set_sensitive(false);
     ckbApplyHueSatMap->set_tooltip_text(M("TP_ICM_APPLYHUESATMAP_TOOLTIP"));
+    ckbApplyHueSatMap->setCheckBoxListener(this);
     setExpandAlignProperties(ckbApplyHueSatMap, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
-    ckbApplyBaselineExposureOffset = Gtk::manage(new Gtk::CheckButton(M("TP_ICM_APPLYBASELINEEXPOSUREOFFSET")));
+    ckbApplyBaselineExposureOffset = Gtk::manage(new CheckBox(M("TP_ICM_APPLYBASELINEEXPOSUREOFFSET"), multiImage));
     ckbApplyBaselineExposureOffset->set_sensitive(false);
     ckbApplyBaselineExposureOffset->set_tooltip_text(M("TP_ICM_APPLYBASELINEEXPOSUREOFFSET_TOOLTIP"));
+    ckbApplyBaselineExposureOffset->setCheckBoxListener(this);
     setExpandAlignProperties(ckbApplyBaselineExposureOffset, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
     dcpGrid->attach_next_to(*dcpIllGrid, Gtk::POS_BOTTOM, 1, 1);
@@ -280,7 +284,8 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     wSlope = Gtk::manage(new Adjuster(M("TP_ICM_WORKING_TRC_SLOPE"), 0., 300., 0.01, 12.92));//defautl sRGB
     wapsat = Gtk::manage(new Adjuster(M("TP_ICM_WORKING_TRC_SAT"), 0., 2., 0.1, 0.5));//saturation slider
     wmidtcie = Gtk::manage(new Adjuster(M("TP_LOCALLAB_MIDTCIEMAIN"), -100., 100., 1., 0.));
-    wsmoothcie = Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE")));//highlights
+    wsmoothcie = Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE"), multiImage));//highlights
+    wsmoothcie->setCheckBoxListener(this);
     wsmoothciesli = Gtk::manage(new Adjuster(M("TP_LOCALLAB_SMOOTHCIETH"), 0., 1.5, 0.01, 0.));
     trcProfVBox->pack_start(*wGamma, Gtk::PACK_SHRINK);
     wGamma->show();
@@ -350,11 +355,11 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     trcProfVBox->pack_start(*wsmoothciesli, Gtk::PACK_SHRINK);
     wsmoothciesli->show();
 
-    wsmoothcieconn = wsmoothcie->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::wsmoothcieChanged));
-    wsmoothcie->set_active(false);
+    wsmoothcie->setValue(false);
 
-    fbw = Gtk::manage(new Gtk::CheckButton((M("TP_ICM_FBW"))));
-    fbw->set_active(true);
+    fbw = Gtk::manage(new CheckBox(M("TP_ICM_FBW"), multiImage));
+    fbw->setValue(true);
+    fbw->setCheckBoxListener(this);
     trcProfVBox->pack_start(*fbw, Gtk::PACK_SHRINK);
 
     wavExp = Gtk::manage(new MyExpander(true, M("TP_ICM_WAVFRAME")));//expander Contrast Enhancement
@@ -411,8 +416,9 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     wprimBox->pack_start(*wprim, Gtk::PACK_EXPAND_WIDGET);
 //    fbw = Gtk::manage(new Gtk::CheckButton((M("TP_ICM_FBW"))));
 //    fbw->set_active(true);
-    gamut = Gtk::manage(new Gtk::CheckButton((M("TP_ICM_GAMUT"))));
-    gamut->set_active(true);
+    gamut = Gtk::manage(new CheckBox(M("TP_ICM_GAMUT"), multiImage));
+    gamut->setValue(true);
+    gamut->setCheckBoxListener(this);
 
     trcPrimVBox->pack_start(*wprimBox, Gtk::PACK_EXPAND_WIDGET);
 //    trcPrimVBox->pack_start(*fbw, Gtk::PACK_EXPAND_WIDGET);
@@ -694,8 +700,9 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     oProfVBox->pack_start(*riHBox, Gtk::PACK_SHRINK);
 
     // Black Point Compensation
-    obpc = Gtk::manage(new Gtk::CheckButton((M("TP_ICM_BPC"))));
-    obpc->set_active(true);
+    obpc = Gtk::manage(new CheckBox(M("TP_ICM_BPC"), multiImage));
+    obpc->setValue(true);
+    obpc->setCheckBoxListener(this);
     oProfVBox->pack_start(*obpc, Gtk::PACK_SHRINK);
 
     oFrame->add(*oProfVBox);
@@ -743,14 +750,6 @@ ICMPanel::ICMPanel() : FoldableToolPanel(this, TOOL_NAME, M("TP_ICM_LABEL")), iu
     wprimconn = wprim->signal_changed().connect(sigc::mem_fun(*this, &ICMPanel::wprimChanged));
     wcatconn = wcat->signal_changed().connect(sigc::mem_fun(*this, &ICMPanel::wcatChanged));
     wgamutconn = wgamut->signal_changed().connect(sigc::mem_fun(*this, &ICMPanel::wgamutChanged));
-
-    fbwconn = fbw->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::fbwChanged));
-    gamutconn = gamut->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::gamutChanged));
-    obpcconn = obpc->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::oBPCChanged));
-    tcurveconn = ckbToneCurve->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::toneCurveChanged));
-    ltableconn = ckbApplyLookTable->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::applyLookTableChanged));
-    beoconn = ckbApplyBaselineExposureOffset->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::applyBaselineExposureOffsetChanged));
-    hsmconn = ckbApplyHueSatMap->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::applyHueSatMapChanged));
 
     icamera->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::ipChanged));
     icameraICC->signal_toggled().connect(sigc::mem_fun(*this, &ICMPanel::ipChanged));
@@ -1141,15 +1140,7 @@ void ICMPanel::read(const ProcParams* pp, const ParamsEdited* pedited)
 
     disableListener();
 
-    ConnectionBlocker obpcconn_(obpcconn);
-    ConnectionBlocker fbwconn_(fbwconn);
-    ConnectionBlocker gamutconn_(gamutconn);
-    ConnectionBlocker wsmoothcieconn_(wsmoothcieconn);
     ConnectionBlocker ipc_(ipc);
-    ConnectionBlocker tcurveconn_(tcurveconn);
-    ConnectionBlocker ltableconn_(ltableconn);
-    ConnectionBlocker beoconn_(beoconn);
-    ConnectionBlocker hsmconn_(hsmconn);
     ConnectionBlocker wprofnamesconn_(wprofnamesconn);
     ConnectionBlocker oprofnamesconn_(oprofnamesconn);
     ConnectionBlocker orendintentconn_(orendintentconn);
@@ -1211,8 +1202,7 @@ void ICMPanel::read(const ProcParams* pp, const ParamsEdited* pedited)
     willChanged();
     wprimChanged();
     wcatChanged();
-    gamutChanged();
-    wsmoothcieChanged();
+    wcatBox->set_sensitive(gamut->getLastActive());
 
     if (pp->icm.outputProfile == ColorManagementParams::NoICMString) {
         oProfNames->set_active_text(M("TP_ICM_NOICM"));
@@ -1228,20 +1218,16 @@ void ICMPanel::read(const ProcParams* pp, const ParamsEdited* pedited)
     aRendIntent->setSelected(pp->icm.aRendIntent);
     opacityShapeWLI->setCurve(pp->icm.opacityCurveWLI);
 
-    obpc->set_active(pp->icm.outputBPC);
-    fbw->set_active(pp->icm.fbw);
+    obpc->setValue(pp->icm.outputBPC);
+    fbw->setValue(pp->icm.fbw);
     trcExp->setEnabled(pp->icm.trcExp);
     wavExp->setEnabled(pp->icm.wavExp);
-    gamut->set_active(pp->icm.gamut);
-    wsmoothcie->set_active(pp->icm.wsmoothcie);
-    ckbToneCurve->set_active(pp->icm.toneCurve);
-    lastToneCurve = pp->icm.toneCurve;
-    ckbApplyLookTable->set_active(pp->icm.applyLookTable);
-    lastApplyLookTable = pp->icm.applyLookTable;
-    ckbApplyBaselineExposureOffset->set_active(pp->icm.applyBaselineExposureOffset);
-    lastApplyBaselineExposureOffset = pp->icm.applyBaselineExposureOffset;
-    ckbApplyHueSatMap->set_active(pp->icm.applyHueSatMap);
-    lastApplyHueSatMap = pp->icm.applyHueSatMap;
+    gamut->setValue(pp->icm.gamut);
+    wsmoothcie->setValue(pp->icm.wsmoothcie);
+    ckbToneCurve->setValue(pp->icm.toneCurve);
+    ckbApplyLookTable->setValue(pp->icm.applyLookTable);
+    ckbApplyBaselineExposureOffset->setValue(pp->icm.applyBaselineExposureOffset);
+    ckbApplyHueSatMap->setValue(pp->icm.applyHueSatMap);
 
   //  wGamma->setValue(pp->icm.workingTRCGamma);
   //  wSlope->setValue(pp->icm.workingTRCSlope);
@@ -1279,16 +1265,16 @@ void ICMPanel::read(const ProcParams* pp, const ParamsEdited* pedited)
 
     if (pedited) {
         iunchanged->set_active(!pedited->icm.inputProfile);
-        obpc->set_inconsistent(!pedited->icm.outputBPC);
-        fbw->set_inconsistent(!pedited->icm.fbw);
+        obpc->setEdited(pedited->icm.outputBPC);
+        fbw->setEdited(pedited->icm.fbw);
         trcExp->set_inconsistent(!pedited->icm.trcExp);
         wavExp->set_inconsistent(!pedited->icm.wavExp);
-        gamut->set_inconsistent(!pedited->icm.gamut);
-        wsmoothcie->set_inconsistent(!pedited->icm.wsmoothcie);
-        ckbToneCurve->set_inconsistent(!pedited->icm.toneCurve);
-        ckbApplyLookTable->set_inconsistent(!pedited->icm.applyLookTable);
-        ckbApplyBaselineExposureOffset->set_inconsistent(!pedited->icm.applyBaselineExposureOffset);
-        ckbApplyHueSatMap->set_inconsistent(!pedited->icm.applyHueSatMap);
+        gamut->setEdited(pedited->icm.gamut);
+        wsmoothcie->setEdited(pedited->icm.wsmoothcie);
+        ckbToneCurve->setEdited(pedited->icm.toneCurve);
+        ckbApplyLookTable->setEdited(pedited->icm.applyLookTable);
+        ckbApplyBaselineExposureOffset->setEdited(pedited->icm.applyBaselineExposureOffset);
+        ckbApplyHueSatMap->setEdited(pedited->icm.applyHueSatMap);
         opacityShapeWLI->setUnChanged(!pedited->icm.opacityCurveWLI);
 
         if (!pedited->icm.workingProfile) {
@@ -1745,16 +1731,16 @@ void ICMPanel::write(ProcParams* pp, ParamsEdited* pedited)
     pp->icm.wprim = ColorManagementParams::Primaries(wprim->get_active_row_number());
     pp->icm.wcat = ColorManagementParams::Cat(wcat->get_active_row_number());
 
-    pp->icm.toneCurve = ckbToneCurve->get_active();
-    pp->icm.applyLookTable = ckbApplyLookTable->get_active();
-    pp->icm.applyBaselineExposureOffset = ckbApplyBaselineExposureOffset->get_active();
-    pp->icm.applyHueSatMap = ckbApplyHueSatMap->get_active();
-    pp->icm.outputBPC = obpc->get_active();
-    pp->icm.fbw = fbw->get_active();
+    pp->icm.toneCurve = ckbToneCurve->getLastActive();
+    pp->icm.applyLookTable = ckbApplyLookTable->getLastActive();
+    pp->icm.applyBaselineExposureOffset = ckbApplyBaselineExposureOffset->getLastActive();
+    pp->icm.applyHueSatMap = ckbApplyHueSatMap->getLastActive();
+    pp->icm.outputBPC = obpc->getLastActive();
+    pp->icm.fbw = fbw->getLastActive();
     pp->icm.trcExp = trcExp->getEnabled();
     pp->icm.wavExp = wavExp->getEnabled();
-    pp->icm.gamut = gamut->get_active();
-    pp->icm.wsmoothcie = wsmoothcie->get_active();
+    pp->icm.gamut = gamut->getLastActive();
+    pp->icm.wsmoothcie = wsmoothcie->getLastActive();
  //   pp->icm.workingTRCGamma =  wGamma->getValue();
  //   pp->icm.workingTRCSlope =  wSlope->getValue();
     pp->icm.wGamma =  wGamma->getValue();
@@ -1795,17 +1781,17 @@ void ICMPanel::write(ProcParams* pp, ParamsEdited* pedited)
         pedited->icm.outputProfile = oProfNames->get_active_text() != M("GENERAL_UNCHANGED");
         pedited->icm.outputIntent = oRendIntent->getSelected() < 4;
         pedited->icm.aRendIntent = aRendIntent->getSelected() < 4;
-        pedited->icm.outputBPC = !obpc->get_inconsistent();
-        pedited->icm.fbw = !fbw->get_inconsistent();
+        pedited->icm.outputBPC = obpc->getEdited();
+        pedited->icm.fbw = fbw->getEdited();
         pedited->icm.trcExp = !trcExp->get_inconsistent();
         pedited->icm.wavExp = !wavExp->get_inconsistent();
-        pedited->icm.gamut = !gamut->get_inconsistent();
-        pedited->icm.wsmoothcie = !wsmoothcie->get_inconsistent();
+        pedited->icm.gamut = gamut->getEdited();
+        pedited->icm.wsmoothcie = wsmoothcie->getEdited();
         pedited->icm.dcpIlluminant = dcpIll->get_active_text() != M("GENERAL_UNCHANGED");
-        pedited->icm.toneCurve = !ckbToneCurve->get_inconsistent();
-        pedited->icm.applyLookTable = !ckbApplyLookTable->get_inconsistent();
-        pedited->icm.applyBaselineExposureOffset = !ckbApplyBaselineExposureOffset->get_inconsistent();
-        pedited->icm.applyHueSatMap = !ckbApplyHueSatMap->get_inconsistent();
+        pedited->icm.toneCurve = ckbToneCurve->getEdited();
+        pedited->icm.applyLookTable = ckbApplyLookTable->getEdited();
+        pedited->icm.applyBaselineExposureOffset = ckbApplyBaselineExposureOffset->getEdited();
+        pedited->icm.applyHueSatMap = ckbApplyHueSatMap->getEdited();
       //  pedited->icm.workingTRCGamma = wGamma->getEditedState();
        // pedited->icm.workingTRCSlope = wSlope->getEditedState();
         pedited->icm.wGamma = wGamma->getEditedState();
@@ -2716,110 +2702,6 @@ void ICMPanel::dcpIlluminantChanged()
     }
 }
 
-void ICMPanel::toneCurveChanged()
-{
-    if (multiImage) {
-        if (ckbToneCurve->get_inconsistent()) {
-            ckbToneCurve->set_inconsistent(false);
-            tcurveconn.block(true);
-            ckbToneCurve->set_active(false);
-            tcurveconn.block(false);
-        } else if (lastToneCurve) {
-            ckbToneCurve->set_inconsistent(true);
-        }
-
-        lastToneCurve = ckbToneCurve->get_active();
-    }
-
-    if (listener) {
-        if (ckbToneCurve->get_inconsistent()) {
-            listener->panelChanged(EvDCPToneCurve, M("GENERAL_UNCHANGED"));
-        } else if (ckbToneCurve->get_active()) {
-            listener->panelChanged(EvDCPToneCurve, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvDCPToneCurve, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
-void ICMPanel::applyLookTableChanged()
-{
-    if (multiImage) {
-        if (ckbApplyLookTable->get_inconsistent()) {
-            ckbApplyLookTable->set_inconsistent(false);
-            ltableconn.block(true);
-            ckbApplyLookTable->set_active(false);
-            ltableconn.block(false);
-        } else if (lastApplyLookTable) {
-            ckbApplyLookTable->set_inconsistent(true);
-        }
-
-        lastApplyLookTable = ckbApplyLookTable->get_active();
-    }
-
-    if (listener) {
-        if (ckbApplyLookTable->get_inconsistent()) {
-            listener->panelChanged(EvDCPApplyLookTable, M("GENERAL_UNCHANGED"));
-        } else if (ckbApplyLookTable->get_active()) {
-            listener->panelChanged(EvDCPApplyLookTable, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvDCPApplyLookTable, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
-void ICMPanel::applyBaselineExposureOffsetChanged()
-{
-    if (multiImage) {
-        if (ckbApplyBaselineExposureOffset->get_inconsistent()) {
-            ckbApplyBaselineExposureOffset->set_inconsistent(false);
-            beoconn.block(true);
-            ckbApplyBaselineExposureOffset->set_active(false);
-            beoconn.block(false);
-        } else if (lastApplyBaselineExposureOffset) {
-            ckbApplyBaselineExposureOffset->set_inconsistent(true);
-        }
-
-        lastApplyBaselineExposureOffset = ckbApplyBaselineExposureOffset->get_active();
-    }
-
-    if (listener) {
-        if (ckbApplyBaselineExposureOffset->get_inconsistent()) {
-            listener->panelChanged(EvDCPApplyBaselineExposureOffset, M("GENERAL_UNCHANGED"));
-        } else if (ckbApplyBaselineExposureOffset->get_active()) {
-            listener->panelChanged(EvDCPApplyBaselineExposureOffset, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvDCPApplyBaselineExposureOffset, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
-void ICMPanel::applyHueSatMapChanged()
-{
-    if (multiImage) {
-        if (ckbApplyHueSatMap->get_inconsistent()) {
-            ckbApplyHueSatMap->set_inconsistent(false);
-            hsmconn.block(true);
-            ckbApplyHueSatMap->set_active(false);
-            hsmconn.block(false);
-        } else if (lastApplyHueSatMap) {
-            ckbApplyHueSatMap->set_inconsistent(true);
-        }
-
-        lastApplyHueSatMap = ckbApplyHueSatMap->get_active();
-    }
-
-    if (listener) {
-        if (ckbApplyHueSatMap->get_inconsistent()) {
-            listener->panelChanged(EvDCPApplyHueSatMap, M("GENERAL_UNCHANGED"));
-        } else if (ckbApplyHueSatMap->get_active()) {
-            listener->panelChanged(EvDCPApplyHueSatMap, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvDCPApplyHueSatMap, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
 void ICMPanel::ipChanged()
 {
 
@@ -2929,32 +2811,6 @@ void ICMPanel::aiChanged(int n)
     }
 }
 
-void ICMPanel::oBPCChanged()
-{
-    if (multiImage) {
-        if (obpc->get_inconsistent()) {
-            obpc->set_inconsistent(false);
-            obpcconn.block(true);
-            obpc->set_active(false);
-            obpcconn.block(false);
-        } else if (lastobpc) {
-            obpc->set_inconsistent(true);
-        }
-
-        lastobpc = obpc->get_active();
-    }
-
-    if (listener) {
-        if (obpc->get_inconsistent()) {
-            listener->panelChanged(EvOBPCompens, M("GENERAL_UNCHANGED"));
-        } else if (obpc->get_active()) {
-            listener->panelChanged(EvOBPCompens, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvOBPCompens, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
 void ICMPanel::trcExpChanged()
 {
 
@@ -2980,93 +2836,31 @@ void ICMPanel::wavExpChanged()
 }
 
 
-void ICMPanel::fbwChanged()
+void ICMPanel::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    enableTool();
-    if (trcExp->getUseEnabled() && !trcExp->getEnabled()) {
-        trcExp->setEnabled(true);
+    if (!listener) {
+        return;
     }
-    if (multiImage) {
-        if (fbw->get_inconsistent()) {
-            fbw->set_inconsistent(false);
-            fbwconn.block(true);
-            fbw->set_active(false);
-            fbwconn.block(false);
-        } else if (lastfbw) {
-            fbw->set_inconsistent(true);
+    if (c == fbw) {
+        if (trcExp->getUseEnabled() && !trcExp->getEnabled()) {
+            trcExp->setEnabled(true);
         }
-
-        lastfbw = fbw->get_active();
-    }
-
-    if (listener) {
-        if (fbw->get_inconsistent()) {
-            listener->panelChanged(EvICMfbw, M("GENERAL_UNCHANGED"));
-        } else if (fbw->get_active()) {
-            listener->panelChanged(EvICMfbw, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvICMfbw, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
-void ICMPanel::gamutChanged()
-{
-    if (multiImage) {
-        if (gamut->get_inconsistent()) {
-            gamut->set_inconsistent(false);
-            gamutconn.block(true);
-            gamut->set_active(false);
-            gamutconn.block(false);
-        } else if (lastgamut) {
-            gamut->set_inconsistent(true);
-        }
-
-        lastgamut = gamut->get_active();
-    }
-    
-    if (gamut->get_active()) {
-        wcatBox->set_sensitive(true);
-    } else {
-        wcatBox->set_sensitive(false);
-    }
-    
-    if (listener) {
-        if (gamut->get_inconsistent()) {
-            listener->panelChanged(EvICMgamut, M("GENERAL_UNCHANGED"));
-        } else if (gamut->get_active()) {
-            listener->panelChanged(EvICMgamut, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvICMgamut, M("GENERAL_DISABLED"));
-        }
-    }
-}
-
-
-void ICMPanel::wsmoothcieChanged()
-{
-    if (multiImage) {
-        if (wsmoothcie->get_inconsistent()) {
-            wsmoothcie->set_inconsistent(false);
-            wsmoothcieconn.block(true);
-            wsmoothcie->set_active(false);
-            wsmoothcieconn.block(false);
-        } else if (lastwsmoothcie) {
-            wsmoothcie->set_inconsistent(true);
-        }
-
-        lastwsmoothcie = wsmoothcie->get_active();
-    }
-    
-    
-    if (listener) {
-        if (wsmoothcie->get_inconsistent()) {
-            listener->panelChanged(EvICMwsmoothcie, M("GENERAL_UNCHANGED"));
-        } else if (wsmoothcie->get_active()) {
-            listener->panelChanged(EvICMwsmoothcie, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged(EvICMwsmoothcie, M("GENERAL_DISABLED"));
-        }
+        listener->panelChanged(EvICMfbw, c->getValueAsStr());
+    } else if (c == gamut) {
+        wcatBox->set_sensitive(c->getLastActive());
+        listener->panelChanged(EvICMgamut, c->getValueAsStr());
+    } else if (c == obpc) {
+        listener->panelChanged(EvOBPCompens, c->getValueAsStr());
+    } else if (c == ckbToneCurve) {
+        listener->panelChanged(EvDCPToneCurve, c->getValueAsStr());
+    } else if (c == ckbApplyLookTable) {
+        listener->panelChanged(EvDCPApplyLookTable, c->getValueAsStr());
+    } else if (c == ckbApplyBaselineExposureOffset) {
+        listener->panelChanged(EvDCPApplyBaselineExposureOffset, c->getValueAsStr());
+    } else if (c == ckbApplyHueSatMap) {
+        listener->panelChanged(EvDCPApplyHueSatMap, c->getValueAsStr());
+    } else if (c == wsmoothcie) {
+        listener->panelChanged(EvICMwsmoothcie, c->getValueAsStr());
     }
 }
 

--- a/rtgui/tools/icmpanel.h
+++ b/rtgui/tools/icmpanel.h
@@ -26,6 +26,7 @@
 #include "toolpanel.h"
 #include "curvelistener.h"
 #include "widgets/basic/adjuster.h"
+#include "widgets/basic/checkbox.h"
 #include "widgets/basic/popupbutton.h"
 #include "widgets/basic/thresholdadjuster.h"
 
@@ -51,7 +52,8 @@ class ICMPanel final :
     public CurveListener,
     public FoldableToolPanel,
     public rtengine::AutoprimListener,
-    public AdjusterListener
+    public AdjusterListener,
+    public CheckBoxListener
 {
 
 protected:
@@ -69,7 +71,7 @@ protected:
     Adjuster* wapsat;
     
     Adjuster* wmidtcie;
-    Gtk::CheckButton* wsmoothcie;
+    CheckBox* wsmoothcie;
     Adjuster* wsmoothciesli;
     Adjuster* sigmatrc;
     Adjuster* offstrc;
@@ -99,8 +101,6 @@ protected:
     Adjuster* refi;
     Adjuster* shiftx;
     Adjuster* shifty;
-    sigc::connection wsmoothcieconn;
-    bool lastwsmoothcie;
     Gtk::Label* labmga;
     Gtk::Box* gabox;
     //Gtk::Label* blr;
@@ -111,21 +111,7 @@ protected:
     sigc::connection wavExpconn;
 
     sigc::connection neutralconn;
-    bool lastToneCurve;
-    sigc::connection tcurveconn;
-    bool lastApplyLookTable;
-    sigc::connection ltableconn;
-    bool lastApplyBaselineExposureOffset;
-    sigc::connection beoconn;
-    bool lastApplyHueSatMap;
-    sigc::connection hsmconn;
-    bool lastobpc;
-    sigc::connection obpcconn;
-    bool lastfbw;
-    sigc::connection fbwconn;
     bool isBatchMode;
-    bool lastgamut;
-    sigc::connection gamutconn;
 
 private:
     rtengine::ProcEvent EvICMprimariMethod;
@@ -198,14 +184,14 @@ private:
     Gtk::Box* wgamutBox;
     Gtk::Label* wgamutlab;
 
-    Gtk::CheckButton* fbw;
-    Gtk::CheckButton* gamut;
+    CheckBox* fbw;
+    CheckBox* gamut;
 
     Gtk::Box* wcatBox;
     Gtk::Label* wcatlab;
 
 
-    Gtk::CheckButton* obpc;
+    CheckBox* obpc;
     Gtk::RadioButton* inone;
 
     Gtk::RadioButton* iembedded;
@@ -215,10 +201,10 @@ private:
     Gtk::Label* dcpIllLabel;
     MyComboBoxText* dcpIll;
     sigc::connection dcpillconn;
-    Gtk::CheckButton* ckbToneCurve;
-    Gtk::CheckButton* ckbApplyLookTable;
-    Gtk::CheckButton* ckbApplyBaselineExposureOffset;
-    Gtk::CheckButton* ckbApplyHueSatMap;
+    CheckBox* ckbToneCurve;
+    CheckBox* ckbApplyLookTable;
+    CheckBox* ckbApplyBaselineExposureOffset;
+    CheckBox* ckbApplyHueSatMap;
     MyComboBoxText* wProfNames;
     sigc::connection wprofnamesconn;
     MyComboBoxText* wTRC;
@@ -289,6 +275,7 @@ public:
     void neutral_pressed();
     void curveChanged(CurveEditor* ce) override;
     void wavlocChanged(double nlevel, double nmax, bool curveloc) override;
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
     void wpChanged();
     void wtrcinChanged();
@@ -301,18 +288,10 @@ public:
     void opChanged();
     void oiChanged(int n);
     void aiChanged(int n);
-    void oBPCChanged();
-    void fbwChanged();
-    void wsmoothcieChanged();
     void resetpolar();
-    void gamutChanged();
     void ipChanged();
     void ipSelectionChanged();
     void dcpIlluminantChanged();
-    void toneCurveChanged();
-    void applyLookTableChanged();
-    void applyBaselineExposureOffsetChanged();
-    void applyHueSatMapChanged();
     void upgateGUI_lin_pol_graph();
     void setRawMeta(bool raw, const rtengine::FramesData* pMeta);
     void saveReferencePressed();

--- a/rtgui/tools/labcurve.cc
+++ b/rtgui/tools/labcurve.cc
@@ -93,6 +93,7 @@ LCurve::LCurve() : FoldableToolPanel(this, TOOL_NAME, M("TP_LABCURVE_LABEL"), fa
     pack_start(*lcredsk);
 
     rstprotection = Gtk::manage(new Adjuster(M("TP_LABCURVE_RSTPROTECTION"), 0., 100., 0.1, 0.));
+    rstprotection->setAutoEnableTool(false);
     pack_start(*rstprotection);
     rstprotection->show();
 

--- a/rtgui/tools/labcurve.cc
+++ b/rtgui/tools/labcurve.cc
@@ -76,6 +76,7 @@ LCurve::LCurve() : FoldableToolPanel(this, TOOL_NAME, M("TP_LABCURVE_LABEL"), fa
     metHBox->pack_start(*metLabel, Gtk::PACK_SHRINK);
 
     gamutmunselmethod =  Gtk::manage(new MyComboBoxText());
+    gamutmunselmethod->setToolPanel(this);
     gamutmunselmethod->append(M("TP_LOCALLAB_GAMUTNON"));
     gamutmunselmethod->append(M("TP_LOCALLAB_GAMUTLABRELA"));
     gamutmunselmethod->append(M("TP_LOCALLAB_GAMUTXYZABSO"));
@@ -88,12 +89,12 @@ LCurve::LCurve() : FoldableToolPanel(this, TOOL_NAME, M("TP_LABCURVE_LABEL"), fa
     gamutmunselmethodconn = gamutmunselmethod->signal_changed().connect(sigc::mem_fun(*this, &LCurve::gamutmunselChanged));
 
 
-    lcredsk = Gtk::manage(new Gtk::CheckButton(M("TP_LABCURVE_LCREDSK")));
+    lcredsk = Gtk::manage(new MyCheckButton(M("TP_LABCURVE_LCREDSK")));
+    lcredsk->setToolPanel(this);
     lcredsk->set_tooltip_markup(M("TP_LABCURVE_LCREDSK_TOOLTIP"));
     pack_start(*lcredsk);
 
     rstprotection = Gtk::manage(new Adjuster(M("TP_LABCURVE_RSTPROTECTION"), 0., 100., 0.1, 0.));
-    rstprotection->setAutoEnableTool(false);
     pack_start(*rstprotection);
     rstprotection->show();
 

--- a/rtgui/tools/labcurve.h
+++ b/rtgui/tools/labcurve.h
@@ -59,7 +59,7 @@ protected:
     DiagonalCurveEditor* cdshape;
 
     //%%%%%%%%%%%%%%%%
-    Gtk::CheckButton* lcredsk;
+    MyCheckButton* lcredsk;
 
     MyComboBoxText* gamutmunselmethod;
     sigc::connection   gamutmunselmethodconn;

--- a/rtgui/tools/locallab.cc
+++ b/rtgui/tools/locallab.cc
@@ -1666,6 +1666,7 @@ void Locallab::addTool(Gtk::Box* where, LocallabTool* tool)
     locallabTools.push_back(tool);
     tool->setLocallabToolListener(this);
     tool->setSpotNameSource(&spotName);
+    tool->setParentPanel(this);
 }
 
 void Locallab::setParamEditable(bool cond)

--- a/rtgui/tools/locallab.h
+++ b/rtgui/tools/locallab.h
@@ -27,6 +27,7 @@
 #include "controlspotpanel.h"
 #include "guiutils.h"
 #include "tools/locallabtools.h"
+#include "widgets/basic/checkbox.h"
 
 /* ==== LocallabToolListListener ==== */
 class LocallabToolList;

--- a/rtgui/tools/locallabtools.cc
+++ b/rtgui/tools/locallabtools.cc
@@ -161,7 +161,7 @@ LocallabTool::LocallabTool(Gtk::Box* content, Glib::ustring toolName, Glib::ustr
     needMode(needMode),
     isLocActivated(false),
     locToolListener(nullptr),
-
+    content(content),
     // LocallabTool generic widgets
     complexity(Gtk::manage(new MyComboBoxText()))
 {
@@ -225,7 +225,37 @@ Glib::ustring LocallabTool::getSpotName() const
     }
     return "";
 }
-
+namespace
+{
+void setToolPanelRecursive(Gtk::Container* container, FoldableToolPanel* toolPanel)
+{
+    for (Gtk::Widget* child : container->get_children()) {
+        if (auto* widget = dynamic_cast<MyComboBoxText*>(child)) {
+            widget->setToolPanel(toolPanel);
+        } else if (auto* widget = dynamic_cast<MyComboBox*>(child)) {
+            widget->setToolPanel(toolPanel);
+        } else if (auto* widget = dynamic_cast<MySpinButton*>(child)) {
+            widget->setToolPanel(toolPanel);
+        } else if (auto* widget = dynamic_cast<MyCheckButton*>(child)) {
+            widget->setToolPanel(toolPanel);
+        } else if (auto* widget = dynamic_cast<MyButton*>(child)) {
+            widget->setToolPanel(toolPanel);
+        } else if (auto* subContainer = dynamic_cast<Gtk::Container*>(child)) {
+            setToolPanelRecursive(subContainer, toolPanel);
+        }
+    }
+}
+}
+void LocallabTool::setParentPanel(FoldableToolPanel* parentPanel)
+{
+    if (!parentPanel) {
+        return;
+    }
+    setToolPanelRecursive(content, parentPanel);
+    if (parentPanel->getExpander()) {
+        registerExpanders(content, {parentPanel->getExpander(), exp});
+    }
+}
 void LocallabTool::addLocallabTool(bool raiseEvent)
 {
     exp->set_visible(true);
@@ -486,7 +516,7 @@ LocallabColor::LocallabColor():
     lightness(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LIGHTNESS"), -100, 500, 1, 0))),
     contrast(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTRAST"), -100, 100, 1, 0))),
     chroma(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CHROMA"), -100, 150, 1, 0))),
-    curvactiv(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_CURV")))),
+    curvactiv(Gtk::manage(new CheckBox(M("TP_LOCALLAB_CURV"), multiImage))),
     gridFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABGRID")))),
     labgrid(Gtk::manage(new LabGrid(EvLocallabLabGridValue, M("TP_LOCALLAB_LABGRID_VALUES"), true, false))),
     gridMethod(Gtk::manage(new MyComboBoxText())),
@@ -504,7 +534,7 @@ LocallabColor::LocallabColor():
     lowthresc(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHRLOW"), 1., 80., 0.5, 12.))),
     higthresc(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHR"), 20., 99., 0.5, 85.))),
     decayc(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
-    invers(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVERS")))),
+    invers(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVERS"), multiImage))),
     expgradcol(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_EXPGRAD")))),
     strcol(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTRLUM"), -4., 4., 0.05, 0.))),
     strcolab(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTRCHRO"), -6., 6., 0.05, 0.))),
@@ -529,7 +559,7 @@ LocallabColor::LocallabColor():
     rgbCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_RGB"))),
     toneMethod(Gtk::manage(new MyComboBoxText())),
     rgbshape(static_cast<DiagonalCurveEditor*>(rgbCurveEditorG->addCurve(CT_Diagonal, "", toneMethod))),
-    special(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SPECIAL")))),
+    special(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SPECIAL"), multiImage))),
     expmaskcol1(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWC1")))),
     merMethod(Gtk::manage(new MyComboBoxText())),
     mask7(Gtk::manage(new ToolParamBlock())),
@@ -544,7 +574,7 @@ LocallabColor::LocallabColor():
     mergecolFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_MERGECOLFRA")))),
     showmaskcolMethod(Gtk::manage(new MyComboBoxText())),
     showmaskcolMethodinv(Gtk::manage(new MyComboBoxText())),
-    enaColorMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enaColorMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //    maskCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASKCOL"))),
     maskCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir,"", 1)),
     CCmaskshape(static_cast<FlatCurveEditor*>(maskCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -552,9 +582,9 @@ LocallabColor::LocallabColor():
     HHmaskshape(static_cast<FlatCurveEditor *>(maskCurveEditorG->addCurve(CT_Flat, "LC(h)", nullptr, false, true))),
     struFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABSTRUM")))),
     strumaskcol(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRUMASKCOL"), 0., 200., 0.1, 0.))),
-    toolcol(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_TOOLCOL")))),
+    toolcol(Gtk::manage(new CheckBox(M("TP_LOCALLAB_TOOLCOL"), multiImage))),
     blurFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABBLURM")))),
-    fftColorMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTCOL_MASK")))),
+    fftColorMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTCOL_MASK"), multiImage))),
     contcol(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTCOL"), 0., 200., 0.5, 0.))),
     blurcol(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLURCOL"), 0.2, 100., 0.5, 0.2))),
     blendmaskcol(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLENDMASKCOL"), -100, 100, 1, 0))),
@@ -606,7 +636,7 @@ LocallabColor::LocallabColor():
 
     chroma->setAdjusterListener(this);
 
-    curvactivConn = curvactiv->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::curvactivChanged));
+    curvactiv->setCheckBoxListener(this);
 
     gridFrame->set_label_align(0.025, 0.5);
 
@@ -631,7 +661,7 @@ LocallabColor::LocallabColor():
     decayc->setAdjusterListener(this);
     setExpandAlignProperties(exprecov, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
 
-    inversConn = invers->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::inversChanged));
+    invers->setCheckBoxListener(this);
     invers->set_tooltip_text(M("TP_LOCALLAB_INVERS_TOOLTIP"));
 
     setExpandAlignProperties(expgradcol, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
@@ -733,7 +763,7 @@ LocallabColor::LocallabColor():
 
     rgbCurveEditorG->curveListComplete();
 
-    specialConn  = special->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::specialChanged));
+    special->setCheckBoxListener(this);
 
     setExpandAlignProperties(expmaskcol1, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
 
@@ -795,7 +825,7 @@ LocallabColor::LocallabColor():
     showmaskcolMethodinv->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskcolMethodConninv  = showmaskcolMethodinv->signal_changed().connect(sigc::mem_fun(*this, &LocallabColor::showmaskcolMethodChangedinv));
 
-    enaColorMaskConn = enaColorMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::enaColorMaskChanged));
+    enaColorMask->setCheckBoxListener(this);
 
     maskCurveEditorG->setCurveListener(this);
 
@@ -818,11 +848,11 @@ LocallabColor::LocallabColor():
 
     strumaskcol->setAdjusterListener(this);
 
-    toolcolConn  = toolcol->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::toolcolChanged));
+    toolcol->setCheckBoxListener(this);
 
     blurFrame->set_label_align(0.025, 0.5);
 
-    fftColorMaskConn = fftColorMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabColor::fftColorMaskChanged));
+    fftColorMask->setCheckBoxListener(this);
 
     contcol->setAdjusterListener(this);
 
@@ -1052,7 +1082,7 @@ void LocallabColor::updateguicolor(int spottype)
                 sensi->hide();
                 expmaskcol->hide();
                 exprecov->hide();
-                enaColorMask->set_active(false);
+                enaColorMask->setValue(false);
                 previewcol->hide();
                 previewcol->set_active(false);
             } else {
@@ -1060,7 +1090,7 @@ void LocallabColor::updateguicolor(int spottype)
                 sensi->show();
                 expmaskcol->show();
                 exprecov->show();
-                if(!invers->get_active()) {
+                if(!invers->getLastActive()) {
                     previewcol->show();
                 } else {
                     previewcol->hide();
@@ -1255,38 +1285,26 @@ void LocallabColor::disableListener()
 {
     LocallabTool::disableListener();
 
-    curvactivConn.block(true);
     gridMethodConn.block(true);
-    inversConn.block(true);
     qualitycurveMethodConn.block(true);
     toneMethodConn.block(true);
-    specialConn.block(true);
     merMethodConn.block(true);
     mergecolMethodConn.block(true);
     showmaskcolMethodConn.block(true);
     showmaskcolMethodConninv.block(true);
-    enaColorMaskConn.block(true);
-    toolcolConn.block(true);
-    fftColorMaskConn.block(true);
 }
 
 void LocallabColor::enableListener()
 {
     LocallabTool::enableListener();
 
-    curvactivConn.block(false);
     gridMethodConn.block(false);
-    inversConn.block(false);
     qualitycurveMethodConn.block(false);
     toneMethodConn.block(false);
-    specialConn.block(false);
     merMethodConn.block(false);
     mergecolMethodConn.block(false);
     showmaskcolMethodConn.block(false);
     showmaskcolMethodConninv.block(false);
-    enaColorMaskConn.block(false);
-    toolcolConn.block(false);
-    fftColorMaskConn.block(false);
 }
 
 void LocallabColor::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -1309,7 +1327,7 @@ void LocallabColor::read(const rtengine::procparams::ProcParams* pp, const Param
         reparcol->setValue(spot.reparcol);
         contrast->setValue(spot.contrast);
         chroma->setValue(spot.chroma);
-        curvactiv->set_active(spot.curvactiv);
+        curvactiv->setValue(spot.curvactiv);
         labgrid->setParams(spot.labgridALow / LocallabParams::LABGRIDL_CORR_MAX,
                            spot.labgridBLow / LocallabParams::LABGRIDL_CORR_MAX,
                            spot.labgridAHigh / LocallabParams::LABGRIDL_CORR_MAX,
@@ -1327,7 +1345,7 @@ void LocallabColor::read(const rtengine::procparams::ProcParams* pp, const Param
         structcol->setValue(spot.structcol);
         blurcolde->setValue(spot.blurcolde);
         softradiuscol->setValue(spot.softradiuscol);
-        invers->set_active(spot.invers);
+        invers->setValue(spot.invers);
         strcol->setValue(spot.strcol);
         strcolab->setValue(spot.strcolab);
         strcolh->setValue(spot.strcolh);
@@ -1359,7 +1377,7 @@ void LocallabColor::read(const rtengine::procparams::ProcParams* pp, const Param
         }
 
         rgbshape->setCurve(spot.rgbcurve);
-        special->set_active(spot.special);
+        special->setValue(spot.special);
 
         if (spot.merMethod == "mone") {
             merMethod->set_active(0);
@@ -1430,13 +1448,13 @@ void LocallabColor::read(const rtengine::procparams::ProcParams* pp, const Param
                                spot.labgridBHighmerg / LocallabParams::LABGRIDL_CORR_MAX,
                                0, 0, 0, 0, 0, 0, false);
         merlucol->setValue(spot.merlucol);
-        enaColorMask->set_active(spot.enaColorMask);
+        enaColorMask->setValue(spot.enaColorMask);
         CCmaskshape->setCurve(spot.CCmaskcurve);
         LLmaskshape->setCurve(spot.LLmaskcurve);
         HHmaskshape->setCurve(spot.HHmaskcurve);
         strumaskcol->setValue(spot.strumaskcol);
-        toolcol->set_active(spot.toolcol);
-        fftColorMask->set_active(spot.fftColorMask);
+        toolcol->setValue(spot.toolcol);
+        fftColorMask->setValue(spot.fftColorMask);
         contcol->setValue(spot.contcol);
         // Update GUI according to fftColorMash button state
         // Note: Contrary to the others, shall be called before setting 'blurcol' value
@@ -1486,7 +1504,7 @@ void LocallabColor::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         spot.reparcol = reparcol->getValue();
         spot.contrast = contrast->getIntValue();
         spot.chroma = chroma->getIntValue();
-        spot.curvactiv = curvactiv->get_active();
+        spot.curvactiv = curvactiv->getLastActive();
         double zerox = 0.;
         double zeroy = 0.;
         labgrid->getParams(spot.labgridALow,
@@ -1509,7 +1527,7 @@ void LocallabColor::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         spot.structcol = structcol->getIntValue();
         spot.blurcolde = blurcolde->getIntValue();
         spot.softradiuscol = softradiuscol->getValue();
-        spot.invers = invers->get_active();
+        spot.invers = invers->getLastActive();
         spot.strcol = strcol->getValue();
         spot.strcolab = strcolab->getValue();
         spot.strcolh = strcolh->getValue();
@@ -1546,7 +1564,7 @@ void LocallabColor::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         }
 
         spot.rgbcurve = rgbshape->getCurve();
-        spot.special = special->get_active();
+        spot.special = special->getLastActive();
 
         if (merMethod->get_active_row_number() == 0) {
             spot.merMethod = "mone";
@@ -1618,13 +1636,13 @@ void LocallabColor::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         spot.labgridBLowmerg *= LocallabParams::LABGRIDL_CORR_MAX;
         spot.labgridBHighmerg *= LocallabParams::LABGRIDL_CORR_MAX;
         spot.merlucol = merlucol->getValue();
-        spot.enaColorMask = enaColorMask->get_active();
+        spot.enaColorMask = enaColorMask->getLastActive();
         spot.CCmaskcurve = CCmaskshape->getCurve();
         spot.LLmaskcurve = LLmaskshape->getCurve();
         spot.HHmaskcurve = HHmaskshape->getCurve();
         spot.strumaskcol = strumaskcol->getValue();
-        spot.toolcol = toolcol->get_active();
-        spot.fftColorMask = fftColorMask->get_active();
+        spot.toolcol = toolcol->getLastActive();
+        spot.fftColorMask = fftColorMask->getLastActive();
         spot.contcol = contcol->getValue();
         spot.blurcol = blurcol->getValue();
         spot.blendmaskcol = blendmaskcol->getIntValue();
@@ -2097,7 +2115,7 @@ void LocallabColor::convertParamToNormal()
     }
 
     rgbshape->setCurve(defSpot.rgbcurve);
-    special->set_active(defSpot.special);
+    special->setValue(defSpot.special);
 
     if (defSpot.mergecolMethod == "one") {
         mergecolMethod->set_active(0);
@@ -2152,8 +2170,8 @@ void LocallabColor::convertParamToNormal()
                            0, 0, 0, 0, 0, 0, false);
     merlucol->setValue(defSpot.merlucol);
     strumaskcol->setValue(defSpot.strumaskcol);
-    toolcol->set_active(defSpot.toolcol);
-    fftColorMask->set_active(defSpot.fftColorMask);
+    toolcol->setValue(defSpot.toolcol);
+    fftColorMask->setValue(defSpot.fftColorMask);
     contcol->setValue(defSpot.contcol);
     blurcol->setValue(defSpot.blurcol);
     lapmaskcol->setValue(defSpot.lapmaskcol);
@@ -2210,7 +2228,7 @@ void LocallabColor::convertParamToSimple()
     ccshape->setCurve(defSpot.cccurve);
     showmaskcolMethod->set_active(0);
     showmaskcolMethodinv->set_active(0);
-    enaColorMask->set_active(defSpot.enaColorMask);
+    enaColorMask->setValue(defSpot.enaColorMask);
 //    CCmaskshape->setCurve(defSpot.CCmaskcurve);
 //    LLmaskshape->setCurve(defSpot.LLmaskcurve);
 //    HHmaskshape->setCurve(defSpot.HHmaskcurve);
@@ -2272,7 +2290,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
             toolcolFrame2->hide();
             // Specific Simple mode widgets are shown in Normal mode
             softradiuscol->show();
-            if (enaColorMask->get_active()) {
+            if (enaColorMask->getLastActive()) {
                 maskusablec->show();
                 maskunusablec->hide();
 
@@ -2281,7 +2299,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
                 maskunusablec->show();
             }
 
-            if (!invers->get_active()) { // Keep widget hidden when invers is toggled
+            if (!invers->getLastActive()) { // Keep widget hidden when invers is toggled
                 expmaskcol1->show();
                 exprecov->show();
                 gamc->hide();
@@ -2299,7 +2317,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
             blurcolde->show();
             gamc->show();
 
-            if (!invers->get_active()) { // Keep widget hidden when invers is toggled
+            if (!invers->getLastActive()) { // Keep widget hidden when invers is toggled
                 softradiuscol->show();
                 exprecov->show();
                 gamc->show();
@@ -2308,7 +2326,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
             strcolab->show();
             strcolh->show();
             expcurvcol->show();
-            if (enaColorMask->get_active()) {
+            if (enaColorMask->getLastActive()) {
                 maskusablec->show();
                 maskunusablec->hide();
 
@@ -2320,7 +2338,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
             exprecov->show();
             decayc->show();
 
-            if (!invers->get_active()) { // Keep widgets hidden when invers is toggled
+            if (!invers->getLastActive()) { // Keep widgets hidden when invers is toggled
                 clCurveEditorG->show();
                 HCurveEditorG->show();
                 H3CurveEditorG->show();
@@ -2330,7 +2348,7 @@ void LocallabColor::updateGUIToMode(const modeType new_type)
             rgbCurveEditorG->show();
             special->show();
 
-            if (!invers->get_active()) { // Keep widget hidden when invers is toggled
+            if (!invers->getLastActive()) { // Keep widget hidden when invers is toggled
                 expmaskcol1->show();
             }
 
@@ -2373,17 +2391,55 @@ void LocallabColor::updateMaskBackground(const double normChromar, const double 
     );
 }
 
-void LocallabColor::curvactivChanged()
+
+void LocallabColor::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (curvactiv->get_active()) {
-                listener->panelChanged(Evlocallabcurvactiv,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabcurvactiv,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    if (!listener) {
+        return;
+    }
+
+    if (c == curvactiv) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabcurvactiv,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == invers) {
+        const bool maskPreviewActivated = isMaskViewActive();
+        updateColorGUI1();
+        if (maskPreviewActivated) {
+            listener->panelChanged(EvlocallabshowmaskMethod, "");
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinvers,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == special) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabspecial,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enaColorMask) {
+        if (c->getLastActive()) {
+            maskusablec->show();
+            maskunusablec->hide();
+        } else {
+            maskusablec->hide();
+            maskunusablec->show();
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaColorMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == toolcol) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabtoolcol,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == fftColorMask) {
+        updateColorGUI3();
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabfftColorMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
     }
 }
@@ -2398,32 +2454,6 @@ void LocallabColor::gridMethodChanged()
     }
 }
 
-void LocallabColor::inversChanged()
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update GUI according to invers button state
-    updateColorGUI1();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
-            listener->panelChanged(EvlocallabshowmaskMethod, "");
-        }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (invers->get_active()) {
-                listener->panelChanged(Evlocallabinvers,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinvers,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabColor::qualitycurveMethodChanged()
 {
@@ -2445,20 +2475,6 @@ void LocallabColor::toneMethodChanged()
     }
 }
 
-void LocallabColor::specialChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (special->get_active()) {
-                listener->panelChanged(EvLocallabspecial,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabspecial,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabColor::merMethodChanged()
 {
@@ -2518,67 +2534,14 @@ void LocallabColor::showmaskcolMethodChangedinv()
     }
 }
 
-void LocallabColor::enaColorMaskChanged()
-{
-    if (enaColorMask->get_active()) {
-        maskusablec->show();
-        maskunusablec->hide();
 
-    } else {
-        maskusablec->hide();
-        maskunusablec->show();
-    }
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaColorMask->get_active()) {
-                listener->panelChanged(EvLocallabEnaColorMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaColorMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabColor::toolcolChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (toolcol->get_active()) {
-                listener->panelChanged(EvLocallabtoolcol,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabtoolcol,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabColor::fftColorMaskChanged()
-{
-    updateColorGUI3(); // Update GUI according to fftColorMash button state
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftColorMask->get_active()) {
-                listener->panelChanged(EvLocallabfftColorMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabfftColorMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabColor::updateColorGUI1()
 {
     const int mode = complexity->get_active_row_number();
 
-    if (invers->get_active()) {
+    if (invers->getLastActive()) {
         gridFrame->hide();
         structcol->hide();
         softradiuscol->hide();
@@ -2697,7 +2660,7 @@ void LocallabColor::updateColorGUI3()
 {
     const double temp = blurcol->getValue();
 
-    if (fftColorMask->get_active()) {
+    if (fftColorMask->getLastActive()) {
         blurcol->setLimits(0.2, 1000., 0.5, 0.2);
     } else {
         blurcol->setLimits(0.2, 100., 0.5, 0.2);
@@ -2725,8 +2688,8 @@ LocallabExposure::LocallabExposure():
     expfat(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_FATFRA")))),
     fatamount(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FATAMOUNT"), 1., 100., 1., 1.))),
     fatdetail(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FATDETAIL"), -100., 300., 1., 0.))),
-    fatsatur(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FATSAT")))),
-    norm(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_EQUIL")))),
+    fatsatur(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FATSAT"), multiImage))),
+    norm(Gtk::manage(new CheckBox(M("TP_LOCALLAB_EQUIL"), multiImage))),
     fatlevel(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FATLEVEL"), 0.5, 2.0, 0.01, 1.))),
     fatanchor(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FATANCHOR"), 0.1, 100.0, 0.01, 50., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     gamex(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GAMC"), 0.5, 3.0, 0.05, 1.))),
@@ -2757,12 +2720,12 @@ LocallabExposure::LocallabExposure():
     angexp(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADANG"), -180, 180, 0.1, 0.))),
     featherexp(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FEATVALUE"), 10., 100., 0.1, 25.))),
     softradiusexp(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOFTRADIUSCOL"), 0.0, 100.0, 0.5, 0.))),
-    inversex(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVERS")))),
+    inversex(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVERS"), multiImage))),
     expmaskexp(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWE")))),
     showmaskexpMethod(Gtk::manage(new MyComboBoxText())),
     showmaskexpMethodinv(Gtk::manage(new MyComboBoxText())),
-    enaExpMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
-    enaExpMaskaft(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASKAFT")))),
+    enaExpMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
+    enaExpMaskaft(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASKAFT"), multiImage))),
  //   maskexpCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     maskexpCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskexpshape(static_cast<FlatCurveEditor*>(maskexpCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -2877,10 +2840,10 @@ LocallabExposure::LocallabExposure():
                            *this, &LocallabExposure::previewexeChanged));
     
     setExpandAlignProperties(exprecove, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
-    normConn  = norm->signal_toggled().connect(sigc::mem_fun(*this, &LocallabExposure::normChanged));
-    fatsaturConn  = fatsatur->signal_toggled().connect(sigc::mem_fun(*this, &LocallabExposure::fatsaturChanged));
+    norm->setCheckBoxListener(this);
+    fatsatur->setCheckBoxListener(this);
 
-    inversexConn  = inversex->signal_toggled().connect(sigc::mem_fun(*this, &LocallabExposure::inversexChanged));
+    inversex->setCheckBoxListener(this);
     inversex->set_tooltip_text(M("TP_LOCALLAB_INVERS_TOOLTIP"));
 
     setExpandAlignProperties(expmaskexp, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
@@ -2901,9 +2864,9 @@ LocallabExposure::LocallabExposure():
     showmaskexpMethodinv->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskexpMethodConninv  = showmaskexpMethodinv->signal_changed().connect(sigc::mem_fun(*this, &LocallabExposure::showmaskexpMethodChangedinv));
 
-    enaExpMaskConn = enaExpMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabExposure::enaExpMaskChanged));
+    enaExpMask->setCheckBoxListener(this);
 
-    enaExpMaskaftConn = enaExpMaskaft->signal_toggled().connect(sigc::mem_fun(*this, &LocallabExposure::enaExpMaskaftChanged));
+    enaExpMaskaft->setCheckBoxListener(this);
 
     maskexpCurveEditorG->setCurveListener(this);
 
@@ -3060,8 +3023,8 @@ void LocallabExposure::updateguiexpos(int spottype)
                 inversex->hide();
                 sensiex->hide();
                 previewexe->hide();
-                enaExpMask->set_active(false);
-                enaExpMaskaft->set_active(false);
+                enaExpMask->setValue(false);
+                enaExpMaskaft->setValue(false);
                 previewexe->set_active(false);
                 expmaskexp->hide();
                 exprecove->hide();
@@ -3071,7 +3034,7 @@ void LocallabExposure::updateguiexpos(int spottype)
                 expmaskexp->show();
                 exprecove->show();
 
-                if(!inversex->get_active()) {
+                if(!inversex->getLastActive()) {
                     previewexe->show();
                 } else {
                     previewexe->hide();
@@ -3232,13 +3195,8 @@ void LocallabExposure::disableListener()
 
     expMethodConn.block(true);
     exnoiseMethodConn.block(true);
-    inversexConn.block(true);
-    normConn.block(true);
-    fatsaturConn.block(true);
     showmaskexpMethodConn.block(true);
     showmaskexpMethodConninv.block(true);
-    enaExpMaskConn.block(true);
-    enaExpMaskaftConn.block(true);
 }
 
 void LocallabExposure::enableListener()
@@ -3247,13 +3205,8 @@ void LocallabExposure::enableListener()
 
     expMethodConn.block(false);
     exnoiseMethodConn.block(false);
-    inversexConn.block(false);
-    normConn.block(false);
-    fatsaturConn.block(false);
     showmaskexpMethodConn.block(false);
     showmaskexpMethodConninv.block(false);
-    enaExpMaskConn.block(false);
-    enaExpMaskaftConn.block(false);
 }
 
 void LocallabExposure::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -3335,11 +3288,11 @@ void LocallabExposure::read(const rtengine::procparams::ProcParams* pp, const Pa
         angexp->setValue(spot.angexp);
         featherexp->setValue(spot.featherexp);
         softradiusexp->setValue(spot.softradiusexp);
-        norm->set_active(spot.norm);
-        fatsatur->set_active(spot.fatsatur);
-        inversex->set_active(spot.inversex);
-        enaExpMask->set_active(spot.enaExpMask);
-        enaExpMaskaft->set_active(spot.enaExpMaskaft);
+        norm->setValue(spot.norm);
+        fatsatur->setValue(spot.fatsatur);
+        inversex->setValue(spot.inversex);
+        enaExpMask->setValue(spot.enaExpMask);
+        enaExpMaskaft->setValue(spot.enaExpMaskaft);
         CCmaskexpshape->setCurve(spot.CCmaskexpcurve);
         LLmaskexpshape->setCurve(spot.LLmaskexpcurve);
         HHmaskexpshape->setCurve(spot.HHmaskexpcurve);
@@ -3427,11 +3380,11 @@ void LocallabExposure::write(rtengine::procparams::ProcParams* pp, ParamsEdited*
         spot.angexp = angexp->getValue();
         spot.featherexp = featherexp->getValue();
         spot.softradiusexp = softradiusexp->getValue();
-        spot.inversex = inversex->get_active();
-        spot.norm = norm->get_active();
-        spot.fatsatur = fatsatur->get_active();
-        spot.enaExpMask = enaExpMask->get_active();
-        spot.enaExpMaskaft = enaExpMaskaft->get_active();
+        spot.inversex = inversex->getLastActive();
+        spot.norm = norm->getLastActive();
+        spot.fatsatur = fatsatur->getLastActive();
+        spot.enaExpMask = enaExpMask->getLastActive();
+        spot.enaExpMaskaft = enaExpMaskaft->getLastActive();
         spot.CCmaskexpcurve = CCmaskexpshape->getCurve();
         spot.LLmaskexpcurve = LLmaskexpshape->getCurve();
         spot.HHmaskexpcurve = HHmaskexpshape->getCurve();
@@ -3848,7 +3801,7 @@ void LocallabExposure::convertParamToNormal()
     strmaskexp->setValue(defSpot.strmaskexp);
     angmaskexp->setValue(defSpot.angmaskexp);
     decaye->setValue(defSpot.decaye);
-//    norm->set_active(defSpot.enaExpMask);
+//    norm->setValue(defSpot.enaExpMask);
     fatlevel->setValue(defSpot.fatlevel);
 
     // Enable all listeners
@@ -3864,14 +3817,14 @@ void LocallabExposure::convertParamToSimple()
     laplacexp->setValue(defSpot.laplacexp);
     fatlevel->setValue(defSpot.fatlevel);
     fatanchor->setValue(defSpot.fatanchor);
-    norm->set_active(false);
+    norm->setValue(false);
     // Set hidden specific GUI widgets in Simple mode to default spot values
     //strexp->setValue(defSpot.strexp);
     //angexp->setValue(defSpot.angexp);
     //featherexp->setValue(defSpot.featherexp);
     softradiusexp->setValue(defSpot.softradiusexp);
-    enaExpMask->set_active(defSpot.enaExpMask);
-    enaExpMaskaft->set_active(defSpot.enaExpMaskaft);
+    enaExpMask->setValue(defSpot.enaExpMask);
+    enaExpMaskaft->setValue(defSpot.enaExpMaskaft);
     showmaskexpMethod->set_active(0);
     gamex->setValue(defSpot.gamex);
  //   CCmaskexpshape->setCurve(defSpot.CCmaskexpcurve);
@@ -3920,7 +3873,7 @@ void LocallabExposure::updateGUIToMode(const modeType new_type)
             slomaskexp->hide();
             gradFramemask->hide();
             exprecove->show();
-            if (enaExpMask->get_active()) {
+            if (enaExpMask->getLastActive()) {
                 maskusablee->show();
                 maskunusablee->hide();
 
@@ -3937,7 +3890,7 @@ void LocallabExposure::updateGUIToMode(const modeType new_type)
             blurexpde->hide();
             exppde->hide();
 
-            if (!inversex->get_active()) { // Keep widget hidden when invers is toggled
+            if (!inversex->getLastActive()) { // Keep widget hidden when invers is toggled
               //  expgradexp->show();
                 softradiusexp->show();
                 exprecove->show();
@@ -3952,7 +3905,7 @@ void LocallabExposure::updateGUIToMode(const modeType new_type)
         case Expert:
             // Show widgets hidden in Normal and Simple mode
            structexp->hide();
-           if (!inversex->get_active()) { // Keep widget hidden when invers is toggled
+           if (!inversex->getLastActive()) { // Keep widget hidden when invers is toggled
                 structexp->show();
             }
 
@@ -3963,7 +3916,7 @@ void LocallabExposure::updateGUIToMode(const modeType new_type)
             softradiusexp->hide();
             gamex->show();
 
-            if (!inversex->get_active()) { // Keep widget hidden when invers is toggled
+            if (!inversex->getLastActive()) { // Keep widget hidden when invers is toggled
                 //expgradexp->show();
                 softradiusexp->show();
                 exprecove->show();
@@ -3971,7 +3924,7 @@ void LocallabExposure::updateGUIToMode(const modeType new_type)
                 blurexpde->show();
 
             }
-            if (enaExpMask->get_active()) {
+            if (enaExpMask->getLastActive()) {
                 maskusablee->show();
                 maskunusablee->hide();
 
@@ -4029,61 +3982,48 @@ void LocallabExposure::exnoiseMethodChanged()
     }
 }
 
-void LocallabExposure::normChanged()
+void LocallabExposure::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (norm->get_active()) {
-                listener->panelChanged(Evlocallabnorm,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabnorm,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
+    if (!listener) {
+        return;
     }
-}
 
-void LocallabExposure::fatsaturChanged()
-{
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fatsatur->get_active()) {
-                listener->panelChanged(Evlocallabtmosatur,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabtmosatur,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    if (c == norm) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabnorm,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-void LocallabExposure::inversexChanged()
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update exposure GUI according to inversex button state
-    updateExposureGUI3();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
+    } else if (c == fatsatur) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabtmosatur,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == inversex) {
+        const bool maskPreviewActivated = isMaskViewActive();
+        updateExposureGUI3();
+        if (maskPreviewActivated) {
             listener->panelChanged(EvlocallabshowmaskMethod, "");
         }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (inversex->get_active()) {
-                listener->panelChanged(Evlocallabinversex,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinversex,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinversex,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enaExpMask) {
+        if (c->getLastActive()) {
+            maskusablee->show();
+            maskunusablee->hide();
+        } else {
+            maskusablee->hide();
+            maskunusablee->show();
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaExpMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enaExpMaskaft) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaExpMaskaft,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
     }
 }
@@ -4126,43 +4066,6 @@ void LocallabExposure::showmaskexpMethodChangedinv()
     }
 }
 
-void LocallabExposure::enaExpMaskChanged()
-{
-    if (enaExpMask->get_active()) {
-        maskusablee->show();
-        maskunusablee->hide();
-    } else {
-        maskusablee->hide();
-        maskunusablee->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaExpMask->get_active()) {
-                listener->panelChanged(EvLocallabEnaExpMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaExpMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabExposure::enaExpMaskaftChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaExpMaskaft->get_active()) {
-                listener->panelChanged(EvLocallabEnaExpMaskaft,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaExpMaskaft,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabExposure::updateExposureGUI1()
 {
@@ -4200,7 +4103,7 @@ void LocallabExposure::updateExposureGUI3()
     const int mode = complexity->get_active_row_number();
 
     // Update exposure GUI according to inversex button state
-    if (inversex->get_active()) {
+    if (inversex->getLastActive()) {
         expMethod->hide();
         expcomp->setLabel(M("TP_LOCALLAB_EXPCOMPINV"));
         exprecove->hide();
@@ -4318,7 +4221,7 @@ LocallabShadow::LocallabShadow():
     labgridghs(Gtk::manage(new LabGrid(EvlocallabGridciexy, M("TP_LOCALLAB_GHS_GHSDIAG"), true, false, true, false))),
     ghsFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_GHSFRA")))),
     matHBox(Gtk::manage(new Gtk::Box())),   
-    ghs_agx(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_GHS_AGX")))),
+    ghs_agx(Gtk::manage(new CheckBox(M("TP_LOCALLAB_GHS_AGX"), multiImage))),
     ghsMatmet(Gtk::manage(new MyComboBoxText())),
     ghs_D(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GHS_D"), 0., 20.0, 0.001, 0.001))),
     Lab_Frame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_GHSLABFRA")))),
@@ -4335,24 +4238,24 @@ LocallabShadow::LocallabShadow():
     ghs_LC(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GHS_LC"), 0.0, 100.0, 0.1, 10.0))),
     ghs_MID(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GHS_MID"), -100.0, 100.0, 0.1, 0.0))),
     BP_Frame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_GHS_BLACKPOINT_FRAME")))),
-    ghs_autobw(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_GHS_AUTOBW")))),
+    ghs_autobw(Gtk::manage(new CheckBox(M("TP_LOCALLAB_GHS_AUTOBW"), multiImage))),
     ghs_BLP(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GHS_BLP"), -0.2, 1.0, 0.0001, 0.0))),
     ghs_HLP(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GHS_HLP"), 0.2002, 25.0, 0.0001, 1.))),
     ghsbpwpLabels(Gtk::manage(new Gtk::Label("---"))),
     ghsbpwpvalueLabels(Gtk::manage(new Gtk::Label("---"))),
     ghscolorLabels(Gtk::manage(new Gtk::Label("---"))),
     ghsDRLabels(Gtk::manage(new Gtk::Label("---"))),
-    ghs_smooth(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_GHS_SMOOTH")))),
-    ghs_inv(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_GHS_INV")))),
+    ghs_smooth(Gtk::manage(new CheckBox(M("TP_LOCALLAB_GHS_SMOOTH"), multiImage))),
+    ghs_inv(Gtk::manage(new CheckBox(M("TP_LOCALLAB_GHS_INV"), multiImage))),
     expgradsh(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_EXPGRAD")))),
     strSH(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTR"), -4., 4., 0.05, 0.))),
     angSH(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADANG"), -180, 180, 0.1, 0.))),
     featherSH(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FEATVALUE"), 10., 100., 0.1, 25.))),//10.
-    inverssh(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVERS")))),
+    inverssh(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVERS"), multiImage))),
     expmasksh(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWS")))),
     showmaskSHMethod(Gtk::manage(new MyComboBoxText())),
     showmaskSHMethodinv(Gtk::manage(new MyComboBoxText())),
-    enaSHMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enaSHMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //    maskSHCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     maskSHCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskSHshape(static_cast<FlatCurveEditor*>(maskSHCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -4506,10 +4409,10 @@ LocallabShadow::LocallabShadow():
 
     ghs_SP->setLogScale(10, 0);
     ghs_BLP->setLogScale(10, -0.2);
-    ghs_autobwConn = ghs_autobw->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::ghs_autobwChanged));
-    ghs_smoothConn = ghs_smooth->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::ghs_smoothChanged));
-    ghs_invConn = ghs_inv->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::ghs_invChanged));
-    ghs_agxConn = ghs_agx->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::ghs_agxChanged));
+    ghs_autobw->setCheckBoxListener(this);
+    ghs_smooth->setCheckBoxListener(this);
+    ghs_inv->setCheckBoxListener(this);
+    ghs_agx->setCheckBoxListener(this);
 
 
     setExpandAlignProperties(expgradsh, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
@@ -4520,7 +4423,7 @@ LocallabShadow::LocallabShadow():
     angSH->set_tooltip_text(M("TP_LOCALLAB_GRADANG_TOOLTIP"));
     featherSH->setAdjusterListener(this);
 
-    inversshConn = inverssh->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::inversshChanged));
+    inverssh->setCheckBoxListener(this);
     inverssh->set_tooltip_text(M("TP_LOCALLAB_INVERS_TOOLTIP"));
 
     setExpandAlignProperties(expmasksh, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
@@ -4545,7 +4448,7 @@ LocallabShadow::LocallabShadow():
     showmaskSHMethodinv->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskSHMethodConninv = showmaskSHMethodinv->signal_changed().connect(sigc::mem_fun(*this, &LocallabShadow::showmaskSHMethodChangedinv));
 
-    enaSHMaskConn = enaSHMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabShadow::enaSHMaskChanged));
+    enaSHMask->setCheckBoxListener(this);
 
     maskSHCurveEditorG->setCurveListener(this);
 
@@ -4813,19 +4716,19 @@ void LocallabShadow::updateguishad(int spottype)
                 previewsh->hide();
                 exprecovs->hide();
                 expmasksh->hide();
-                enaSHMask->set_active(false);
+                enaSHMask->setValue(false);
                 previewsh->set_active(false);
             } else {
                 sensihs->show();
                 inverssh->show();
                 if (shMethod->get_active_row_number() == 2) {
                     inverssh->hide();
-                    inverssh->set_active(false);
+                    inverssh->setValue(false);
                 }
                
                 exprecovs->show();
                 expmasksh->show();
-                if(!inverssh->get_active()) {
+                if(!inverssh->getLastActive()) {
                     previewsh->show();
                 } else {
                     previewsh->hide();
@@ -5009,14 +4912,8 @@ void LocallabShadow::disableListener()
     shMethodConn.block(true);
     ghsMethodConn.block(true);
     ghsMatmetConn.block(true);
-    inversshConn.block(true);
-    ghs_smoothConn.block(true);
-    ghs_autobwConn.block(true);
-    ghs_agxConn.block(true);
-    ghs_invConn.block(true);
     showmaskSHMethodConn.block(true);
     showmaskSHMethodConninv.block(true);
-    enaSHMaskConn.block(true);
 }
 
 void LocallabShadow::enableListener()
@@ -5025,15 +4922,9 @@ void LocallabShadow::enableListener()
 
     shMethodConn.block(false);
     ghsMethodConn.block(false);
-    ghsMatmetConn.block(false); 
-    ghs_smoothConn.block(false);
-    ghs_autobwConn.block(false);
-    ghs_agxConn.block(false);
-    ghs_invConn.block(false);
-    inversshConn.block(false);
+    ghsMatmetConn.block(false);
     showmaskSHMethodConn.block(false);
     showmaskSHMethodConninv.block(false);
-    enaSHMaskConn.block(false);
 }
 
 void LocallabShadow::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -5124,7 +5015,7 @@ void LocallabShadow::read(const rtengine::procparams::ProcParams* pp, const Para
             ghs_LC->set_sensitive(true); 
             ghs_MID->set_sensitive(true);
         } else {
-            if (ghs_autobw->get_active()) {
+            if (ghs_autobw->getLastActive()) {
                 ghs_BLP->set_sensitive(false);
                 ghs_HLP->set_sensitive(false);
                 ghs_inv->set_sensitive(false);
@@ -5139,9 +5030,9 @@ void LocallabShadow::read(const rtengine::procparams::ProcParams* pp, const Para
                 ghsMatmet->set_sensitive(true);
             }
             ghs_autobw->set_sensitive(true);
-            if(ghs_inv->get_active()) {
+            if(ghs_inv->getLastActive()) {
                 ghs_autobw->set_sensitive(false);
-                ghs_autobw->set_active(false);
+                ghs_autobw->setValue(false);
             }
             ghs_LC->set_sensitive(false); 
             ghs_MID->set_sensitive(false); 
@@ -5166,12 +5057,12 @@ void LocallabShadow::read(const rtengine::procparams::ProcParams* pp, const Para
         strSH->setValue(spot.strSH);
         angSH->setValue(spot.angSH);
         featherSH->setValue(spot.featherSH);
-        inverssh->set_active(spot.inverssh);
-        ghs_smooth->set_active(spot.ghs_smooth);
-        ghs_autobw->set_active(spot.ghs_autobw);
-        ghs_agx->set_active(spot.ghs_agx);
-        ghs_inv->set_active(spot.ghs_inv);
-        enaSHMask->set_active(spot.enaSHMask);
+        inverssh->setValue(spot.inverssh);
+        ghs_smooth->setValue(spot.ghs_smooth);
+        ghs_autobw->setValue(spot.ghs_autobw);
+        ghs_agx->setValue(spot.ghs_agx);
+        ghs_inv->setValue(spot.ghs_inv);
+        enaSHMask->setValue(spot.enaSHMask);
         CCmaskSHshape->setCurve(spot.CCmaskSHcurve);
         LLmaskSHshape->setCurve(spot.LLmaskSHcurve);
         HHmaskSHshape->setCurve(spot.HHmaskSHcurve);
@@ -5194,7 +5085,7 @@ void LocallabShadow::read(const rtengine::procparams::ProcParams* pp, const Para
         ghs_LP->getValue(),
         ghs_SP->getValue(),
         ghs_HP->getValue(),
-        ghs_inv->get_active(),
+        ghs_inv->getLastActive(),
         *labgridghs);
     // Enable all listeners
     enableListener();
@@ -5292,12 +5183,12 @@ void LocallabShadow::write(rtengine::procparams::ProcParams* pp, ParamsEdited* p
         spot.strSH = strSH->getValue();
         spot.angSH = angSH->getValue();
         spot.featherSH = featherSH->getValue();
-        spot.inverssh = inverssh->get_active();
-        spot.ghs_smooth = ghs_smooth->get_active();
-        spot.ghs_autobw = ghs_autobw->get_active();
-        spot.ghs_agx = ghs_agx->get_active();
-        spot.ghs_inv = ghs_inv->get_active();
-        spot.enaSHMask = enaSHMask->get_active();
+        spot.inverssh = inverssh->getLastActive();
+        spot.ghs_smooth = ghs_smooth->getLastActive();
+        spot.ghs_autobw = ghs_autobw->getLastActive();
+        spot.ghs_agx = ghs_agx->getLastActive();
+        spot.ghs_inv = ghs_inv->getLastActive();
+        spot.enaSHMask = enaSHMask->getLastActive();
         spot.LLmaskSHcurve = LLmaskSHshape->getCurve();
         spot.CCmaskSHcurve = CCmaskSHshape->getCurve();
         spot.HHmaskSHcurve = HHmaskSHshape->getCurve();
@@ -5405,7 +5296,7 @@ void LocallabShadow::adjusterChanged(Adjuster* a, double newval)
                 ghs_LC->set_sensitive(true);
                 ghs_MID->set_sensitive(true);
             } else {
-                if (ghs_autobw->get_active()) {
+                if (ghs_autobw->getLastActive()) {
                     ghs_BLP->set_sensitive(false);
                     ghs_HLP->set_sensitive(false);
                     ghs_inv->set_sensitive(false);
@@ -5419,9 +5310,9 @@ void LocallabShadow::adjusterChanged(Adjuster* a, double newval)
                     ghsMatmet->set_sensitive(true);
                 }
                 ghs_autobw->set_sensitive(true);
-                if(ghs_inv->get_active()) {
+                if(ghs_inv->getLastActive()) {
                     ghs_autobw->set_sensitive(false);
-                    ghs_autobw->set_active(false);
+                    ghs_autobw->setValue(false);
                 }
                 ghs_LC->set_sensitive(false);
                 ghs_MID->set_sensitive(false);
@@ -5710,7 +5601,7 @@ void LocallabShadow::adjusterChanged(Adjuster* a, double newval)
                 ghs_LP->getValue(),
                 ghs_SP->getValue(),
                 ghs_HP->getValue(),
-                ghs_inv->get_active(),
+                ghs_inv->getLastActive(),
                 *labgridghs);
         }
     }
@@ -5892,7 +5783,7 @@ void LocallabShadow::convertParamToSimple()
     disableListener();
     // Set hidden specific GUI widgets in Simple mode to default spot values
     ghsMethod->set_active(0);
-    ghs_inv->set_active(false);
+    ghs_inv->setValue(false);
 
     gamSH->setValue(defSpot.gamSH);
     sloSH->setValue(defSpot.sloSH);
@@ -5901,7 +5792,7 @@ void LocallabShadow::convertParamToSimple()
    // strSH->setValue(defSpot.strSH);
     showmaskSHMethod->set_active(0);
     showmaskSHMethodinv->set_active(0);
-    enaSHMask->set_active(defSpot.enaSHMask);
+    enaSHMask->setValue(defSpot.enaSHMask);
  //   CCmaskSHshape->setCurve(defSpot.CCmaskSHcurve);
  //   LLmaskSHshape->setCurve(defSpot.LLmaskSHcurve);
  //   HHmaskSHshape->setCurve(defSpot.HHmaskSHcurve);
@@ -5958,7 +5849,7 @@ void LocallabShadow::updateGUIToMode(const modeType new_type)
             }
 
 
-            if (enaSHMask->get_active()) {
+            if (enaSHMask->getLastActive()) {
                 maskusables->show();
                 maskunusables->hide();
 
@@ -5967,7 +5858,7 @@ void LocallabShadow::updateGUIToMode(const modeType new_type)
                 maskunusables->show();
             }
 
-            if (!inverssh->get_active()) { // Keep widget hidden when inverssh is toggled
+            if (!inverssh->getLastActive()) { // Keep widget hidden when inverssh is toggled
                 exprecovs->show();
             }
             expmasksh->show();
@@ -5994,10 +5885,10 @@ void LocallabShadow::updateGUIToMode(const modeType new_type)
             }
 
 
-            if (!inverssh->get_active()) { // Keep widget hidden when inverssh is toggled
+            if (!inverssh->getLastActive()) { // Keep widget hidden when inverssh is toggled
                 exprecovs->show();
             }
-            if (enaSHMask->get_active()) {
+            if (enaSHMask->getLastActive()) {
                 maskusables->show();
                 maskunusables->hide();
 
@@ -6097,164 +5988,94 @@ void LocallabShadow::ghsMatmetChanged()
     }
 }
 
-void LocallabShadow::inversshChanged()
+void LocallabShadow::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    const bool maskPreviewActivated = isMaskViewActive();
-    if (shMethod->get_active_row_number() == 2) {//GHS
-        inverssh->hide();
-        inverssh->set_active(false);
+    if (!listener) {
+        return;
     }
 
-    // Update shadow highlight GUI according to inverssh button state
-    updateShadowGUImask();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
-            listener->panelChanged(EvlocallabshowmaskMethod, "");
-        }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (inverssh->get_active()) {
-                listener->panelChanged(Evlocallabinverssh,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinverssh,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabShadow::ghs_agxChanged()
-{
     const bool maskPreviewActivated = isMaskViewActive();
 
-    // Update shadow highlight GUI according to inverssh button state
-    updateShadowGUImask();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
+    if (c == inverssh) {
+        if (shMethod->get_active_row_number() == 2) {
+            inverssh->hide();
+            inverssh->setValue(false);
+        }
+        updateShadowGUImask();
+        if (maskPreviewActivated) {
             listener->panelChanged(EvlocallabshowmaskMethod, "");
         }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (ghs_agx->get_active()) {
-                listener->panelChanged(Evlocallabghs_agx,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabghs_agx,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinverssh,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-
-
-void LocallabShadow::ghs_autobwChanged()
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update shadow highlight GUI according to inverssh button state
-    updateShadowGUImask();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
+    } else if (c == ghs_agx) {
+        updateShadowGUImask();
+        if (maskPreviewActivated) {
             listener->panelChanged(EvlocallabshowmaskMethod, "");
         }
-    }
-
-    if (ghs_autobw->get_active()) {
-        ghs_BLP->set_sensitive(false);
-        ghs_HLP->set_sensitive(false);        
-    } else {
-        ghs_BLP->set_sensitive(true);
-        ghs_HLP->set_sensitive(true);              
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (ghs_autobw->get_active()) {
-                nbwb = 0;//initialize count for white point and black point
-                listener->panelChanged(Evlocallabghs_autobw,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabghs_autobw,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabghs_agx,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-
-
-void LocallabShadow::ghs_smoothChanged()
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update shadow highlight GUI according to inverssh button state
-    updateShadowGUImask();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
+    } else if (c == ghs_autobw) {
+        updateShadowGUImask();
+        if (maskPreviewActivated) {
             listener->panelChanged(EvlocallabshowmaskMethod, "");
         }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (ghs_smooth->get_active()) {
-                listener->panelChanged(Evlocallabghs_smooth,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabghs_smooth,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+        if (c->getLastActive()) {
+            ghs_BLP->set_sensitive(false);
+            ghs_HLP->set_sensitive(false);
+        } else {
+            ghs_BLP->set_sensitive(true);
+            ghs_HLP->set_sensitive(true);
         }
-    }
-}
-
-void LocallabShadow::ghs_invChanged()
-
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update shadow highlight GUI according to inverssh button state
-    updateShadowGUImask();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
+        if (isLocActivated && exp->getEnabled()) {
+            if (c->getLastActive()) {
+                nbwb = 0;
+            }
+            listener->panelChanged(Evlocallabghs_autobw,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == ghs_smooth) {
+        updateShadowGUImask();
+        if (maskPreviewActivated) {
             listener->panelChanged(EvlocallabshowmaskMethod, "");
         }
-    }
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (ghs_inv->get_active()) {
-                listener->panelChanged(Evlocallabghs_inv,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabghs_inv,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabghs_smooth,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    } 
-    update_ghs_curve(
-        ghs_B->getValue(),
-        ghs_D->getValue(),
-        ghs_LP->getValue(),
-        ghs_SP->getValue(),
-        ghs_HP->getValue(),
-        ghs_inv->get_active(),
-        *labgridghs);
+    } else if (c == ghs_inv) {
+        updateShadowGUImask();
+        if (maskPreviewActivated) {
+            listener->panelChanged(EvlocallabshowmaskMethod, "");
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabghs_inv,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+        update_ghs_curve(
+            ghs_B->getValue(),
+            ghs_D->getValue(),
+            ghs_LP->getValue(),
+            ghs_SP->getValue(),
+            ghs_HP->getValue(),
+            c->getLastActive(),
+            *labgridghs);
+    } else if (c == enaSHMask) {
+        if (c->getLastActive()) {
+            maskusables->show();
+            maskunusables->hide();
+        } else {
+            maskusables->hide();
+            maskunusables->show();
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaSHMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
 }
 
 
@@ -6296,29 +6117,6 @@ void LocallabShadow::showmaskSHMethodChangedinv()
     }
 }
 
-void LocallabShadow::enaSHMaskChanged()
-{
-    if (enaSHMask->get_active()) {
-        maskusables->show();
-        maskunusables->hide();
-
-    } else {
-        maskusables->hide();
-        maskunusables->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaSHMask->get_active()) {
-                listener->panelChanged(EvLocallabEnaSHMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaSHMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabShadow::updateShadowGUImask()
 {
@@ -6326,11 +6124,11 @@ void LocallabShadow::updateShadowGUImask()
     const LocallabParams::LocallabSpot defSpot;
     if (shMethod->get_active_row_number() == 2) {
         inverssh->hide();
-        inverssh->set_active(false);
+        inverssh->setValue(false);
     }
 
     // Update shadow highlight GUI according to inverssh button state
-    if (inverssh->get_active()) {
+    if (inverssh->getLastActive()) {
         expgradsh->hide();
         showmaskSHMethod->hide();
         // Reset hidden mask combobox
@@ -6354,7 +6152,7 @@ void LocallabShadow::updateShadowGUImask()
             ghs_LC->set_sensitive(true); 
             ghs_MID->set_sensitive(true); 
         } else {
-            if (ghs_autobw->get_active()) {
+            if (ghs_autobw->getLastActive()) {
                 ghs_BLP->set_sensitive(false);
                 ghs_HLP->set_sensitive(false);
                 ghs_inv->set_sensitive(false);
@@ -6368,9 +6166,9 @@ void LocallabShadow::updateShadowGUImask()
                 ghsMatmet->set_sensitive(true);
             }
             ghs_autobw->set_sensitive(true);
-            if(ghs_inv->get_active()) {
+            if(ghs_inv->getLastActive()) {
                 ghs_autobw->set_sensitive(false);
-                ghs_autobw->set_active(false);
+                ghs_autobw->setValue(false);
             }
             ghs_LC->set_sensitive(false); 
             ghs_MID->set_sensitive(false);
@@ -6490,7 +6288,7 @@ void LocallabShadow::updateShadowGUIshmet()
         sh_radius->hide();
         ghsFrame->show();
         inverssh->hide();
-        inverssh->set_active(false);
+        inverssh->setValue(false);
         ghsMethod->hide();
         ghs_slope->hide();
         Lab_Frame->hide();
@@ -6509,7 +6307,7 @@ void LocallabShadow::updateShadowGUIshmet()
             ghs_LC->set_sensitive(true);
             ghs_MID->set_sensitive(true);
        } else {
-            if (ghs_autobw->get_active()) {
+            if (ghs_autobw->getLastActive()) {
                 ghs_BLP->set_sensitive(false);
                 ghs_HLP->set_sensitive(false);
                 ghs_inv->set_sensitive(false);
@@ -6523,9 +6321,9 @@ void LocallabShadow::updateShadowGUIshmet()
                 ghsMatmet->set_sensitive(true);
             }
             ghs_autobw->set_sensitive(true);
-            if(ghs_inv->get_active()) {
+            if(ghs_inv->getLastActive()) {
                ghs_autobw->set_sensitive(false);
-               ghs_autobw->set_active(false);
+               ghs_autobw->setValue(false);
             }
             ghs_LC->set_sensitive(false); 
             ghs_MID->set_sensitive(false); 
@@ -6557,9 +6355,9 @@ LocallabVibrance::LocallabVibrance():
     vibgam(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GAMC"), 0.5, 3., 0.05, 1.))),
     warm(Gtk::manage(new Adjuster(M("TP_LOCALLAB_WARM"), -100., 100., 1., 0., Gtk::manage(new RTImage("circle-blue-small")), Gtk::manage(new RTImage("circle-orange-small"))))),
     psThreshold(Gtk::manage(new ThresholdAdjuster(M("TP_VIBRANCE_PSTHRESHOLD"), -100., 100., 0., M("TP_VIBRANCE_PSTHRESHOLD_WEIGTHING"), 0, 0., 100., 75., M("TP_VIBRANCE_PSTHRESHOLD_SATTHRESH"), 0, this, false))),
-    protectSkins(Gtk::manage(new Gtk::CheckButton(M("TP_VIBRANCE_PROTECTSKINS")))),
-    avoidColorShift(Gtk::manage(new Gtk::CheckButton(M("TP_VIBRANCE_AVOIDCOLORSHIFT")))),
-    pastSatTog(Gtk::manage(new Gtk::CheckButton(M("TP_VIBRANCE_PASTSATTOG")))),
+    protectSkins(Gtk::manage(new CheckBox(M("TP_VIBRANCE_PROTECTSKINS"), multiImage))),
+    avoidColorShift(Gtk::manage(new CheckBox(M("TP_VIBRANCE_AVOIDCOLORSHIFT"), multiImage))),
+    pastSatTog(Gtk::manage(new CheckBox(M("TP_VIBRANCE_PASTSATTOG"), multiImage))),
     sensiv(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 30))),//reused - unused here, but used for normalize_mean_dt 
     previewvib(Gtk::manage(new Gtk::ToggleButton(M("TP_LOCALLAB_PREVIEW")))),
     curveEditorGG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_VIBRANCE_CURVEEDITOR_SKINTONES_LABEL"))),
@@ -6579,7 +6377,7 @@ LocallabVibrance::LocallabVibrance():
     feathervib(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FEATVALUE"), 10., 100., 0.1, 25.))),
     expmaskvib(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWVI")))),
     showmaskvibMethod(Gtk::manage(new MyComboBoxText())),
-    enavibMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enavibMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
  //   maskvibCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     maskvibCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskvibshape(static_cast<FlatCurveEditor*>(maskvibCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -6615,11 +6413,11 @@ LocallabVibrance::LocallabVibrance():
     psThreshold->set_tooltip_markup(M("TP_VIBRANCE_PSTHRESHOLD_TOOLTIP"));
     psThreshold->setAdjusterListener(this);
 
-    pskinsConn = protectSkins->signal_toggled().connect(sigc::mem_fun(*this, &LocallabVibrance::protectskins_toggled));
+    protectSkins->setCheckBoxListener(this);
 
-    ashiftConn = avoidColorShift->signal_toggled().connect(sigc::mem_fun(*this, &LocallabVibrance::avoidcolorshift_toggled));
+    avoidColorShift->setCheckBoxListener(this);
 
-    pastsattogConn = pastSatTog->signal_toggled().connect(sigc::mem_fun(*this, &LocallabVibrance::pastsattog_toggled));
+    pastSatTog->setCheckBoxListener(this);
 
     sensiv->setAdjusterListener(this);
 
@@ -6678,7 +6476,7 @@ LocallabVibrance::LocallabVibrance():
     showmaskvibMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskvibMethodConn = showmaskvibMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabVibrance::showmaskvibMethodChanged));
 
-    enavibMaskConn = enavibMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabVibrance::enavibMaskChanged));
+    enavibMask->setCheckBoxListener(this);
 
     maskvibCurveEditorG->setCurveListener(this);
 
@@ -6809,7 +6607,7 @@ void LocallabVibrance::updateguivib(int spottype)
             if(spottype == 3) {
                 sensiv->hide();
                 previewvib->hide();
-                enavibMask->set_active(false);
+                enavibMask->setValue(false);
                 previewvib->set_active(false);
                 exprecovv->hide();
                 expmaskvib->hide();
@@ -6965,22 +6763,14 @@ void LocallabVibrance::disableListener()
 {
     LocallabTool::disableListener();
 
-    pskinsConn.block(true);
-    ashiftConn.block(true);
-    pastsattogConn.block(true);
     showmaskvibMethodConn.block(true);
-    enavibMaskConn.block(true);
 }
 
 void LocallabVibrance::enableListener()
 {
     LocallabTool::enableListener();
 
-    pskinsConn.block(false);
-    ashiftConn.block(false);
-    pastsattogConn.block(false);
     showmaskvibMethodConn.block(false);
-    enavibMaskConn.block(false);
 }
 
 void LocallabVibrance::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -7003,9 +6793,9 @@ void LocallabVibrance::read(const rtengine::procparams::ProcParams* pp, const Pa
         vibgam->setValue(spot.vibgam);
         warm->setValue(spot.warm);
         psThreshold->setValue<int>(spot.psthreshold);
-        protectSkins->set_active(spot.protectskins);
-        avoidColorShift->set_active(spot.avoidcolorshift);
-        pastSatTog->set_active(spot.pastsattog);
+        protectSkins->setValue(spot.protectskins);
+        avoidColorShift->setValue(spot.avoidcolorshift);
+        pastSatTog->setValue(spot.pastsattog);
         sensiv->setValue(spot.sensiv);
         skinTonesCurve->setCurve(spot.skintonescurve);
         strvib->setValue(spot.strvib);
@@ -7013,7 +6803,7 @@ void LocallabVibrance::read(const rtengine::procparams::ProcParams* pp, const Pa
         strvibh->setValue(spot.strvibh);
         angvib->setValue(spot.angvib);
         feathervib->setValue(spot.feathervib);
-        enavibMask->set_active(spot.enavibMask);
+        enavibMask->setValue(spot.enavibMask);
         CCmaskvibshape->setCurve(spot.CCmaskvibcurve);
         LLmaskvibshape->setCurve(spot.LLmaskvibcurve);
         HHmaskvibshape->setCurve(spot.HHmaskvibcurve);
@@ -7058,9 +6848,9 @@ void LocallabVibrance::write(rtengine::procparams::ProcParams* pp, ParamsEdited*
         spot.vibgam = vibgam->getValue();
         spot.warm = warm->getIntValue();
         spot.psthreshold = psThreshold->getValue<int>();
-        spot.protectskins = protectSkins->get_active();
-        spot.avoidcolorshift = avoidColorShift->get_active();
-        spot.pastsattog = pastSatTog->get_active();
+        spot.protectskins = protectSkins->getLastActive();
+        spot.avoidcolorshift = avoidColorShift->getLastActive();
+        spot.pastsattog = pastSatTog->getLastActive();
         spot.sensiv = sensiv->getIntValue();
         spot.skintonescurve = skinTonesCurve->getCurve();
         spot.strvib = strvib->getValue();
@@ -7068,7 +6858,7 @@ void LocallabVibrance::write(rtengine::procparams::ProcParams* pp, ParamsEdited*
         spot.strvibh = strvibh->getValue();
         spot.angvib = angvib->getValue();
         spot.feathervib = feathervib->getValue();
-        spot.enavibMask = enavibMask->get_active();
+        spot.enavibMask = enavibMask->getLastActive();
         spot.CCmaskvibcurve = CCmaskvibshape->getCurve();
         spot.LLmaskvibcurve = LLmaskvibshape->getCurve();
         spot.HHmaskvibcurve = HHmaskvibshape->getCurve();
@@ -7125,12 +6915,12 @@ void LocallabVibrance::setDefaults(const rtengine::procparams::ProcParams* defPa
 void LocallabVibrance::adjusterChanged(Adjuster* a, double newval)
 {
     // Copy pastels adjuster value to saturated one according to pastSatTog button state
-    if (a == pastels && pastSatTog->get_active()) {
+    if (a == pastels && pastSatTog->getLastActive()) {
         saturated->setValue(newval);
     }
 
     if (isLocActivated && exp->getEnabled()) {
-        if (a == saturated && !pastSatTog->get_active()) {
+        if (a == saturated && !pastSatTog->getLastActive()) {
             if (listener) {
                 listener->panelChanged(EvlocallabSaturated,
                                        saturated->getTextValue() + " (" + escapeHtmlChars(getSpotName()) + ")");
@@ -7398,9 +7188,9 @@ void LocallabVibrance::convertParamToNormal()
     vibgam->setValue(defSpot.vibgam);
 
     psThreshold->setValue<int>(defSpot.psthreshold);
-    protectSkins->set_active(defSpot.protectskins);
-    avoidColorShift->set_active(defSpot.avoidcolorshift);
-    pastSatTog->set_active(defSpot.pastsattog);
+    protectSkins->setValue(defSpot.protectskins);
+    avoidColorShift->setValue(defSpot.avoidcolorshift);
+    pastSatTog->setValue(defSpot.pastsattog);
     skinTonesCurve->setCurve(defSpot.skintonescurve);
     strvibab->setValue(defSpot.strvibab);
     strvibh->setValue(defSpot.strvibh);
@@ -7432,7 +7222,7 @@ void LocallabVibrance::convertParamToSimple()
     strvibh->setValue(defSpot.strvibh);
   
     showmaskvibMethod->set_active(0);
-    enavibMask->set_active(defSpot.enavibMask);
+    enavibMask->setValue(defSpot.enavibMask);
   //  CCmaskvibshape->setCurve(defSpot.CCmaskvibcurve);
   //  LLmaskvibshape->setCurve(defSpot.LLmaskvibcurve);
    // HHmaskvibshape->setCurve(defSpot.HHmaskvibcurve);
@@ -7491,7 +7281,7 @@ void LocallabVibrance::updateGUIToMode(const modeType new_type)
             expmaskvib->show();
             exprecovv->show();
             decayv->hide();
-            if (enavibMask->get_active()) {
+            if (enavibMask->getLastActive()) {
                 maskusablev->show();
                 maskunusablev->hide();
 
@@ -7520,7 +7310,7 @@ void LocallabVibrance::updateGUIToMode(const modeType new_type)
             slomaskvib->show();
             exprecovv->show();
             decayv->show();
-            if (enavibMask->get_active()) {
+            if (enavibMask->getLastActive()) {
                 maskusablev->show();
                 maskunusablev->hide();
 
@@ -7548,50 +7338,39 @@ void LocallabVibrance::updateMaskBackground(const double normChromar, const doub
     );
 }
 
-void LocallabVibrance::protectskins_toggled()
+void LocallabVibrance::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (protectSkins->get_active()) {
-                listener->panelChanged(EvlocallabProtectSkins,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabProtectSkins,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
+    if (!listener) {
+        return;
     }
-}
 
-void LocallabVibrance::avoidcolorshift_toggled()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (avoidColorShift->get_active()) {
-                listener->panelChanged(EvlocallabAvoidColorShift,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabAvoidColorShift,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    if (c == protectSkins) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvlocallabProtectSkins,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-void LocallabVibrance::pastsattog_toggled()
-{
-    // Update vibrance GUI according to pastsattog button state
-    updateVibranceGUI();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (pastSatTog->get_active()) {
-                listener->panelChanged(EvlocallabPastSatTog,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabPastSatTog,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    } else if (c == avoidColorShift) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvlocallabAvoidColorShift,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == pastSatTog) {
+        updateVibranceGUI();
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvlocallabPastSatTog,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enavibMask) {
+        if (c->getLastActive()) {
+            maskusablev->show();
+            maskunusablev->hide();
+        } else {
+            maskusablev->hide();
+            maskunusablev->show();
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnavibMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
     }
 }
@@ -7610,34 +7389,11 @@ void LocallabVibrance::showmaskvibMethodChanged()
     }
 }
 
-void LocallabVibrance::enavibMaskChanged()
-{
-    if (enavibMask->get_active()) {
-        maskusablev->show();
-        maskunusablev->hide();
-
-    } else {
-        maskusablev->hide();
-        maskunusablev->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enavibMask->get_active()) {
-                listener->panelChanged(EvLocallabEnavibMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnavibMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabVibrance::updateVibranceGUI()
 {
     // Update vibrance GUI according to pastsattog button state
-    if (pastSatTog->get_active()) {
+    if (pastSatTog->getLastActive()) {
         // Link both slider, so we set saturated and psThresholds unsensitive
         psThreshold->set_sensitive(false);
         saturated->set_sensitive(false);
@@ -8071,7 +7827,7 @@ LocallabBlur::LocallabBlur():
     // Blur, Noise & Denoise specific widgets
     expblnoise(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_BLNOI_EXP")))),
     blMethod(Gtk::manage(new MyComboBoxText())),
-    fftwbl(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTWBLUR")))),
+    fftwbl(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTWBLUR"), multiImage))),
     radius(Gtk::manage(new Adjuster(M("TP_LOCALLAB_RADIUS"), MINRAD, MAXRAD, 0.1, 1.5, nullptr, nullptr, &blurSlider2radius, &blurRadius2Slider))),
     strength(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRENGTH"), 0, 100, 1, 0))),
     grainFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_GRAINFRA")))),
@@ -8091,15 +7847,15 @@ LocallabBlur::LocallabBlur():
     higthres(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHR2"), 20., 99., 0.5, 85.))),
     sensibn(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 40))),
     blurMethod(Gtk::manage(new MyComboBoxText())),
-    invbl(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVBL")))),
+    invbl(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVBL"), multiImage))),
     chroMethod(Gtk::manage(new MyComboBoxText())),
-    activlum(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ACTIV")))),
+    activlum(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ACTIV"), multiImage))),
     expdenoise(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_DENOI_EXP")))),
     denoFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_DENOIFRA")))),
-    enacontrast(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_DENOIENA")))),
+    enacontrast(Gtk::manage(new CheckBox(M("TP_LOCALLAB_DENOIENA"), multiImage))),
     denocontrast(Gtk::manage(new Adjuster(M("TP_SHARPENING_CONTRAST"), 0.5, 100., 0.5, 10.))),
     denoratio(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DENOIRATIO"), 0, 100, 1, 95))),
-    contrshow(Gtk::manage(new Gtk::CheckButton(M("TP_PDSHARPENING_SHOWCAP")))),
+    contrshow(Gtk::manage(new CheckBox(M("TP_PDSHARPENING_SHOWCAP"), multiImage))),
     denomask(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DENOI_MASK"), 0., 100., 1., 30.))),
     quamethod(Gtk::manage(new MyComboBoxText())),
     expdenoisenl(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_NLFRA")))),
@@ -8113,7 +7869,7 @@ LocallabBlur::LocallabBlur():
     lum46Labels(Gtk::manage(new Gtk::Label("---"))),
     chroLabels(Gtk::manage(new Gtk::Label("---"))),
     chro46Labels(Gtk::manage(new Gtk::Label("---"))),
-    lockmadl(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LOCKMADL")))),
+    lockmadl(Gtk::manage(new CheckBox(M("TP_LOCALLAB_LOCKMADL"), multiImage))),
     madlFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_MADLFRA")))),
 
     madls([]() -> std::array<Adjuster *, 21>
@@ -8138,7 +7894,7 @@ LocallabBlur::LocallabBlur():
         return res;
     }
     ()),
-    madllock(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LOCKMADL2")))),
+    madllock(Gtk::manage(new CheckBox(M("TP_LOCALLAB_LOCKMADL2"), multiImage))),
     
     expdenoise1(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_DENOI1_EXP")))),
     maskusable(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUSABLE")))),
@@ -8147,7 +7903,7 @@ LocallabBlur::LocallabBlur():
     maskunusable2(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUNUSABLE")))),
     maskusable3(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUSABLE")))),
     maskunusable3(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUNUSABLE")))),
-    usemask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_USEMASK")))),
+    usemask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_USEMASK"), multiImage))),
     lnoiselow(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLNOISELOW"), 0.7, 2., 0.01, 1.))),
     levelthr(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHR2"), 20., 99., 0.5, 85.))),
     levelthrlow(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHRLOW2"), 1., 80., 0.5, 12.))),
@@ -8175,8 +7931,8 @@ LocallabBlur::LocallabBlur():
     midthresdch(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHRMIDCH"), 0., 100., 0.5, 0.))),
     higthresd(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHR2"), 20., 99., 0.5, 85.))),
     decayd(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
-    invmaskd(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVMASK")))),
-    invmask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVMASK")))),
+    invmaskd(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVMASK"), multiImage))),
+    invmask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVMASK"), multiImage))),
     prevFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LCLABELS")))),
     nlstr(Gtk::manage(new Adjuster(M("TP_LOCALLAB_NLLUM"), 0, 100, 1, 0))),
     nldet(Gtk::manage(new Adjuster(M("TP_LOCALLAB_NLDET"), 0, 100, 1, 50))),
@@ -8191,14 +7947,14 @@ LocallabBlur::LocallabBlur():
     expmaskbl(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWPLUS")))),
     showmaskblMethod(Gtk::manage(new MyComboBoxText())),
     showmaskblMethodtyp(Gtk::manage(new MyComboBoxText())),
-    enablMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enablMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //    maskblCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     maskblCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskblshape(static_cast<FlatCurveEditor*>(maskblCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
     LLmaskblshape(static_cast<FlatCurveEditor*>(maskblCurveEditorG->addCurve(CT_Flat, "L", nullptr, false, false))),
     HHmaskblshape(static_cast<FlatCurveEditor *>(maskblCurveEditorG->addCurve(CT_Flat, "LC(h)", nullptr, false, true))),
     strumaskbl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRUMASKCOL"), 0., 200., 0.1, 0.))),
-    toolbl(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_TOOLCOL")))),
+    toolbl(Gtk::manage(new CheckBox(M("TP_LOCALLAB_TOOLCOL"), multiImage))),
     toolblFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_TOOLMASK")))),
     toolblFrame2(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_TOOLMASK_2")))),
     blendmaskbl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLENDMASKCOL"), -100, 100, 1, 0))),
@@ -8251,15 +8007,15 @@ LocallabBlur::LocallabBlur():
     blMethod->set_active(0);
     blMethodConn = blMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabBlur::blMethodChanged));
 
-    fftwblConn = fftwbl->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::fftwblChanged));
-    usemaskConn = usemask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::usemaskChanged));
-    invblConn = invbl->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::invblChanged));
-    invmaskdConn = invmaskd->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::invmaskdChanged));
-    invmaskConn = invmask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::invmaskChanged));
-    contrshowConn = contrshow->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::contrshowChanged));
-    enacontrastConn = enacontrast->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::enacontrastChanged));
-    lockmadlConn = lockmadl->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::lockmadlChanged));
-    madllockConn = madllock->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::madllockChanged));
+    fftwbl->setCheckBoxListener(this);
+    usemask->setCheckBoxListener(this);
+    invbl->setCheckBoxListener(this);
+    invmaskd->setCheckBoxListener(this);
+    invmask->setCheckBoxListener(this);
+    contrshow->setCheckBoxListener(this);
+    enacontrast->setCheckBoxListener(this);
+    lockmadl->setCheckBoxListener(this);
+    madllock->setCheckBoxListener(this);
     for (const auto adj : madls) {
         adj->setAdjusterListener(this);
     }
@@ -8318,7 +8074,7 @@ LocallabBlur::LocallabBlur():
     chroMethod->set_active(0);
     chroMethodConn = chroMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabBlur::chroMethodChanged));
 
-    activlumConn = activlum->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::activlumChanged));
+    activlum->setCheckBoxListener(this);
 
     setExpandAlignProperties(expdenoise, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
 
@@ -8451,7 +8207,7 @@ LocallabBlur::LocallabBlur():
     showmaskblMethodtyp->set_active(1);
     showmaskblMethodtypConn = showmaskblMethodtyp->signal_changed().connect(sigc::mem_fun(*this, &LocallabBlur::showmaskblMethodtypChanged));
 
-    enablMaskConn = enablMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::enablMaskChanged));
+    enablMask->setCheckBoxListener(this);
 
     maskblCurveEditorG->setCurveListener(this);
 
@@ -8472,7 +8228,7 @@ LocallabBlur::LocallabBlur():
 
     strumaskbl->setAdjusterListener(this);
 
-    toolblConn = toolbl->signal_toggled().connect(sigc::mem_fun(*this, &LocallabBlur::toolblChanged));
+    toolbl->setCheckBoxListener(this);
 
     blendmaskbl->setAdjusterListener(this);
 
@@ -8744,7 +8500,7 @@ void LocallabBlur::updateguiblur(int spottype)
                 invbl->hide();
                 expmaskbl->hide();
                 expdenoise2->hide();
-                enablMask->set_active(false);
+                enablMask->setValue(false);
             } else {
                 sensibn->show();
                 sensiden->show();
@@ -8955,9 +8711,9 @@ void LocallabBlur::neutral_pressed ()
     wavshapeden->setCurve(defSpot.locwavcurveden);
     wavhue->setCurve(defSpot.locwavcurvehue);
     wavhuecont->setCurve(defSpot.locwavcurvehuecont);
-    usemask->set_active(defSpot.usemask);
-    invmaskd->set_active(defSpot.invmaskd);
-    invmask->set_active(defSpot.invmask);
+    usemask->setValue(defSpot.usemask);
+    invmaskd->setValue(defSpot.invmaskd);
+    invmask->setValue(defSpot.invmask);
     recothresd->setValue(defSpot.recothresd);
     lowthresd->setValue(defSpot.lowthresd);
     midthresd->setValue(defSpot.midthresd);
@@ -9076,24 +8832,12 @@ void LocallabBlur::disableListener()
     LocallabTool::disableListener();
 
     blMethodConn.block(true);
-    fftwblConn.block(true);
-    usemaskConn.block(true);
-    invmaskdConn.block(true);
-    invmaskConn.block(true);
-    invblConn.block(true);
     medMethodConn.block(true);
     blurMethodConn.block(true);
     chroMethodConn.block(true);
     quamethodconn.block(true);
-    activlumConn.block(true);
     showmaskblMethodConn.block(true);
     showmaskblMethodtypConn.block(true);
-    enablMaskConn.block(true);
-    toolblConn.block(true);
-    enacontrastConn.block(true);
-    contrshowConn.block(true);
-    lockmadlConn.block(true);
-    madllockConn.block(true);
 }
 
 void LocallabBlur::enableListener()
@@ -9101,24 +8845,12 @@ void LocallabBlur::enableListener()
     LocallabTool::enableListener();
 
     blMethodConn.block(false);
-    fftwblConn.block(false);
-    usemaskConn.block(false);
-    invmaskdConn.block(false);
-    invmaskConn.block(false);
-    invblConn.block(false);
     medMethodConn.block(false);
     blurMethodConn.block(false);
     chroMethodConn.block(false);
     quamethodconn.block(false);
-    activlumConn.block(false);
     showmaskblMethodConn.block(false);
     showmaskblMethodtypConn.block(false);
-    enablMaskConn.block(false);
-    toolblConn.block(false);
-    enacontrastConn.block(false);
-    contrshowConn.block(false);
-    lockmadlConn.block(false);
-    madllockConn.block(false);
 
 }
 
@@ -9148,11 +8880,11 @@ void LocallabBlur::read(const rtengine::procparams::ProcParams* pp, const Params
             madls[i]->setValue(spot.madlsav[i]);
         }
 
-        fftwbl->set_active(spot.fftwbl);
-        usemask->set_active(spot.usemask);
-        invmaskd->set_active(spot.invmaskd);
-        invmask->set_active(spot.invmask);
-        invbl->set_active(spot.invbl);
+        fftwbl->setValue(spot.fftwbl);
+        usemask->setValue(spot.usemask);
+        invmaskd->setValue(spot.invmaskd);
+        invmask->setValue(spot.invmask);
+        invbl->setValue(spot.invbl);
         radius->setValue(spot.radius);
         strength->setValue(spot.strength);
         isogr->setValue((double)spot.isogr);
@@ -9212,7 +8944,7 @@ void LocallabBlur::read(const rtengine::procparams::ProcParams* pp, const Params
             quamethod->set_active(3);
         }
 
-        activlum->set_active(spot.activlum);
+        activlum->setValue(spot.activlum);
         wavshapeden->setCurve(spot.locwavcurveden);
         wavhue->setCurve(spot.locwavcurvehue);
         wavhuecont->setCurve(spot.locwavcurvehuecont);
@@ -9248,12 +8980,12 @@ void LocallabBlur::read(const rtengine::procparams::ProcParams* pp, const Params
             showmaskblMethodtyp->set_active(2);
         }
 
-        enablMask->set_active(spot.enablMask);
+        enablMask->setValue(spot.enablMask);
         CCmaskblshape->setCurve(spot.CCmaskblcurve);
         LLmaskblshape->setCurve(spot.LLmaskblcurve);
         HHmaskblshape->setCurve(spot.HHmaskblcurve);
         strumaskbl->setValue(spot.strumaskbl);
-        toolbl->set_active(spot.toolbl);
+        toolbl->setValue(spot.toolbl);
         blendmaskbl->setValue((double)spot.blendmaskbl);
         radmaskbl->setValue(spot.radmaskbl);
         lapmaskbl->setValue(spot.lapmaskbl);
@@ -9267,10 +8999,10 @@ void LocallabBlur::read(const rtengine::procparams::ProcParams* pp, const Params
         csThresholdblur->setValue<int>(spot.csthresholdblur);
         denocontrast->setValue((double)spot.denocontrast);
         denocontrast->setAutoValue(spot.denoAutocontrast);
-        contrshow->set_active(spot.contrshow);
-        lockmadl->set_active(spot.lockmadl);
-        madllock->set_active(spot.madllock);
-        enacontrast->set_active(spot.enacontrast);
+        contrshow->setValue(spot.contrshow);
+        lockmadl->setValue(spot.lockmadl);
+        madllock->setValue(spot.madllock);
+        enacontrast->setValue(spot.enacontrast);
         denoratio->setValue((double)spot.denoratio);
         denomask->setValue((double)spot.denomask);
 
@@ -9310,11 +9042,11 @@ void LocallabBlur::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
             spot.madlsav[i] =  madls[i]->getValue();
         }
 
-        spot.fftwbl = fftwbl->get_active();
-        spot.usemask = usemask->get_active();
-        spot.invmaskd = invmaskd->get_active();
-        spot.invmask = invmask->get_active();
-        spot.invbl = invbl->get_active();
+        spot.fftwbl = fftwbl->getLastActive();
+        spot.usemask = usemask->getLastActive();
+        spot.invmaskd = invmaskd->getLastActive();
+        spot.invmask = invmask->getLastActive();
+        spot.invbl = invbl->getLastActive();
         spot.radius = radius->getValue();
         spot.strength = strength->getIntValue();
         spot.isogr = isogr->getIntValue();
@@ -9374,7 +9106,7 @@ void LocallabBlur::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
             spot.quamethod = "nlmean";
         }
 
-        spot.activlum = activlum->get_active();
+        spot.activlum = activlum->getLastActive();
         spot.locwavcurveden = wavshapeden->getCurve();
         spot.locwavcurvehue = wavhue->getCurve();
         spot.locwavcurvehuecont = wavhuecont->getCurve();
@@ -9410,12 +9142,12 @@ void LocallabBlur::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
             spot.showmaskblMethodtyp = "all";
         }
 
-        spot.enablMask = enablMask->get_active();
+        spot.enablMask = enablMask->getLastActive();
         spot.LLmaskblcurve = LLmaskblshape->getCurve();
         spot.CCmaskblcurve = CCmaskblshape->getCurve();
         spot.HHmaskblcurve = HHmaskblshape->getCurve();
         spot.strumaskbl = strumaskbl->getValue();
-        spot.toolbl = toolbl->get_active();
+        spot.toolbl = toolbl->getLastActive();
         spot.blendmaskbl = blendmaskbl->getIntValue();
         spot.radmaskbl = radmaskbl->getValue();
         spot.lapmaskbl = lapmaskbl->getValue();
@@ -9429,10 +9161,10 @@ void LocallabBlur::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
         spot.csthresholdblur = csThresholdblur->getValue<int>();
         spot.denocontrast = denocontrast->getValue();
         spot.denoAutocontrast = denocontrast->getAutoValue();
-        spot.contrshow = contrshow->get_active();
-        spot.lockmadl = lockmadl->get_active();
-        spot.madllock = madllock->get_active();
-        spot.enacontrast = enacontrast->get_active();
+        spot.contrshow = contrshow->getLastActive();
+        spot.lockmadl = lockmadl->getLastActive();
+        spot.madllock = madllock->getLastActive();
+        spot.enacontrast = enacontrast->getLastActive();
         spot.denoratio = denoratio->getValue();
         spot.denomask = denomask->getValue();
 
@@ -9515,64 +9247,98 @@ void LocallabBlur::setDefaults(const rtengine::procparams::ProcParams* defParams
     // Note: No need to manage pedited as batch mode is deactivated for Locallab
 }
 
-void LocallabBlur::enacontrastChanged()
+
+void LocallabBlur::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enacontrast->get_active()) {
-                listener->panelChanged(Evlocallabenacontrast,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabenacontrast,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
+    if (!listener) {
+        return;
     }
-}
 
-
-
-void LocallabBlur::contrshowChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (contrshow->get_active()) {
-                listener->panelChanged(Evlocallabcontrshow,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabcontrshow,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    if (c == enacontrast) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabenacontrast,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-void LocallabBlur::lockmadlChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (lockmadl->get_active()) {
-                listener->panelChanged(Evlocallablockmadl,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallablockmadl,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    } else if (c == contrshow) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabcontrshow,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-void LocallabBlur::madllockChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (madllock->get_active()) {
-                listener->panelChanged(Evlocallabmadllock,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabmadllock,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    } else if (c == lockmadl) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallablockmadl,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == madllock) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabmadllock,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == fftwbl) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabfftwbl,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == usemask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabusemask1,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == invmaskd) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinvmaskd,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == invmask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinvmask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == invbl) {
+        const LocallabParams::LocallabSpot defSpot;
+        if (invbl->getLastActive() && blMethod->get_active_row_number() == 2) {
+            radius->setValue(defSpot.radius);
+            medMethod->set_active(0);
+        } else if (invbl->getLastActive() && blMethod->get_active_row_number() == 0) {
+            guidbl->setValue(defSpot.guidbl);
+            medMethod->set_active(0);
+        } else if (invbl->getLastActive() && blMethod->get_active_row_number() == 1) {
+            radius->setValue(defSpot.radius);
+            guidbl->setValue(defSpot.guidbl);
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinvbl,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == activlum) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabactivlum,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enablMask) {
+        if (enablMask->getLastActive()) {
+            maskusable->show();
+            maskunusable->hide();
+            maskusable2->show();
+            maskunusable2->hide();
+            maskusable3->show();
+            maskunusable3->hide();
+        } else {
+            maskusable->hide();
+            maskunusable->show();
+            maskusable2->hide();
+            maskunusable2->show();
+            maskusable3->hide();
+            maskunusable3->show();
+        }
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnablMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == toolbl) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabtoolbl,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
     }
 }
@@ -10132,12 +9898,12 @@ void LocallabBlur::convertParamToNormal()
 
     // Disable all listeners
     disableListener();
-    invmask->set_active(defSpot.invmask);
-    invmaskd->set_active(defSpot.invmaskd);
+    invmask->setValue(defSpot.invmask);
+    invmaskd->setValue(defSpot.invmaskd);
     // Set hidden GUI widgets in Normal mode to default spot values
-    fftwbl->set_active(defSpot.fftwbl);
+    fftwbl->setValue(defSpot.fftwbl);
     strumaskbl->setValue(defSpot.strumaskbl);
-    toolbl->set_active(defSpot.toolbl);
+    toolbl->setValue(defSpot.toolbl);
     decayd->setValue(defSpot.decayd);
     lapmaskbl->setValue(defSpot.lapmaskbl);
     shadmaskbl->setValue((double)defSpot.shadmaskbl);
@@ -10147,7 +9913,7 @@ void LocallabBlur::convertParamToNormal()
     lnoiselow->setValue(defSpot.lnoiselow);
     nlrad->setValue(defSpot.nlrad);
     noisegam->setValue(defSpot.noisegam);
-    madllock->set_active(defSpot.madllock);
+    madllock->setValue(defSpot.madllock);
 
     // Enable all listeners
     enableListener();
@@ -10159,12 +9925,12 @@ void LocallabBlur::convertParamToSimple()
 
     // Disable all listeners
     disableListener();
-    invmask->set_active(defSpot.invmask);
-    invmaskd->set_active(defSpot.invmaskd);
+    invmask->setValue(defSpot.invmask);
+    invmaskd->setValue(defSpot.invmaskd);
     scalegr->setValue(defSpot.scalegr);
     // Set hidden specific GUI widgets in Simple mode to default spot values
     showmaskblMethod->set_active(0);
-    madllock->set_active(defSpot.madllock);
+    madllock->setValue(defSpot.madllock);
     
     if (defSpot.showmaskblMethodtyp == "blur") {
         showmaskblMethodtyp ->set_active(0);
@@ -10174,7 +9940,7 @@ void LocallabBlur::convertParamToSimple()
         showmaskblMethodtyp->set_active(2);
     }
     lnoiselow->setValue(defSpot.lnoiselow);
-    enablMask->set_active(defSpot.enablMask);
+    enablMask->setValue(defSpot.enablMask);
  //   CCmaskblshape->setCurve(defSpot.CCmaskblcurve);
  //   LLmaskblshape->setCurve(defSpot.LLmaskblcurve);
  //   HHmaskblshape->setCurve(defSpot.HHmaskblcurve);
@@ -10187,9 +9953,9 @@ void LocallabBlur::convertParamToSimple()
     levelthr->setValue(defSpot.levelthr);
     lnoiselow->setValue(defSpot.lnoiselow);
     levelthrlow->setValue(defSpot.levelthrlow);
-    usemask->set_active(defSpot.usemask);
-    invmaskd->set_active(defSpot.invmaskd);
-    invmask->set_active(defSpot.invmask);
+    usemask->setValue(defSpot.usemask);
+    invmaskd->setValue(defSpot.invmaskd);
+    invmask->setValue(defSpot.invmask);
     recothresd->setValue(defSpot.recothresd);
     lowthresd->setValue(defSpot.lowthresd);
     midthresd->setValue(defSpot.midthresd);
@@ -10291,7 +10057,7 @@ void LocallabBlur::updateGUIToMode(const modeType new_type)
                 }
             }
 
-            if (enablMask->get_active()) {
+            if (enablMask->getLastActive()) {
                 maskusable->show();
                 maskunusable->hide();
                 maskusable2->show();
@@ -10367,7 +10133,7 @@ void LocallabBlur::updateGUIToMode(const modeType new_type)
                 }
             }
 
-            if (enablMask->get_active()) {
+            if (enablMask->getLastActive()) {
                 maskusable->show();
                 maskunusable->hide();
                 maskusable2->show();
@@ -10414,13 +10180,13 @@ void LocallabBlur::blMethodChanged()
     } else {
         epsbl->hide();      
     }
-    if (invbl->get_active()  &&  blMethod->get_active_row_number() == 2) {
+    if (invbl->getLastActive()  &&  blMethod->get_active_row_number() == 2) {
         radius->setValue(defSpot.radius);
         medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 0) {
+    } else if(invbl->getLastActive()  &&  blMethod->get_active_row_number() == 0) {
         guidbl->setValue(defSpot.guidbl);
         medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 1) {
+    } else if(invbl->getLastActive()  &&  blMethod->get_active_row_number() == 1) {
         radius->setValue(defSpot.radius);
         guidbl->setValue(defSpot.guidbl);
     }
@@ -10434,96 +10200,6 @@ void LocallabBlur::blMethodChanged()
     }
 }
 
-void LocallabBlur::fftwblChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftwbl->get_active()) {
-                listener->panelChanged(Evlocallabfftwbl,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabfftwbl,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabBlur::usemaskChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (usemask->get_active()) {
-                listener->panelChanged(Evlocallabusemask1,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabusemask1,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabBlur::invmaskdChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (invmaskd->get_active()) {
-                listener->panelChanged(Evlocallabinvmaskd,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinvmaskd,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabBlur::invmaskChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (invmask->get_active()) {
-                listener->panelChanged(Evlocallabinvmask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinvmask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-
-void LocallabBlur::invblChanged()
-{
-    const LocallabParams::LocallabSpot defSpot;
-
-    if (invbl->get_active()  &&  blMethod->get_active_row_number() == 2) {
-        radius->setValue(defSpot.radius);
-        medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 0) {
-        guidbl->setValue(defSpot.guidbl);
-        medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 1) {
-        radius->setValue(defSpot.radius);
-        guidbl->setValue(defSpot.guidbl);
-    }
-
-
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (invbl->get_active()) {
-                listener->panelChanged(Evlocallabinvbl,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinvbl,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabBlur::medMethodChanged()
 {
@@ -10566,20 +10242,6 @@ void LocallabBlur::quamethodChanged()
 }
 
 
-void LocallabBlur::activlumChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (activlum->get_active()) {
-                listener->panelChanged(Evlocallabactivlum,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabactivlum,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabBlur::showmaskblMethodChanged()
 {
@@ -10622,63 +10284,19 @@ void LocallabBlur::showmaskblMethodtypChanged()
     }
 }
 
-void LocallabBlur::enablMaskChanged()
-{
-    if (enablMask->get_active()) {
-        maskusable->show();
-        maskunusable->hide();
-        maskusable2->show();
-        maskunusable2->hide();
-        maskusable3->show();
-        maskunusable3->hide();
-    } else {
-        maskusable->hide();
-        maskunusable->show();
-        maskusable2->hide();
-        maskunusable2->show();
-        maskusable3->hide();
-        maskunusable3->show();
-    }
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enablMask->get_active()) {
-                listener->panelChanged(EvLocallabEnablMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnablMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabBlur::toolblChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (toolbl->get_active()) {
-                listener->panelChanged(Evlocallabtoolbl,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabtoolbl,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabBlur::updateBlurGUI()
 {
     const LocallabParams::LocallabSpot defSpot;
 
-    if (invbl->get_active()  &&  blMethod->get_active_row_number() == 2) {
+    if (invbl->getLastActive()  &&  blMethod->get_active_row_number() == 2) {
         radius->setValue(defSpot.radius);
         medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 0) {
+    } else if(invbl->getLastActive()  &&  blMethod->get_active_row_number() == 0) {
         guidbl->setValue(defSpot.guidbl);
         medMethod->set_active(0);
-    } else if(invbl->get_active()  &&  blMethod->get_active_row_number() == 1) {
+    } else if(invbl->getLastActive()  &&  blMethod->get_active_row_number() == 1) {
         radius->setValue(defSpot.radius);
         guidbl->setValue(defSpot.guidbl);
     }

--- a/rtgui/tools/locallabtools.h
+++ b/rtgui/tools/locallabtools.h
@@ -25,6 +25,7 @@
 #include "toolpanel.h"
 #include "widgets/basic/adjuster.h"
 #include "widgets/basic/thresholdadjuster.h"
+#include "widgets/basic/checkbox.h"
 #include "widgets/curves/curveeditorgroup.h"
 #include "widgets/curves/curveeditor.h"
 
@@ -169,7 +170,7 @@ protected:
     bool isLocActivated;
     const Glib::ustring *spotNameSource;
     LocallabToolListener* locToolListener;
-
+    Gtk::Box* content;
     // LocallabTool generic widgets
     MyExpander* exp;
     MyComboBoxText* const complexity;
@@ -219,7 +220,8 @@ public:
     {
         locToolListener = ltl;
     }
-
+    // Setter for parent panel to enable auto-enable chain
+    void setParentPanel(FoldableToolPanel* parentPanel);
     // Management functions to add/remove Locallab tool
     void addLocallabTool(bool raiseEvent);
     void removeLocallabTool(bool raiseEvent);
@@ -288,7 +290,8 @@ private:
 class LocallabColor:
     public Gtk::Box,
     public LocallabTool,
-    public ThresholdAdjusterListener
+    public ThresholdAdjusterListener,
+    public CheckBoxListener
 {
 private:
     // Color & Light specific widgets
@@ -298,7 +301,7 @@ private:
     Adjuster* const lightness;
     Adjuster* const contrast;
     Adjuster* const chroma;
-    Gtk::CheckButton* const curvactiv;
+    CheckBox* const curvactiv;
     Gtk::Frame* const gridFrame;
     LabGrid* const labgrid;
     MyComboBoxText* const gridMethod;
@@ -316,7 +319,7 @@ private:
     Adjuster* const lowthresc;
     Adjuster* const higthresc;
     Adjuster* const decayc;
-    Gtk::CheckButton* const invers;
+    CheckBox* const invers;
     MyExpander* const expgradcol;
     Adjuster* const strcol;
     Adjuster* const strcolab;
@@ -341,7 +344,7 @@ private:
     CurveEditorGroup* const rgbCurveEditorG;
     MyComboBoxText* const toneMethod;
     DiagonalCurveEditor* const rgbshape;
-    Gtk::CheckButton* const special;
+    CheckBox* const special;
     MyExpander* const expmaskcol1;
     MyComboBoxText* const merMethod;
     ToolParamBlock* const mask7;
@@ -356,16 +359,16 @@ private:
     Gtk::Frame* const mergecolFrame ;
     MyComboBoxText* const showmaskcolMethod;
     MyComboBoxText* const showmaskcolMethodinv;
-    Gtk::CheckButton* const enaColorMask;
+    CheckBox* const enaColorMask;
     CurveEditorGroup* const maskCurveEditorG;
     FlatCurveEditor* const CCmaskshape;
     FlatCurveEditor* const LLmaskshape;
     FlatCurveEditor* const HHmaskshape;
     Gtk::Frame* const struFrame;
     Adjuster* const strumaskcol;
-    Gtk::CheckButton* const toolcol;
+    CheckBox* const toolcol;
     Gtk::Frame* const blurFrame;
-    Gtk::CheckButton* const fftColorMask;
+    CheckBox* const fftColorMask;
     Adjuster* const contcol;
     Adjuster* const blurcol;
     Adjuster* const blendmaskcol;
@@ -385,7 +388,7 @@ private:
     FlatCurveEditor* const LLmaskcolshapewav;
     ThresholdAdjuster* const csThresholdcol;
 
-    sigc::connection curvactivConn, previewcolConn, gridMethodConn, inversConn, qualitycurveMethodConn, toneMethodConn, specialConn, merMethodConn, mergecolMethodConn, showmaskcolMethodConn, showmaskcolMethodConninv, enaColorMaskConn, toolcolConn, fftColorMaskConn;
+    sigc::connection previewcolConn, gridMethodConn, qualitycurveMethodConn, toneMethodConn, merMethodConn, mergecolMethodConn, showmaskcolMethodConn, showmaskcolMethodConninv;
 
 public:
     LocallabColor();
@@ -426,19 +429,14 @@ private:
     void updateGUIToMode(const modeType new_type) override;
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
-    void curvactivChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void gridMethodChanged();
-    void inversChanged();
     void qualitycurveMethodChanged();
     void toneMethodChanged();
-    void specialChanged();
     void merMethodChanged();
     void mergecolMethodChanged();
     void showmaskcolMethodChanged();
     void showmaskcolMethodChangedinv();
-    void enaColorMaskChanged();
-    void toolcolChanged();
-    void fftColorMaskChanged();
     void updateColorGUI1();
     void updateColorGUI2();
     void updateColorGUI3();
@@ -447,7 +445,8 @@ private:
 /* ==== LocallabExposure ==== */
 class LocallabExposure:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     // Exposure specific widgets
@@ -465,8 +464,8 @@ private:
     MyExpander* const expfat;
     Adjuster* const fatamount;
     Adjuster* const fatdetail;
-    Gtk::CheckButton* const fatsatur;
-    Gtk::CheckButton* const norm;
+    CheckBox* const fatsatur;
+    CheckBox* const norm;
     Adjuster* const fatlevel;
     Adjuster* const fatanchor;
     Adjuster* const gamex;
@@ -498,12 +497,12 @@ private:
     Adjuster* const angexp;
     Adjuster* const featherexp;
     Adjuster* const softradiusexp;
-    Gtk::CheckButton* const inversex;
+    CheckBox* const inversex;
     MyExpander* const expmaskexp;
     MyComboBoxText* const showmaskexpMethod;
     MyComboBoxText* const showmaskexpMethodinv;
-    Gtk::CheckButton* const enaExpMask;
-    Gtk::CheckButton* const enaExpMaskaft;
+    CheckBox* const enaExpMask;
+    CheckBox* const enaExpMaskaft;
     CurveEditorGroup* const maskexpCurveEditorG;
     FlatCurveEditor* const CCmaskexpshape;
     FlatCurveEditor* const LLmaskexpshape;
@@ -521,7 +520,7 @@ private:
     DiagonalCurveEditor* const Lmaskexpshape;
     rtengine::ProcEvent Evlocallabtmosatur;
 
-    sigc::connection expMethodConn, exnoiseMethodConn, previewexeConn, inversexConn, normConn, fatsaturConn, showmaskexpMethodConn, showmaskexpMethodConninv, enaExpMaskConn, enaExpMaskaftConn;
+    sigc::connection expMethodConn, exnoiseMethodConn, previewexeConn, showmaskexpMethodConn, showmaskexpMethodConninv;
 
 public:
     LocallabExposure();
@@ -556,15 +555,11 @@ private:
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void expMethodChanged();
     void exnoiseMethodChanged();
-    void inversexChanged();
-    void normChanged();
-    void fatsaturChanged();
     void showmaskexpMethodChanged();
     void showmaskexpMethodChangedinv();
-    void enaExpMaskChanged();
-    void enaExpMaskaftChanged();
 
     void updateExposureGUI1();
     void updateExposureGUI2();
@@ -575,7 +570,8 @@ private:
 /* ==== LocallabjShadow ==== */
 class LocallabShadow:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     // Shadow highlight specific widgets
@@ -609,7 +605,7 @@ private:
     LabGrid* const labgridghs;
     Gtk::Frame* const ghsFrame;
     Gtk::Box* const matHBox;
-    Gtk::CheckButton* const ghs_agx;
+    CheckBox* const ghs_agx;
     MyComboBoxText* const ghsMatmet;
     Adjuster* const ghs_D;
     Gtk::Frame* const Lab_Frame;
@@ -626,24 +622,24 @@ private:
     Adjuster* const ghs_LC;
     Adjuster* const ghs_MID;
     Gtk::Frame* const BP_Frame;
-    Gtk::CheckButton* const ghs_autobw;
+    CheckBox* const ghs_autobw;
     Adjuster* const ghs_BLP;
     Adjuster* const ghs_HLP;
     Gtk::Label* const ghsbpwpLabels;
     Gtk::Label* const ghsbpwpvalueLabels;
     Gtk::Label* const ghscolorLabels;
     Gtk::Label* const ghsDRLabels;
-    Gtk::CheckButton* const ghs_smooth;
-    Gtk::CheckButton* const ghs_inv;
+    CheckBox* const ghs_smooth;
+    CheckBox* const ghs_inv;
     MyExpander* const expgradsh;
     Adjuster* const strSH;
     Adjuster* const angSH;
     Adjuster* const featherSH;
-    Gtk::CheckButton* const inverssh;
+    CheckBox* const inverssh;
     MyExpander* const expmasksh;
     MyComboBoxText* const showmaskSHMethod;
     MyComboBoxText* const showmaskSHMethodinv;
-    Gtk::CheckButton* const enaSHMask;
+    CheckBox* const enaSHMask;
     CurveEditorGroup* const maskSHCurveEditorG;
     FlatCurveEditor* const CCmaskSHshape;
     FlatCurveEditor* const LLmaskSHshape;
@@ -681,7 +677,7 @@ private:
     rtengine::ProcEvent Evlocallabghs_agx;
     rtengine::ProcEvent Evlocallabghs_Matmet;
 
-    sigc::connection shMethodConn, ghsMethodConn, ghsMatmetConn, previewshConn, inversshConn, ghs_smoothConn, ghs_autobwConn, ghs_agxConn, ghs_invConn, showmaskSHMethodConn, showmaskSHMethodConninv, enaSHMaskConn;
+    sigc::connection shMethodConn, ghsMethodConn, ghsMatmetConn, previewshConn, showmaskSHMethodConn, showmaskSHMethodConninv;
 
 public:
     LocallabShadow();
@@ -722,18 +718,12 @@ private:
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void shMethodChanged();
     void ghsMethodChanged();
     void ghsMatmetChanged();
-   
-    void inversshChanged();
-    void ghs_smoothChanged();
-    void ghs_autobwChanged();
-    void ghs_agxChanged(); 
-    void ghs_invChanged();
     void showmaskSHMethodChanged();
     void showmaskSHMethodChangedinv();
-    void enaSHMaskChanged();
     void updateShadowGUImask();
     void updateShadowGUIshmet();
     void updateShadowGUIsym();
@@ -744,7 +734,8 @@ class LocallabVibrance:
     public Gtk::Box,
     public LocallabTool,
     public ThresholdAdjusterListener,
-    public ThresholdCurveProvider
+    public ThresholdCurveProvider,
+    public CheckBoxListener
 {
 private:
     // Vibrance specific widgets
@@ -753,9 +744,9 @@ private:
     Adjuster* const vibgam;
     Adjuster* const warm;
     ThresholdAdjuster* const psThreshold;
-    Gtk::CheckButton* const protectSkins;
-    Gtk::CheckButton* const avoidColorShift;
-    Gtk::CheckButton* const pastSatTog;
+    CheckBox* const protectSkins;
+    CheckBox* const avoidColorShift;
+    CheckBox* const pastSatTog;
     Adjuster* const sensiv;
     Gtk::ToggleButton* const previewvib;
     
@@ -776,7 +767,7 @@ private:
     Adjuster* const feathervib;
     MyExpander* const expmaskvib;
     MyComboBoxText* const showmaskvibMethod;
-    Gtk::CheckButton* const enavibMask;
+    CheckBox* const enavibMask;
     CurveEditorGroup* const maskvibCurveEditorG;
     FlatCurveEditor* const CCmaskvibshape;
     FlatCurveEditor* const LLmaskvibshape;
@@ -790,7 +781,7 @@ private:
     CurveEditorGroup* const mask2vibCurveEditorG;
     DiagonalCurveEditor* const Lmaskvibshape;
 
-    sigc::connection pskinsConn, previewvibConn, ashiftConn, pastsattogConn, showmaskvibMethodConn, enavibMaskConn;
+    sigc::connection previewvibConn, showmaskvibMethodConn;
 
 public:
     LocallabVibrance();
@@ -833,11 +824,8 @@ private:
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
-    void protectskins_toggled();
-    void avoidcolorshift_toggled();
-    void pastsattog_toggled();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void showmaskvibMethodChanged();
-    void enavibMaskChanged();
 
     void updateVibranceGUI();
 };
@@ -893,15 +881,16 @@ private:
 class LocallabBlur:
     public Gtk::Box,
     public LocallabTool,
-    public ThresholdAdjusterListener
+    public ThresholdAdjusterListener,
+    public CheckBoxListener
 //    public ThresholdCurveProvider
-    
+
 {
 private:
     // Blur & Noise specific widgets
     MyExpander* const expblnoise;
     MyComboBoxText* const blMethod;
-    Gtk::CheckButton* const fftwbl;
+    CheckBox* const fftwbl;
     Adjuster* const radius;
     Adjuster* const strength;
     Gtk::Frame* const grainFrame;
@@ -922,16 +911,16 @@ private:
     Adjuster* const sensibn;
     
     MyComboBoxText* const blurMethod;
-    Gtk::CheckButton* const invbl;
+    CheckBox* const invbl;
     MyComboBoxText* const chroMethod;
-    Gtk::CheckButton* const activlum;
+    CheckBox* const activlum;
     MyExpander* const expdenoise;
     Gtk::Frame* const denoFrame;
 
-    Gtk::CheckButton* const enacontrast;
+    CheckBox* const enacontrast;
     Adjuster* const denocontrast;
     Adjuster* const denoratio;
-    Gtk::CheckButton* const contrshow;
+    CheckBox* const contrshow;
     Adjuster* const denomask;
 
     MyComboBoxText* const quamethod;
@@ -945,10 +934,10 @@ private:
     Gtk::Label* const lum46Labels;
     Gtk::Label* const chroLabels;
     Gtk::Label* const chro46Labels;
-    Gtk::CheckButton* const lockmadl;
+    CheckBox* const lockmadl;
     Gtk::Frame* const madlFrame;
     const std::array<Adjuster*, 21> madls;
-    Gtk::CheckButton* const madllock;
+    CheckBox* const madllock;
     
     MyExpander* const expdenoise1;
     Gtk::Label* const maskusable;
@@ -958,7 +947,7 @@ private:
     Gtk::Label* const maskusable3;
     Gtk::Label* const maskunusable3;
 
-    Gtk::CheckButton* const usemask;
+    CheckBox* const usemask;
     Adjuster* const lnoiselow;
     Adjuster* const levelthr;
     Adjuster* const levelthrlow;
@@ -987,8 +976,8 @@ private:
     Adjuster* const higthresd;
     Adjuster* const decayd;
     
-    Gtk::CheckButton* const invmaskd;
-    Gtk::CheckButton* const invmask;
+    CheckBox* const invmaskd;
+    CheckBox* const invmask;
     Gtk::Frame* const prevFrame;
     Adjuster* const nlstr;
     Adjuster* const nldet;
@@ -1006,13 +995,13 @@ private:
     MyExpander* const expmaskbl;
     MyComboBoxText* const showmaskblMethod;
     MyComboBoxText* const showmaskblMethodtyp;
-    Gtk::CheckButton* const enablMask;
+    CheckBox* const enablMask;
     std::unique_ptr<CurveEditorGroup> maskblCurveEditorG;    
     FlatCurveEditor* const CCmaskblshape;
     FlatCurveEditor* const LLmaskblshape;
     FlatCurveEditor* const HHmaskblshape;
     Adjuster* const strumaskbl;
-    Gtk::CheckButton* const toolbl;
+    CheckBox* const toolbl;
     Gtk::Frame* const toolblFrame;
     Gtk::Frame* const toolblFrame2;
     Adjuster* const blendmaskbl;
@@ -1030,8 +1019,8 @@ private:
     Gtk::Box* const quaHBox;
     ThresholdAdjuster* const csThresholdblur;
 
-    sigc::connection blMethodConn, fftwblConn, invblConn, contrshowConn, lockmadlConn, madllockConn, enacontrastConn, medMethodConn, blurMethodConn, chroMethodConn, activlumConn, showmaskblMethodConn, showmaskblMethodtypConn, enablMaskConn, toolblConn;
-    sigc::connection  quamethodconn, usemaskConn, invmaskdConn, invmaskConn, neutralconn;
+    sigc::connection blMethodConn, medMethodConn, blurMethodConn, chroMethodConn, showmaskblMethodConn, showmaskblMethodtypConn;
+    sigc::connection  quamethodconn, neutralconn;
     rtengine::ProcEvent Evlocallabdenocontrast;
     rtengine::ProcEvent Evlocallabautodenoon;
     rtengine::ProcEvent Evlocallabautodenooff;
@@ -1085,25 +1074,14 @@ private:
     void updateGUIToMode(const modeType new_type) override;
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
-    void contrshowChanged();
-    void enacontrastChanged();
-    void lockmadlChanged();
-    void madllockChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
     void blMethodChanged();
-    void fftwblChanged();
-    void usemaskChanged();
-    void invmaskdChanged();
-    void invmaskChanged();
-    void invblChanged();
     void medMethodChanged();
     void blurMethodChanged();
     void chroMethodChanged();
-    void activlumChanged();
     void showmaskblMethodChanged();
     void showmaskblMethodtypChanged();
-    void enablMaskChanged();
-    void toolblChanged();
     void quamethodChanged();
 
     void updateBlurGUI();
@@ -1112,14 +1090,15 @@ private:
 /* ==== LocallabTone ==== */
 class LocallabTone:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     // Tone Mapping specific widgets
     Adjuster* const repartm;
     Adjuster* const amount;
     Adjuster* const stren;
-    Gtk::CheckButton* const equiltm;
+    CheckBox* const equiltm;
     Adjuster* const gamma;
     Adjuster* const satur;
     Adjuster* const estop;
@@ -1138,8 +1117,8 @@ private:
     Adjuster* const decayt;
     MyExpander* const expmasktm;
     MyComboBoxText* const showmasktmMethod;
-    Gtk::CheckButton* const enatmMask;
-    Gtk::CheckButton* const enatmMaskaft;
+    CheckBox* const enatmMask;
+    CheckBox* const enatmMaskaft;
     CurveEditorGroup* const masktmCurveEditorG;
     FlatCurveEditor* const CCmasktmshape;
     FlatCurveEditor* const LLmasktmshape;
@@ -1153,7 +1132,7 @@ private:
     CurveEditorGroup* const mask2tmCurveEditorG;
     DiagonalCurveEditor* const Lmasktmshape;
 
-    sigc::connection equiltmConn, previewtmConn, showmasktmMethodConn, enatmMaskConn, enatmMaskaftConn;
+    sigc::connection previewtmConn, showmasktmMethodConn;
 
 public:
     LocallabTone();
@@ -1186,16 +1165,15 @@ private:
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
-    void equiltmChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void showmasktmMethodChanged();
-    void enatmMaskChanged();
-    void enatmMaskaftChanged();
 };
 
 /* ==== LocallabRetinex ==== */
 class LocallabRetinex:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     // Retinex specific widgets
@@ -1206,12 +1184,12 @@ private:
     Adjuster* const dehazeblack;
     Gtk::Frame* const retiFrame;
     Adjuster* const str;
-    Gtk::CheckButton* const loglin;
+    CheckBox* const loglin;
     Adjuster* const sensih;
     Gtk::Frame* const retitoolFrame;
     MyComboBoxText* const retinexMethod;
-    Gtk::CheckButton* const fftwreti;
-    Gtk::CheckButton* const equilret;
+    CheckBox* const fftwreti;
+    CheckBox* const equilret;
     Adjuster* const neigh;
     Adjuster* const vart;
     Adjuster* const scalereti;
@@ -1239,8 +1217,8 @@ private:
     Adjuster* const decayr;
     MyExpander* const expmaskreti;
     MyComboBoxText* const showmaskretiMethod;
-    Gtk::CheckButton* const enaretiMask;
-    Gtk::CheckButton* const enaretiMasktmap;
+    CheckBox* const enaretiMask;
+    CheckBox* const enaretiMasktmap;
     CurveEditorGroup* const maskretiCurveEditorG;
     FlatCurveEditor* const CCmaskretishape;
     FlatCurveEditor* const LLmaskretishape;
@@ -1253,11 +1231,11 @@ private:
     Adjuster* const slomaskreti;
     CurveEditorGroup* const mask2retiCurveEditorG;
     DiagonalCurveEditor* const Lmaskretishape;
-    Gtk::CheckButton* const inversret;
+    CheckBox* const inversret;
 
     rtengine::ProcEvent Evlocallabdehazeblack;
 
-    sigc::connection loglinConn, retinexMethodConn, fftwretiConn, equilretConn, showmaskretiMethodConn, enaretiMaskConn, enaretiMasktmapConn, inversretConn;
+    sigc::connection retinexMethodConn, showmaskretiMethodConn;
 
 public:
     LocallabRetinex();
@@ -1289,14 +1267,9 @@ private:
 
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
-    void loglinChanged();
     void retinexMethodChanged();
-    void fftwretiChanged();
-    void equilretChanged();
     void showmaskretiMethodChanged();
-    void enaretiMaskChanged();
-    void enaretiMasktmapChanged();
-    void inversretChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
     void updateRetinexGUI1();
     void updateRetinexGUI2();
@@ -1306,7 +1279,8 @@ private:
 /* ==== LocallabSharp ==== */
 class LocallabSharp:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     // Adjuster* blur;
@@ -1315,14 +1289,14 @@ private:
 
     Adjuster* const reparsha;
     Adjuster* const sharcontrast;
-    Gtk::CheckButton* const sharshow;
+    CheckBox* const sharshow;
     Adjuster* const capradius;
 
     Adjuster* const deconvCoBoost;
     Adjuster* const deconvCoProt;
     Adjuster* const deconvCoLat;
     Adjuster* const deconvCogam;
-    Gtk::CheckButton* const itercheck;
+    CheckBox* const itercheck;
     Gtk::Frame* const capFrame;
     Gtk::Frame* const rlFrame;
     Adjuster* const sharblur;
@@ -1332,7 +1306,7 @@ private:
     Adjuster* const shariter;
     Adjuster* const sharradius;
     Adjuster* const sensisha;
-    Gtk::CheckButton* const inverssha;
+    CheckBox* const inverssha;
     Gtk::Frame* const sharFrame;
     MyComboBoxText* const showmasksharMethod;
 
@@ -1351,7 +1325,7 @@ private:
     rtengine::ProcEvent Evlocallababitercheck;
     rtengine::ProcEvent Evlocallababdconvgam;
 
-    sigc::connection inversshaConn, showmasksharMethodConn, methodcapConn, sharshowConn, itercheckConn;
+    sigc::connection showmasksharMethodConn, methodcapConn;
 
 public:
     LocallabSharp();
@@ -1379,10 +1353,7 @@ private:
     void convertParamToNormal() override;
     void convertParamToSimple() override;
     void updateGUIToMode(const modeType new_type) override;
-    void sharshowChanged();
-    void itercheckChanged();
-
-    void inversshaChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void methodcapChanged();
     void showmasksharMethodChanged();
 };
@@ -1391,7 +1362,8 @@ private:
 class LocallabContrast:
     public Gtk::Box,
     public LocallabTool,
-    public ThresholdAdjusterListener
+    public ThresholdAdjusterListener,
+    public CheckBoxListener
 
 {
 private:
@@ -1406,7 +1378,7 @@ private:
     CurveEditorGroup* const LocalcurveEditorwav;
     FlatCurveEditor* const wavshape;
     ThresholdAdjuster* const csThreshold;
-    Gtk::CheckButton* const processwav;
+    CheckBox* const processwav;
     
     Adjuster* const levelwav;
     MyExpander* const expresidpyr;
@@ -1427,21 +1399,21 @@ private:
     Adjuster* const clarilres;
     Adjuster* const claricres;
     Adjuster* const clarisoft;
-    Gtk::CheckButton* const origlc;
+    CheckBox* const origlc;
     MyExpander* const expcontrastpyr;
     Gtk::Frame* const gradwavFrame;
-    Gtk::CheckButton* const wavgradl;
+    CheckBox* const wavgradl;
     Adjuster* const sigmalc2;
     Adjuster* const strwav;
     Adjuster* const angwav;
     Adjuster* const featherwav;
-    Gtk::CheckButton* const wavedg;
+    CheckBox* const wavedg;
     Adjuster* const strengthw;
     Adjuster* const sigmaed;
     CurveEditorGroup* const LocalcurveEditorwavedg;
     FlatCurveEditor* const wavshapeedg;
     Adjuster* const gradw;
-    Gtk::CheckButton* const waveshow;
+    CheckBox* const waveshow;
     ToolParamBlock* const edgsBoxshow;
     Adjuster* const radiusw;
     Adjuster* const detailw;
@@ -1451,34 +1423,34 @@ private:
     Adjuster* const edgw;
     Adjuster* const basew;
     MyComboBoxText* const localneiMethod;
-    Gtk::CheckButton* const wavblur;
+    CheckBox* const wavblur;
     Adjuster* const levelblur;
     Adjuster* const sigmabl;
     Adjuster* const chromablu;
     CurveEditorGroup* const LocalcurveEditorwavlev;
     FlatCurveEditor* const wavshapelev;
     Adjuster* const residblur;
-    Gtk::CheckButton* const blurlc;
+    CheckBox* const blurlc;
     MyExpander* const expcontrastpyr2;
-    Gtk::CheckButton* const wavcont;
+    CheckBox* const wavcont;
     Adjuster* const sigma;
     Adjuster* const offset;
     Adjuster* const chromalev;
     CurveEditorGroup* const LocalcurveEditorwavcon;
     FlatCurveEditor* const wavshapecon;
-    Gtk::CheckButton* const wavcompre;
+    CheckBox* const wavcompre;
     CurveEditorGroup* const LocalcurveEditorwavcompre;
     FlatCurveEditor* const wavshapecompre;
     Adjuster* const sigmadr;
     Adjuster* const threswav;
     Adjuster* const residcomp;
-    Gtk::CheckButton* const wavcomp;
+    CheckBox* const wavcomp;
     Adjuster* const sigmadc;
     Adjuster* const deltad;
     CurveEditorGroup* const LocalcurveEditorwavcomp;
     FlatCurveEditor* const wavshapecomp;
     //Adjuster* const fatres;
-    Gtk::CheckButton* const fftwlc;
+    CheckBox* const fftwlc;
     MyExpander* const exprecovw;
     Gtk::Label* const maskusablew;
     Gtk::Label* const maskunusablew;
@@ -1488,7 +1460,7 @@ private:
     Adjuster* const decayw;
     MyExpander* const expmasklc;
     MyComboBoxText* const showmasklcMethod;
-    Gtk::CheckButton* const enalcMask;
+    CheckBox* const enalcMask;
     CurveEditorGroup* const masklcCurveEditorG;
     FlatCurveEditor* const CCmasklcshape;
     FlatCurveEditor* const LLmasklcshape;
@@ -1499,7 +1471,7 @@ private:
     CurveEditorGroup* const mask2lcCurveEditorG;
     DiagonalCurveEditor* const Lmasklcshape;
 
-    sigc::connection localcontMethodConn, previewlcConn, origlcConn, processwavConn, wavgradlConn, wavedgConn, localedgMethodConn, waveshowConn, localneiMethodConn, wavblurConn, blurlcConn, wavcontConn, wavcompreConn, wavcompConn, fftwlcConn, showmasklcMethodConn, enalcMaskConn;
+    sigc::connection localcontMethodConn, previewlcConn, localedgMethodConn, localneiMethodConn, showmasklcMethodConn;
     rtengine::ProcEvent Evlocallabprocesswav;
 
 public:
@@ -1541,21 +1513,10 @@ private:
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
     void localcontMethodChanged();
-    void origlcChanged();
-    void processwavChanged();
-    void wavgradlChanged();
-    void wavedgChanged();
     void localedgMethodChanged();
-    void waveshowChanged();
     void localneiMethodChanged();
-    void wavblurChanged();
-    void blurlcChanged();
-    void wavcontChanged();
-    void wavcompreChanged();
-    void wavcompChanged();
-    void fftwlcChanged();
     void showmasklcMethodChanged();
-    void enalcMaskChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
     void updateContrastGUI1();
     void updateContrastGUI2();
@@ -1565,7 +1526,8 @@ private:
 /* ==== LocallabCBDL ==== */
 class LocallabCBDL:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     Gtk::Frame* const levFrame;
@@ -1585,7 +1547,7 @@ private:
     Adjuster* const decaycb;
     MyExpander* const expmaskcb;
     MyComboBoxText* const showmaskcbMethod;
-    Gtk::CheckButton* const enacbMask;
+    CheckBox* const enacbMask;
     CurveEditorGroup* const maskcbCurveEditorG;
     FlatCurveEditor* const CCmaskcbshape;
     FlatCurveEditor* const LLmaskcbshape;
@@ -1599,7 +1561,7 @@ private:
     CurveEditorGroup* const mask2cbCurveEditorG;
     DiagonalCurveEditor* const Lmaskcbshape;
 
-    sigc::connection showmaskcbMethodConn, enacbMaskConn;
+    sigc::connection showmaskcbMethodConn;
 
     Gtk::Button* const lumacontrastMinusButton;
     Gtk::Button* const lumaneutralButton;
@@ -1636,7 +1598,7 @@ private:
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
     void showmaskcbMethodChanged();
-    void enacbMaskChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
     void lumacontrastMinusPressed();
     void lumaneutralPressed();
@@ -1646,11 +1608,12 @@ private:
 /* ==== LocallabLog ==== */
 class LocallabLog:
     public Gtk::Box,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     Adjuster* const repar;
-    Gtk::CheckButton* const ciecam;
+    CheckBox* const ciecam;
     Gtk::ToggleButton* const autocompute;
     Gtk::Frame* const logPFrame;
     Gtk::Frame* const logPFrame2;
@@ -1660,11 +1623,11 @@ private:
     Adjuster* const blackslog;
     Adjuster* const comprlog;
     Adjuster* const strelog; 
-    Gtk::CheckButton* const satlog;
+    CheckBox* const satlog;
     
-    Gtk::CheckButton* const fullimage;
+    CheckBox* const fullimage;
     Gtk::Frame* const logFrame;
-    Gtk::CheckButton* const Autogray;
+    CheckBox* const Autogray;
     Adjuster* const sourceGray;
     Adjuster* const sourceabs;
     MyComboBoxText*  const sursour;
@@ -1707,7 +1670,7 @@ private:
     Adjuster* const featherlog;
     MyExpander* const expmaskL;
     MyComboBoxText* const showmaskLMethod;
-    Gtk::CheckButton* const enaLMask;
+    CheckBox* const enaLMask;
     CurveEditorGroup* const maskCurveEditorL;
     FlatCurveEditor* const CCmaskshapeL;
     FlatCurveEditor* const LLmaskshapeL;
@@ -1718,9 +1681,9 @@ private:
     CurveEditorGroup* const mask2CurveEditorL;
     DiagonalCurveEditor* const LmaskshapeL;
 
-    sigc::connection autoconn, ciecamconn, fullimageConn, AutograyConn;
-    sigc::connection  surroundconn, sursourconn, satlogconn;
-    sigc::connection showmaskLMethodConn, enaLMaskConn, previewlogConn;
+    sigc::connection autoconn;
+    sigc::connection surroundconn, sursourconn;
+    sigc::connection showmaskLMethodConn, previewlogConn;
 public:
     LocallabLog();
     ~LocallabLog();
@@ -1738,8 +1701,6 @@ public:
     void surroundChanged();
     void sursourChanged();
     void setDefaultExpanderVisibility() override;
-    void satlogChanged();
-
     void disableListener() override;
     void enableListener() override;
     void read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited = nullptr) override;
@@ -1758,11 +1719,8 @@ private:
     void complexityModeChanged();
 
     void autocomputeToggled();
-    void fullimageChanged();
-    void AutograyChanged();
-    void ciecamChanged();
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void showmaskLMethodChanged();
-    void enaLMaskChanged();
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
     void updateLogGUI();
@@ -1774,7 +1732,8 @@ private:
 class LocallabMask:
     public Gtk::Box,
     public LocallabTool,
-    public ThresholdAdjusterListener
+    public ThresholdAdjusterListener,
+    public CheckBoxListener
 {
 private:
     Adjuster* const sensimask;
@@ -1784,16 +1743,16 @@ private:
     Adjuster* const blendmaskab;
     Adjuster* const softradiusmask;
     MyComboBoxText* const showmask_Method;
-    Gtk::CheckButton* const enamask;
+    CheckBox* const enamask;
     CurveEditorGroup* const mask_CurveEditorG;
     FlatCurveEditor* const CCmask_shape;
     FlatCurveEditor* const LLmask_shape;
     FlatCurveEditor* const HHmask_shape;
     Gtk::Frame* const struFrame;
     Adjuster* const strumaskmask;
-    Gtk::CheckButton* const toolmask;
+    CheckBox* const toolmask;
     Gtk::Frame* const blurFrame;
-    Gtk::CheckButton* const fftmask;
+    CheckBox* const fftmask;
     Adjuster* const contmask;
     Adjuster* const blurmask;
     Gtk::Frame* const toolmaskFrame;
@@ -1815,7 +1774,7 @@ private:
     Adjuster* const feather_mask;
     Adjuster* const ang_mask;
 
-    sigc::connection showmask_MethodConn, previewmasConn, enamaskConn, toolmaskConn, fftmaskConn;
+    sigc::connection showmask_MethodConn, previewmasConn;
 
 public:
     LocallabMask();
@@ -1845,6 +1804,7 @@ public:
     void adjusterChanged(ThresholdAdjuster* a, int newBottomLeft, int newTopLeft, int newBottomRight, int newTopRight) override {}; // Not used
     void adjusterChanged2(ThresholdAdjuster* a, int newBottomL, int newTopL, int newBottomR, int newTopR) override;
     void curveChanged(CurveEditor* ce) override;
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
 
 private:
     void complexityModeChanged();
@@ -1857,9 +1817,6 @@ private:
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
 
     void showmask_MethodChanged();
-    void enamaskChanged();
-    void toolmaskChanged();
-    void fftmaskChanged();
 
     void updateMaskGUI();
 };
@@ -1869,14 +1826,15 @@ private:
 class Locallabcie:
     public Gtk::Box,
     public ThresholdAdjusterListener,
-    public LocallabTool
+    public LocallabTool,
+    public CheckBoxListener
 {
 private:
     Adjuster* const sensicie;
     Gtk::ToggleButton* const previewcie;
     
     Adjuster* const reparcie;
-    Gtk::CheckButton* const jabcie;
+    CheckBox* const jabcie;
     MyComboBoxText*  const modecam;
     MyComboBoxText*  const modeQJ;
     MyComboBoxText*  const modecie;
@@ -1887,7 +1845,7 @@ private:
     Gtk::Frame* const cieFrame;
     MyExpander* const expcamscene;
     
-    Gtk::CheckButton* const Autograycie;
+    CheckBox* const Autograycie;
     Adjuster* const sourceGraycie;
     Adjuster* const sourceabscie;
     MyComboBoxText*  const sursourcie;
@@ -1900,7 +1858,7 @@ private:
 //    Gtk::Frame* const czcontFrame;
     Gtk::Frame* const czcolorFrame;
     Gtk::Frame* const PQFrame;
-    Gtk::CheckButton* const qtoj;
+    CheckBox* const qtoj;
     Adjuster* const lightlcie;
     Adjuster* const lightjzcie;
     Adjuster* const contjzcie;
@@ -1938,23 +1896,23 @@ private:
     Adjuster* const contsigqcie;
     Adjuster* const contthrescie;
     Gtk::Frame* const logjzFrame;
-    Gtk::CheckButton* const logjz;
+    CheckBox* const logjz;
     Adjuster* const blackEvjz;
     Adjuster* const whiteEvjz;
     Adjuster* const targetjz;
     Gtk::Frame* const bevwevFrame;
-    Gtk::CheckButton* const sigybjz12;
+    CheckBox* const sigybjz12;
     ToolParamBlock* const sigBox12;
     Gtk::Frame* const sigmoidFrame12;
-    Gtk::CheckButton* const sigq12;
+    CheckBox* const sigq12;
     Adjuster* const slopesmoq;
     Adjuster* const sigmoidldacie12;
     Adjuster* const sigmoidthcie12;
     Adjuster* const sigmoidblcie12;
     Gtk::Box* autocomprHBox;
     Gtk::ToggleButton* const comprcieauto;
-    Gtk::CheckButton* const normcie12;
-    Gtk::CheckButton* const normcie;
+    CheckBox* const normcie12;
+    CheckBox* const normcie;
     Gtk::Box* const modeHBoxbwev12;
     MyComboBoxText* const bwevMethod12;
     Gtk::Box* const modeHBoxbwev;
@@ -1962,7 +1920,7 @@ private:
 
      ToolParamBlock* const sigBox;
     Gtk::Frame* const sigmoidFrame;
-    Gtk::CheckButton* const sigq;
+    CheckBox* const sigq;
     Gtk::Frame* const sigmoidnormFrame;
     Adjuster* const sigmoidldacie;
     Adjuster* const sigmoidthcie;
@@ -1970,13 +1928,13 @@ private:
     Adjuster* const sigmoidblcie;
    
     Gtk::Frame* const logcieFrame;
-    Gtk::CheckButton* const logcie;
+    CheckBox* const logcie;
     ToolParamBlock* const comprBox;
     Adjuster* const comprcie;
     
     Adjuster* const strcielog;
-    Gtk::CheckButton* const satcie;
-    Gtk::CheckButton* const logcieq;
+    CheckBox* const satcie;
+    CheckBox* const logcieq;
     Adjuster* const comprcieth;
     MyExpander* const expprecam;    
     Adjuster* const gamjcie;
@@ -1986,14 +1944,14 @@ private:
     Gtk::Frame* const midtcieFrame;
     MyComboBoxText* const midtciemet;
     Adjuster* const midtcie;
-    Gtk::CheckButton* const smoothcie;
-    Gtk::CheckButton* const smoothcielnk;
-    Gtk::CheckButton* const smoothcieinv;
-    Gtk::CheckButton* const smoothcietrc;
-    Gtk::CheckButton* const smoothcietrcrel;
-    Gtk::CheckButton* const smoothcieyb;
-    Gtk::CheckButton* const smoothcielum;
-    Gtk::CheckButton* const smoothciehigh;
+    CheckBox* const smoothcie;
+    CheckBox* const smoothcielnk;
+    CheckBox* const smoothcieinv;
+    CheckBox* const smoothcietrc;
+    CheckBox* const smoothcietrcrel;
+    CheckBox* const smoothcieyb;
+    CheckBox* const smoothcielum;
+    CheckBox* const smoothciehigh;
     Adjuster* const smoothcieth;
     ToolParamBlock* const ciesmoothBox;
     Gtk::Box* smoothBox;
@@ -2037,24 +1995,24 @@ private:
     Gtk::Box* catBox;
     MyComboBoxText* const catMethod;
     Gtk::Box* gamutcieBox;
-    Gtk::CheckButton* const gamutcie;
+    CheckBox* const gamutcie;
     Adjuster* const shiftxl;
     Adjuster* const shiftyl;
     Gtk::Box* bwcieBox;
-    Gtk::CheckButton* const bwcie;
+    CheckBox* const bwcie;
 
     Gtk::Frame* const sigmoidjzFrame12;
     Gtk::Frame* const sigmoidjzFrame;
     Gtk::Frame* const sigmoid2Frame12;
     Gtk::Frame* const sigmoid2Frame;
-    Gtk::CheckButton* const sigcie;
-    Gtk::CheckButton* const sigjz12;
+    CheckBox* const sigcie;
+    CheckBox* const sigjz12;
     Adjuster* const sigmoidldajzcie12;
     Adjuster* const sigmoidthjzcie12;
     Adjuster* const sigmoidbljzcie12;
 
-    Gtk::CheckButton* const sigjz;
-    Gtk::CheckButton* const forcebw;
+    CheckBox* const sigjz;
+    CheckBox* const forcebw;
     Adjuster* const sigmoidldajzcie;
     Adjuster* const sigmoidthjzcie;
     Adjuster* const sigmoidbljzcie;
@@ -2089,7 +2047,7 @@ private:
     FlatCurveEditor* const LHshapejz;
     Adjuster* const softjzcie;
     Adjuster* const thrhjzcie;
-    Gtk::CheckButton* const chjzcie;
+    CheckBox* const chjzcie;
     Adjuster* const strsoftjzcie;
    
     MyExpander* const expLcie;
@@ -2117,17 +2075,17 @@ private:
 
     MyExpander* const expmaskcie;
     MyComboBoxText* const showmaskcieMethod;
-    Gtk::CheckButton* const enacieMask;
-    Gtk::CheckButton* const enacieMaskall;
+    CheckBox* const enacieMask;
+    CheckBox* const enacieMaskall;
     CurveEditorGroup* const maskcieCurveEditorG;
     FlatCurveEditor* const CCmaskcieshape;
     FlatCurveEditor* const LLmaskcieshape;
     FlatCurveEditor* const HHmaskcieshape;
     Gtk::Frame* const struFramecie;
     Adjuster* const strumaskcie;
-    Gtk::CheckButton* const toolcie;
+    CheckBox* const toolcie;
     Gtk::Frame* const blurFramecie;
-    Gtk::CheckButton* const fftcieMask;
+    CheckBox* const fftcieMask;
     Adjuster* const contcie;
     Adjuster* const blurcie;
 
@@ -2151,7 +2109,7 @@ private:
     ThresholdAdjuster* const csThresholdcie;
     int nextcomprciecount = 0;
    
-    sigc::connection AutograycieConn, primMethodconn, illMethodconn, smoothciemetconn, catMethodconn, sigybjz12Conn, qtojConn, showmaskcieMethodConn, enacieMaskConn, enacieMaskallConn, jabcieConn, sursourcieconn, surroundcieconn, modecieconn, modecamconn, modeQJconn, comprcieautoconn, normcie12conn, normcieconn, logcieconn, satcieconn, logcieqconn, smoothcieconn, smoothcielnkconn, smoothcieinvconn, smoothciehighconn, smoothcietrcconn, smoothcietrcrelconn, smoothcieybconn,smoothcielumconn, logjzconn, sigjz12conn, forcebwconn, sigjzconn, sigq12conn, sigqconn, chjzcieconn, toneMethodcieConn, toneMethodcieConn2, toolcieConn, bwevMethod12Conn, midtciemetConn, bwevMethodConn,fftcieMaskConn, gamutcieconn, bwcieconn, expprecamconn, sigcieconn;
+    sigc::connection primMethodconn, illMethodconn, smoothciemetconn, catMethodconn, showmaskcieMethodConn, sursourcieconn, surroundcieconn, modecieconn, modecamconn, modeQJconn, comprcieautoconn, toneMethodcieConn, toneMethodcieConn2, bwevMethod12Conn, midtciemetConn, bwevMethodConn, expprecamconn;
     sigc::connection previewcieConn, sigmoidqjcieconn;
 public:
     Locallabcie();
@@ -2182,6 +2140,7 @@ public:
     void adjusterChanged(ThresholdAdjuster* a, int newBottom, int newTop) override {}; // Not used
     void adjusterChanged(ThresholdAdjuster* a, int newBottomLeft, int newTopLeft, int newBottomRight, int newTopRight) override {}; // Not used
     void adjusterChanged2(ThresholdAdjuster* a, int newBottomL, int newTopL, int newBottomR, int newTopR) override;
+    void checkBoxToggled(CheckBox* c, CheckValue newval) override;
     void sursourcieChanged();
     void surroundcieChanged();
     void modecieChanged();
@@ -2207,48 +2166,17 @@ private:
     void convertParamToSimple() override;
     void updateGUIToMode(const modeType new_type) override;
     void complexityModeChanged();
-    void AutograycieChanged();
-    void sigybjz12Changed();
-    void qtojChanged();
-    void jabcieChanged();
     void comprcieautoChanged();
-    void normcie12Changed();
-    void normcieChanged();
-    void gamutcieChanged();
-    void bwcieChanged();
     void illMethodChanged();
     void smoothciemetChanged();
     void primMethodChanged();
     void catMethodChanged();
-    void logcieChanged();
-    void satcieChanged();
-    void logcieqChanged();
-    void smoothcieChanged();
-    void smoothcielnkChanged();
-    void smoothcieinvChanged();
-    void smoothciehighChanged();
-    void smoothcietrcChanged();
-    void smoothcietrcrelChanged();
-    void smoothcieybChanged();
-    void smoothcielumChanged();
-    void sigcieChanged();
-    void logjzChanged();
-    void sigjz12Changed();
-    void sigjzChanged();
-    void forcebwChanged();
-    void sigq12Changed();
-    void sigqChanged();
-    void chjzcieChanged();
     void updatecieGUI();
     void updatecielnkGUI();
     void updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz) override;
     void showmaskcieMethodChanged();
-    void enacieMaskChanged();
-    void enacieMaskallChanged();
     void enacieMaskallChanged2();
     void guijzczhz();
-    void toolcieChanged();
-    void fftcieMaskChanged();
     void expprecamChanged();
 
     float nextrx;

--- a/rtgui/tools/locallabtools2.cc
+++ b/rtgui/tools/locallabtools2.cc
@@ -124,7 +124,7 @@ LocallabTone::LocallabTone():
     repartm(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGREPART"), 1.0, 100.0, 1., 100.0))),
     amount(Gtk::manage(new Adjuster(M("TP_LOCALLAB_AMOUNT"), 50., 100.0, 0.5, 95.))),
     stren(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STREN"), -0.5, 2.0, 0.01, 0.5))),
-    equiltm(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_EQUIL")))),
+    equiltm(Gtk::manage(new CheckBox(M("TP_LOCALLAB_EQUIL"), multiImage))),
     gamma(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GAM"), 0.4, 4.0, 0.11, 1.0))),
     satur(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SATUR"), -100., 100., 0.1, 0.))), // By default satur = 0 ==> use Mantiuk value
     estop(Gtk::manage(new Adjuster(M("TP_LOCALLAB_ESTOP"), 0.1, 4., 0.01, 1.4))),
@@ -142,8 +142,8 @@ LocallabTone::LocallabTone():
     decayt(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
     expmasktm(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWT")))),
     showmasktmMethod(Gtk::manage(new MyComboBoxText())),
-    enatmMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
-    enatmMaskaft(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_AFTER_MASK")))),
+    enatmMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
+    enatmMaskaft(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_AFTER_MASK"), multiImage))),
 //   masktmCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     masktmCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmasktmshape(static_cast<FlatCurveEditor*>(masktmCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -172,7 +172,7 @@ LocallabTone::LocallabTone():
 
     stren->setAdjusterListener(this);
 
-    equiltmConn = equiltm->signal_toggled().connect(sigc::mem_fun(*this, &LocallabTone::equiltmChanged));
+    equiltm->setCheckBoxListener(this);
 
     gamma->setAdjusterListener(this);
 
@@ -211,9 +211,9 @@ LocallabTone::LocallabTone():
     showmasktmMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmasktmMethodConn = showmasktmMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabTone::showmasktmMethodChanged));
 
-    enatmMaskConn = enatmMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabTone::enatmMaskChanged));
+    enatmMask->setCheckBoxListener(this);
 
-    enatmMaskaftConn = enatmMaskaft->signal_toggled().connect(sigc::mem_fun(*this, &LocallabTone::enatmMaskaftChanged));
+    enatmMaskaft->setCheckBoxListener(this);
 
     masktmCurveEditorG->setCurveListener(this);
 
@@ -399,20 +399,14 @@ void LocallabTone::disableListener()
 {
     LocallabTool::disableListener();
 
-    equiltmConn.block(true);
     showmasktmMethodConn.block(true);
-    enatmMaskConn.block(true);
-    enatmMaskaftConn.block(true);
 }
 
 void LocallabTone::enableListener()
 {
     LocallabTool::enableListener();
 
-    equiltmConn.block(false);
     showmasktmMethodConn.block(false);
-    enatmMaskConn.block(false);
-    enatmMaskaftConn.block(false);
 }
 
 //new function Global
@@ -491,7 +485,7 @@ void LocallabTone::read(const rtengine::procparams::ProcParams* pp, const Params
         amount->setValue(spot.amount);
         stren->setValue(spot.stren);
         repartm->setValue(spot.repartm);
-        equiltm->set_active(spot.equiltm);
+        equiltm->setValue(spot.equiltm);
         gamma->setValue(spot.gamma);
         satur->setValue(spot.satur);
         estop->setValue(spot.estop);
@@ -499,8 +493,8 @@ void LocallabTone::read(const rtengine::procparams::ProcParams* pp, const Params
         rewei->setValue((double)spot.rewei);
         softradiustm->setValue(spot.softradiustm);
         sensitm->setValue((double)spot.sensitm);
-        enatmMask->set_active(spot.enatmMask);
-        enatmMaskaft->set_active(spot.enatmMaskaft);
+        enatmMask->setValue(spot.enatmMask);
+        enatmMaskaft->setValue(spot.enatmMaskaft);
         CCmasktmshape->setCurve(spot.CCmasktmcurve);
         LLmasktmshape->setCurve(spot.LLmasktmcurve);
         HHmasktmshape->setCurve(spot.HHmasktmcurve);
@@ -540,7 +534,7 @@ void LocallabTone::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
         spot.amount = amount->getValue();
         spot.stren = stren->getValue();
         spot.repartm = repartm->getValue();
-        spot.equiltm = equiltm->get_active();
+        spot.equiltm = equiltm->getLastActive();
         spot.gamma = gamma->getValue();
         spot.satur = satur->getValue();
         spot.estop = estop->getValue();
@@ -548,8 +542,8 @@ void LocallabTone::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
         spot.rewei = rewei->getIntValue();
         spot.softradiustm = softradiustm->getValue();
         spot.sensitm = sensitm->getIntValue();
-        spot.enatmMask = enatmMask->get_active();
-        spot.enatmMaskaft = enatmMaskaft->get_active();
+        spot.enatmMask = enatmMask->getLastActive();
+        spot.enatmMaskaft = enatmMaskaft->getLastActive();
         spot.LLmasktmcurve = LLmasktmshape->getCurve();
         spot.CCmasktmcurve = CCmasktmshape->getCurve();
         spot.HHmasktmcurve = HHmasktmshape->getCurve();
@@ -705,8 +699,8 @@ void LocallabTone::convertParamToSimple()
 
     // Set hidden specific GUI widgets in Simple mode to default spot values
     showmasktmMethod->set_active(0);
-    enatmMask->set_active(defSpot.enatmMask);
-    enatmMaskaft->set_active(defSpot.enatmMaskaft);
+    enatmMask->setValue(defSpot.enatmMask);
+    enatmMaskaft->setValue(defSpot.enatmMaskaft);
 //    CCmasktmshape->setCurve(defSpot.CCmasktmcurve);
 //    LLmasktmshape->setCurve(defSpot.LLmasktmcurve);
 //    HHmasktmshape->setCurve(defSpot.HHmasktmcurve);
@@ -752,7 +746,7 @@ void LocallabTone::updateGUIToMode(const modeType new_type)
             exprecovt->show();
             decayt->hide();
 
-            if (enatmMask->get_active()) {
+            if (enatmMask->getLastActive()) {
                 maskusablet->show();
                 maskunusablet->hide();
 
@@ -775,7 +769,7 @@ void LocallabTone::updateGUIToMode(const modeType new_type)
             exprecovt->show();
             decayt->show();
 
-            if (enatmMask->get_active()) {
+            if (enatmMask->getLastActive()) {
                 maskusablet->show();
                 maskunusablet->hide();
 
@@ -803,21 +797,6 @@ void LocallabTone::updateMaskBackground(const double normChromar, const double n
                  );
 }
 
-void LocallabTone::equiltmChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (equiltm->get_active()) {
-                listener->panelChanged(Evlocallabequiltm,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabequiltm,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
 void LocallabTone::showmasktmMethodChanged()
 {
     // If mask preview is activated, deactivate all other tool mask preview
@@ -832,40 +811,26 @@ void LocallabTone::showmasktmMethodChanged()
     }
 }
 
-void LocallabTone::enatmMaskChanged()
+void LocallabTone::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (enatmMask->get_active()) {
-        maskusablet->show();
-        maskunusablet->hide();
-    } else {
-        maskusablet->hide();
-        maskunusablet->show();
+    if (!listener) {
+        return;
     }
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enatmMask->get_active()) {
-                listener->panelChanged(EvLocallabEnatmMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnatmMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    if (c == equiltm) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabequiltm,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
-    }
-}
-
-void LocallabTone::enatmMaskaftChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enatmMaskaft->get_active()) {
-                listener->panelChanged(EvLocallabEnatmMaskaft,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnatmMaskaft,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
+    } else if (c == enatmMask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnatmMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enatmMaskaft) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnatmMaskaft,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
         }
     }
 }
@@ -882,12 +847,12 @@ LocallabRetinex::LocallabRetinex():
     dehazeblack(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DEHAZE_BLACK"), -65., 100., 1., 0.))),
     retiFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_RETIFRA")))),
     str(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STR"), 0., 100., 0.2, 0.))),
-    loglin(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LOGLIN")))),
+    loglin(Gtk::manage(new CheckBox(M("TP_LOCALLAB_LOGLIN"), multiImage))),
     sensih(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 60))),
     retitoolFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_RETITOOLFRA")))),
     retinexMethod(Gtk::manage(new MyComboBoxText())),
-    fftwreti(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTW")))),
-    equilret(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_EQUIL")))),
+    fftwreti(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTW"), multiImage))),
+    equilret(Gtk::manage(new CheckBox(M("TP_LOCALLAB_EQUIL"), multiImage))),
     neigh(Gtk::manage(new Adjuster(M("TP_LOCALLAB_NEIGH"), MINNEIGH, MAXNEIGH, 0.5, 50., nullptr, nullptr, &retiSlider2neigh, &retiNeigh2Slider))),
     vart(Gtk::manage(new Adjuster(M("TP_LOCALLAB_VART"), 0.1, 500., 0.1, 150.))),
     scalereti(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SCALERETI"), 1.0, 10.0, 1., 2.))),
@@ -915,8 +880,8 @@ LocallabRetinex::LocallabRetinex():
     decayr(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
     expmaskreti(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWR")))),
     showmaskretiMethod(Gtk::manage(new MyComboBoxText())),
-    enaretiMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
-    enaretiMasktmap(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_TM_MASK")))),
+    enaretiMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
+    enaretiMasktmap(Gtk::manage(new CheckBox(M("TP_LOCALLAB_TM_MASK"), multiImage))),
 //   maskretiCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     maskretiCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskretishape(static_cast<FlatCurveEditor*>(maskretiCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -930,7 +895,7 @@ LocallabRetinex::LocallabRetinex():
     slomaskreti(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SLOMASKCOL"), 0.0, 15.0, 0.1, 0.))),
     mask2retiCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK2"))),
     Lmaskretishape(static_cast<DiagonalCurveEditor*>(mask2retiCurveEditorG->addCurve(CT_Diagonal, "L(L)"))),
-    inversret(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVERS"))))
+    inversret(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVERS"), multiImage)))
 {
 
     auto m = ProcEventMapper::getInstance();
@@ -951,7 +916,7 @@ LocallabRetinex::LocallabRetinex():
 
     str->setAdjusterListener(this);
 
-    loglinConn = loglin->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::loglinChanged));
+    loglin->setCheckBoxListener(this);
 
     sensih->setAdjusterListener(this);
 
@@ -964,9 +929,9 @@ LocallabRetinex::LocallabRetinex():
     retinexMethod->set_tooltip_markup(M("TP_LOCRETI_METHOD_TOOLTIP"));
     retinexMethodConn = retinexMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabRetinex::retinexMethodChanged));
 
-    fftwretiConn = fftwreti->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::fftwretiChanged));
+    fftwreti->setCheckBoxListener(this);
 
-    equilretConn = equilret->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::equilretChanged));
+    equilret->setCheckBoxListener(this);
 
     neigh->setAdjusterListener(this);
 
@@ -1028,9 +993,9 @@ LocallabRetinex::LocallabRetinex():
     showmaskretiMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskretiMethodConn = showmaskretiMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabRetinex::showmaskretiMethodChanged));
 
-    enaretiMaskConn = enaretiMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::enaretiMaskChanged));
+    enaretiMask->setCheckBoxListener(this);
 
-    enaretiMasktmapConn = enaretiMasktmap->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::enaretiMasktmapChanged));
+    enaretiMasktmap->setCheckBoxListener(this);
 
     maskretiCurveEditorG->setCurveListener(this);
 
@@ -1069,7 +1034,7 @@ LocallabRetinex::LocallabRetinex():
 
     mask2retiCurveEditorG->curveListComplete();
 
-    inversretConn = inversret->signal_toggled().connect(sigc::mem_fun(*this, &LocallabRetinex::inversretChanged));
+    inversret->setCheckBoxListener(this);
 
     // Add Retinex specific widgets to GUI
     pack_start(*sensih);
@@ -1196,8 +1161,8 @@ void LocallabRetinex::updateguireti(int spottype)
                 sensih->hide();
                 exprecovr->hide();
                 expmaskreti->hide();
-                enaretiMask->set_active(false);
-                enaretiMasktmap->set_active(false);
+                enaretiMask->setValue(false);
+                enaretiMasktmap->setValue(false);
             } else {
                 sensih->show();
                 exprecovr->show();
@@ -1327,28 +1292,16 @@ void LocallabRetinex::disableListener()
 {
     LocallabTool::disableListener();
 
-    loglinConn.block(true);
     retinexMethodConn.block(true);
-    fftwretiConn.block(true);
-    equilretConn.block(true);
     showmaskretiMethodConn.block(true);
-    enaretiMaskConn.block(true);
-    enaretiMasktmapConn.block(true);
-    inversretConn.block(true);
 }
 
 void LocallabRetinex::enableListener()
 {
     LocallabTool::enableListener();
 
-    loglinConn.block(false);
     retinexMethodConn.block(false);
-    fftwretiConn.block(false);
-    equilretConn.block(false);
     showmaskretiMethodConn.block(false);
-    enaretiMaskConn.block(false);
-    enaretiMasktmapConn.block(false);
-    inversretConn.block(false);
 }
 
 void LocallabRetinex::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -1371,7 +1324,7 @@ void LocallabRetinex::read(const rtengine::procparams::ProcParams* pp, const Par
         dehazeSaturation->setValue((double)spot.dehazeSaturation);
         dehazeblack->setValue((double)spot.dehazeblack);
         str->setValue(spot.str);
-        loglin->set_active(spot.loglin);
+        loglin->setValue(spot.loglin);
         sensih->setValue((double)spot.sensih);
 
         if (spot.retinexMethod == "low") {
@@ -1382,8 +1335,8 @@ void LocallabRetinex::read(const rtengine::procparams::ProcParams* pp, const Par
             retinexMethod->set_active(2);
         }
 
-        fftwreti->set_active(spot.fftwreti);
-        equilret->set_active(spot.equilret);
+        fftwreti->setValue(spot.fftwreti);
+        equilret->setValue(spot.equilret);
         neigh->setValue(spot.neigh);
         vart->setValue(spot.vart);
         scalereti->setValue(spot.scalereti);
@@ -1397,8 +1350,8 @@ void LocallabRetinex::read(const rtengine::procparams::ProcParams* pp, const Par
         softradiusret->setValue(spot.softradiusret);
         cTtransshape->setCurve(spot.localTtranscurve);
         cTgainshape->setCurve(spot.localTgaincurve);
-        enaretiMask->set_active(spot.enaretiMask);
-        enaretiMasktmap->set_active(spot.enaretiMasktmap);
+        enaretiMask->setValue(spot.enaretiMask);
+        enaretiMasktmap->setValue(spot.enaretiMasktmap);
         CCmaskretishape->setCurve(spot.CCmaskreticurve);
         LLmaskretishape->setCurve(spot.LLmaskreticurve);
         HHmaskretishape->setCurve(spot.HHmaskreticurve);
@@ -1409,7 +1362,7 @@ void LocallabRetinex::read(const rtengine::procparams::ProcParams* pp, const Par
         gammaskreti->setValue(spot.gammaskreti);
         slomaskreti->setValue(spot.slomaskreti);
         Lmaskretishape->setCurve(spot.Lmaskreticurve);
-        inversret->set_active(spot.inversret);
+        inversret->setValue(spot.inversret);
         recothresr->setValue((double)spot.recothresr);
         lowthresr->setValue((double)spot.lowthresr);
         higthresr->setValue((double)spot.higthresr);
@@ -1450,7 +1403,7 @@ void LocallabRetinex::write(rtengine::procparams::ProcParams* pp, ParamsEdited* 
         spot.dehazeSaturation = dehazeSaturation->getIntValue();
         spot.dehazeblack = dehazeblack->getValue();
         spot.str = str->getValue();
-        spot.loglin = loglin->get_active();
+        spot.loglin = loglin->getLastActive();
         spot.sensih = sensih->getIntValue();
 
         if (retinexMethod->get_active_row_number() == 0) {
@@ -1461,8 +1414,8 @@ void LocallabRetinex::write(rtengine::procparams::ProcParams* pp, ParamsEdited* 
             spot.retinexMethod = "high";
         }
 
-        spot.fftwreti = fftwreti->get_active();
-        spot.equilret = equilret->get_active();
+        spot.fftwreti = fftwreti->getLastActive();
+        spot.equilret = equilret->getLastActive();
         spot.neigh = neigh->getValue();
         spot.vart = vart->getValue();
         spot.scalereti = scalereti->getValue();
@@ -1475,8 +1428,8 @@ void LocallabRetinex::write(rtengine::procparams::ProcParams* pp, ParamsEdited* 
         spot.softradiusret = softradiusret->getValue();
         spot.localTtranscurve = cTtransshape->getCurve();
         spot.localTgaincurve = cTgainshape->getCurve();
-        spot.enaretiMask = enaretiMask->get_active();
-        spot.enaretiMasktmap = enaretiMasktmap->get_active();
+        spot.enaretiMask = enaretiMask->getLastActive();
+        spot.enaretiMasktmap = enaretiMasktmap->getLastActive();
         spot.CCmaskreticurve = CCmaskretishape->getCurve();
         spot.LLmaskreticurve = LLmaskretishape->getCurve();
         spot.HHmaskreticurve = HHmaskretishape->getCurve();
@@ -1487,7 +1440,7 @@ void LocallabRetinex::write(rtengine::procparams::ProcParams* pp, ParamsEdited* 
         spot.gammaskreti = gammaskreti->getValue();
         spot.slomaskreti = slomaskreti->getValue();
         spot.Lmaskreticurve = Lmaskretishape->getCurve();
-        spot.inversret = inversret->get_active();
+        spot.inversret = inversret->getLastActive();
         spot.recothresr = recothresr->getValue();
         spot.lowthresr = lowthresr->getValue();
         spot.higthresr = higthresr->getValue();
@@ -1805,7 +1758,7 @@ void LocallabRetinex::convertParamToNormal()
 
     // Set hidden GUI widgets in Normal mode to default spot values
     str->setValue(defSpot.str);
-    loglin->set_active(defSpot.loglin);
+    loglin->setValue(defSpot.loglin);
 
     if (defSpot.retinexMethod == "low") {
         retinexMethod->set_active(0);
@@ -1815,8 +1768,8 @@ void LocallabRetinex::convertParamToNormal()
         retinexMethod->set_active(2);
     }
 
-    fftwreti->set_active(defSpot.fftwreti);
-    equilret->set_active(defSpot.equilret);
+    fftwreti->setValue(defSpot.fftwreti);
+    equilret->setValue(defSpot.equilret);
     neigh->setValue(defSpot.neigh);
     vart->setValue(defSpot.vart);
     scalereti->setValue(defSpot.scalereti);
@@ -1830,8 +1783,8 @@ void LocallabRetinex::convertParamToNormal()
     cTtransshape->setCurve(defSpot.localTtranscurve);
     cTgainshape->setCurve(defSpot.localTgaincurve);
     showmaskretiMethod->set_active(0);
-    enaretiMask->set_active(defSpot.enaretiMask);
-    enaretiMasktmap->set_active(defSpot.enaretiMasktmap);
+    enaretiMask->setValue(defSpot.enaretiMask);
+    enaretiMasktmap->setValue(defSpot.enaretiMasktmap);
     CCmaskretishape->setCurve(defSpot.CCmaskreticurve);
     LLmaskretishape->setCurve(defSpot.LLmaskreticurve);
     HHmaskretishape->setCurve(defSpot.HHmaskreticurve);
@@ -1842,7 +1795,7 @@ void LocallabRetinex::convertParamToNormal()
     gammaskreti->setValue(defSpot.gammaskreti);
     slomaskreti->setValue(defSpot.slomaskreti);
     Lmaskretishape->setCurve(defSpot.Lmaskreticurve);
-    inversret->set_active(defSpot.inversret);
+    inversret->setValue(defSpot.inversret);
     recothresr->setValue(defSpot.recothresr);
     lowthresr->setValue(defSpot.lowthresr);
     higthresr->setValue(defSpot.higthresr);
@@ -1908,7 +1861,7 @@ void LocallabRetinex::updateGUIToMode(const modeType new_type)
             exprecovr->show();
             decayr->show();
 
-            if (enaretiMask->get_active()) {
+            if (enaretiMask->getLastActive()) {
                 maskusabler->show();
                 maskunusabler->hide();
 
@@ -1936,20 +1889,6 @@ void LocallabRetinex::updateMaskBackground(const double normChromar, const doubl
                  );
 }
 
-void LocallabRetinex::loglinChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (loglin->get_active()) {
-                listener->panelChanged(Evlocallabloglin,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabloglin,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabRetinex::retinexMethodChanged()
 {
@@ -1961,35 +1900,7 @@ void LocallabRetinex::retinexMethodChanged()
     }
 }
 
-void LocallabRetinex::fftwretiChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftwreti->get_active()) {
-                listener->panelChanged(Evlocallabfftwreti,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabfftwreti,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabRetinex::equilretChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (inversret->get_active()) {
-                listener->panelChanged(Evlocallabequilret,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabequilret,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabRetinex::showmaskretiMethodChanged()
 {
@@ -2005,71 +1916,8 @@ void LocallabRetinex::showmaskretiMethodChanged()
     }
 }
 
-void LocallabRetinex::enaretiMaskChanged()
-{
-    if (enaretiMask->get_active()) {
-        maskusabler->show();
-        maskunusabler->hide();
 
-    } else {
-        maskusabler->hide();
-        maskunusabler->show();
-    }
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaretiMask->get_active()) {
-                listener->panelChanged(EvLocallabEnaretiMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaretiMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabRetinex::enaretiMasktmapChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaretiMasktmap->get_active()) {
-                listener->panelChanged(EvLocallabEnaretiMasktmap,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaretiMasktmap,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabRetinex::inversretChanged()
-{
-    const bool maskPreviewActivated = isMaskViewActive();
-
-    // Update Retinex GUI according to inversret button state
-    updateRetinexGUI2();
-
-    if (maskPreviewActivated) {
-        // This event is called to transmit reset mask state
-        if (listener) {
-            listener->panelChanged(EvlocallabshowmaskMethod, "");
-        }
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (inversret->get_active()) {
-                listener->panelChanged(Evlocallabinversret,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinversret,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabRetinex::updateRetinexGUI1()
 {
@@ -2090,7 +1938,7 @@ void LocallabRetinex::updateRetinexGUI1()
 void LocallabRetinex::updateRetinexGUI2()
 {
     // Update Retinex GUI according to inversret button state
-    if (inversret->get_active()) {
+    if (inversret->getLastActive()) {
         expmaskreti->hide();
         showmaskretiMethodConn.block(true);
         showmaskretiMethod->set_active(0);
@@ -2109,6 +1957,45 @@ void LocallabRetinex::updateRetinexGUI3()
     }
 }
 
+void LocallabRetinex::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+
+    if (c == loglin) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabloglin,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == fftwreti) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabfftwreti,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == equilret) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabequilret,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enaretiMask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaretiMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enaretiMasktmap) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaretiMasktmap,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == inversret) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinversret,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
+}
+
 /* ==== LocallabSharp ==== */
 LocallabSharp::LocallabSharp():
     LocallabTool(this, M("TP_LOCALLAB_SHARP_TOOLNAME"), M("TP_LOCALLAB_SHARP"), true),
@@ -2118,13 +2005,13 @@ LocallabSharp::LocallabSharp():
     methodcap(Gtk::manage(new MyComboBoxText())),
     reparsha(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGREPART"), 1.0, 100.0, 0.5, 100.0))),   
     sharcontrast(Gtk::manage(new Adjuster(M("TP_SHARPENING_CONTRAST"), 3, 200, 1, 20))),
-    sharshow(Gtk::manage(new Gtk::CheckButton(M("TP_PDSHARPENING_SHOWCAP")))),
+    sharshow(Gtk::manage(new CheckBox(M("TP_PDSHARPENING_SHOWCAP"), multiImage))),
     capradius(Gtk::manage (new Adjuster (M("TP_SHARPENING_EDRADIUS"), 0.4, 2.5, 0.01, 0.75))),
     deconvCoBoost(Gtk::manage(new Adjuster(M("TP_SHARPENING_RADIUS_BOOST"), -0.7, 0.7, 0.01, 0))),
     deconvCoProt(Gtk::manage(new Adjuster(M("TP_SHARPENING_RADIUS_PROT"), 20., 80., 1., 50.))),
     deconvCoLat(Gtk::manage(new Adjuster(M("TP_SHARPENING_RLD_ITERATIONS"), 0, 100, 1, 25))),
     deconvCogam(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GAMC"), 0.4, 3.0, 0.05, 1.))),
-    itercheck(Gtk::manage(new Gtk::CheckButton(M("TP_SHARPENING_ITERCHECK")))),
+    itercheck(Gtk::manage(new CheckBox(M("TP_SHARPENING_ITERCHECK"), multiImage))),
     capFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SHARCAPFRAME")))),
     rlFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SHARRLFRAME")))),
     sharblur(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SHARBLUR"), 0.2, 2.0, 0.05, 0.2))),
@@ -2134,7 +2021,7 @@ LocallabSharp::LocallabSharp():
     shariter(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SHARITER"), 5, 100, 1, 30))),
     sharradius(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SHARRADIUS"), 0.4, 2.5, 0.01, 0.75))),
     sensisha(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 40))),
-    inverssha(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_INVERS")))),
+    inverssha(Gtk::manage(new CheckBox(M("TP_LOCALLAB_INVERS"), multiImage))),
     sharFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SHARFRAME")))),
     showmasksharMethod(Gtk::manage(new MyComboBoxText()))
 {
@@ -2192,9 +2079,9 @@ LocallabSharp::LocallabSharp():
 
     capradius->setAdjusterListener(this);
 
-    inversshaConn = inverssha->signal_toggled().connect(sigc::mem_fun(*this, &LocallabSharp::inversshaChanged));
-    sharshowConn = sharshow->signal_toggled().connect(sigc::mem_fun(*this, &LocallabSharp::sharshowChanged));
-    itercheckConn = itercheck->signal_toggled().connect(sigc::mem_fun(*this, &LocallabSharp::itercheckChanged));
+    inverssha->setCheckBoxListener(this);
+    sharshow->setCheckBoxListener(this);
+    itercheck->setCheckBoxListener(this);
 
     showmasksharMethod->append(M("TP_LOCALLAB_SHOWMNONE"));
     showmasksharMethod->append(M("TP_LOCALLAB_SHOWMODIF2"));
@@ -2336,24 +2223,16 @@ void LocallabSharp::disableListener()
 {
     LocallabTool::disableListener();
 
-    inversshaConn.block(true);
     showmasksharMethodConn.block(true);
     methodcapConn.block(true);
-    sharshowConn.block(true);
-    itercheckConn.block(true);
-    
 }
 
 void LocallabSharp::enableListener()
 {
     LocallabTool::enableListener();
 
-    inversshaConn.block(false);
     showmasksharMethodConn.block(false);
     methodcapConn.block(false);
-    sharshowConn.block(false);
-    itercheckConn.block(false);
-
 }
 
 //new function Global
@@ -2422,9 +2301,9 @@ void LocallabSharp::read(const rtengine::procparams::ProcParams* pp, const Param
         sharblur->setValue(spot.sharblur);
         shargam->setValue(spot.shargam);
         sensisha->setValue((double)spot.sensisha);
-        inverssha->set_active(spot.inverssha);
-        sharshow->set_active(spot.sharshow);
-        itercheck->set_active(spot.itercheck);
+        inverssha->setValue(spot.inverssha);
+        sharshow->setValue(spot.sharshow);
+        itercheck->setValue(spot.itercheck);
         capradius->setValue((double)spot.capradius);
         capradius->setAutoValue(spot.deconvAutoRadius);
         deconvCoBoost->setValue((double)spot.deconvCoBoost);
@@ -2467,9 +2346,9 @@ void LocallabSharp::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pe
         spot.sharblur = sharblur->getValue();
         spot.shargam = shargam->getValue();
         spot.sensisha = sensisha->getIntValue();
-        spot.inverssha = inverssha->get_active();
-        spot.sharshow = sharshow->get_active();
-        spot.itercheck = itercheck->get_active();
+        spot.inverssha = inverssha->getLastActive();
+        spot.sharshow = sharshow->getLastActive();
+        spot.itercheck = itercheck->getLastActive();
         spot.capradius = capradius->getValue();
         spot.deconvAutoRadius = capradius->getAutoValue();
         spot.deconvCoBoost = deconvCoBoost->getValue();
@@ -2775,67 +2654,15 @@ void LocallabSharp::updateGUIToMode(const modeType new_type)
             }
 
 
-            if (inverssha->get_active()) {
+            if (inverssha->getLastActive()) {
                 shargam->hide();
                 shargam->setValue(defSpot.shargam);
             }
     }
 }
 
-void LocallabSharp::inversshaChanged()
-{
-    const LocallabParams::LocallabSpot defSpot;
-    const int mode = complexity->get_active_row_number();    
-    if (inverssha->get_active()) {
-        shargam->hide();
-        shargam->setValue(defSpot.shargam);      
-    } else {
-        if(mode == Expert) {
-            shargam->show();
-       }
-    }
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (inverssha->get_active()) {
-                listener->panelChanged(Evlocallabinverssha,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabinverssha,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabSharp::sharshowChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sharshow->get_active()) {
-                listener->panelChanged(Evlocallababsharshow,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallababsharshow,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabSharp::itercheckChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (itercheck->get_active()) {
-                listener->panelChanged(Evlocallababitercheck,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallababitercheck,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
 void LocallabSharp::methodcapChanged()
@@ -2885,6 +2712,30 @@ void LocallabSharp::showmasksharMethodChanged()
     }
 }
 
+void LocallabSharp::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+
+    if (c == inverssha) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabinverssha,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == sharshow) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallababsharshow,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == itercheck) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallababitercheck,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
+}
+
 /* ==== LocallabContrast ==== */
 LocallabContrast::LocallabContrast():
     LocallabTool(this, M("TP_LOCALLAB_LC_TOOLNAME"), M("TP_LOCALLAB_LOC_CONTRAST"), true),
@@ -2901,7 +2752,7 @@ LocallabContrast::LocallabContrast():
     LocalcurveEditorwav(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAV"))),
     wavshape(static_cast<FlatCurveEditor*>(LocalcurveEditorwav->addCurve(CT_Flat, "", nullptr, false, false))),
     csThreshold(Gtk::manage(new ThresholdAdjuster(M("TP_LOCALLAB_CSTHRESHOLD"), 0, 9, 0, 0, 7, 5, 0, false))),
-    processwav(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_PROCESSWAV")))),
+    processwav(Gtk::manage(new CheckBox(M("TP_LOCALLAB_PROCESSWAV"), multiImage))),
     levelwav(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LEVELWAV"), 1, 9, 1, 4))),
     expresidpyr(Gtk::manage(new MyExpander(false, Gtk::manage(new Gtk::Box())))),
     residcont(Gtk::manage(new Adjuster(M("TP_LOCALLAB_RESIDCONT"), -100, 100, 1, 0))),
@@ -2920,21 +2771,21 @@ LocallabContrast::LocallabContrast():
     clarilres(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CLARILRES"), -20., 100., 0.5, 0.))),
     claricres(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CLARICRES"), -20., 100., 0.5, 0.))),
     clarisoft(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOFTRADIUSCOL"), 0.0, 100.0, 0.5, 1.))),
-    origlc(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ORIGLC")))),
+    origlc(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ORIGLC"), multiImage))),
     expcontrastpyr(Gtk::manage(new MyExpander(false, Gtk::manage(new Gtk::Box())))),
     gradwavFrame(Gtk::manage(new Gtk::Frame())),
-    wavgradl(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_GRALWFRA")))),
+    wavgradl(Gtk::manage(new CheckBox(M("TP_LOCALLAB_GRALWFRA"), multiImage))),
     sigmalc2(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 2.5, 0.01, 1.))),
     strwav(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADSTR"), -4.0, 4.0, 0.05, 0.))),
     angwav(Gtk::manage(new Adjuster(M("TP_LOCALLAB_GRADANG"), -180, 180, 0.1, 0.))),
     featherwav(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FEATVALUE"), 10., 100., 0.1, 25.))),
-    wavedg(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_EDGFRA")))),
+    wavedg(Gtk::manage(new CheckBox(M("TP_LOCALLAB_EDGFRA"), multiImage))),
     strengthw(Gtk::manage(new Adjuster(M("TP_WAVELET_EDVAL"), 0., 100.0, 0.5, 0.))),
     sigmaed(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 2.5, 0.01, 1.))),
     LocalcurveEditorwavedg(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAVEDG"))),
     wavshapeedg(static_cast<FlatCurveEditor*>(LocalcurveEditorwavedg->addCurve(CT_Flat, "", nullptr, false, false))),
     gradw(Gtk::manage(new Adjuster(M("TP_WAVELET_EDGEDETECT"), 0., 100.0, 0.5, 90.))),
-    waveshow(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_EDGSHOW")))),
+    waveshow(Gtk::manage(new CheckBox(M("TP_LOCALLAB_EDGSHOW"), multiImage))),
     edgsBoxshow(Gtk::manage(new ToolParamBlock())),
     radiusw(Gtk::manage(new Adjuster(M("TP_WAVELET_EDRAD"), 5., 100.0, 0.5, 15.))),
     detailw(Gtk::manage(new Adjuster(M("TP_WAVELET_EDGTHRESH"), -50., 100.0, 1., 10.))),
@@ -2944,34 +2795,34 @@ LocallabContrast::LocallabContrast():
     edgw(Gtk::manage(new Adjuster(M("TP_WAVELET_EDGESENSI"), 0., 100.0, 1., 60.))),
     basew(Gtk::manage(new Adjuster(M("TP_WAVELET_EDGEAMPLI"), 0., 100.0, 1., 10.))),
     localneiMethod(Gtk::manage(new MyComboBoxText())),
-    wavblur(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_BLURLEVELFRA")))),
+    wavblur(Gtk::manage(new CheckBox(M("TP_LOCALLAB_BLURLEVELFRA"), multiImage))),
     levelblur(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LEVELBLUR"), 0., 100., 0.5, 0.))),
     sigmabl(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 2.5, 0.01, 1.))),
     chromablu(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CHROMABLU"), 0.0, 5., 0.1, 0.))),
     LocalcurveEditorwavlev(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAVLEV"))),
     wavshapelev(static_cast<FlatCurveEditor*>(LocalcurveEditorwavlev->addCurve(CT_Flat, "", nullptr, false, false))),
     residblur(Gtk::manage(new Adjuster(M("TP_LOCALLAB_RESIDBLUR"), 0., 100., 0.5, 0.))),
-    blurlc(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_BLURLC")))),
+    blurlc(Gtk::manage(new CheckBox(M("TP_LOCALLAB_BLURLC"), multiImage))),
     expcontrastpyr2(Gtk::manage(new MyExpander(false, Gtk::manage(new Gtk::Box())))),
-    wavcont(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_CONTFRA")))),
+    wavcont(Gtk::manage(new CheckBox(M("TP_LOCALLAB_CONTFRA"), multiImage))),
     sigma(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 2.5, 0.01, 1.))),
     offset(Gtk::manage(new Adjuster(M("TP_LOCALLAB_OFFSETWAV"), 0.33, 1.66, 0.01, 1., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     chromalev(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CHROMALEV"), 0.1, 5., 0.1, 1.))),
     LocalcurveEditorwavcon(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAVCON"))),
     wavshapecon(static_cast<FlatCurveEditor*>(LocalcurveEditorwavcon->addCurve(CT_Flat, "", nullptr, false, false))),
-    wavcompre(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_COMPREFRA")))),
+    wavcompre(Gtk::manage(new CheckBox(M("TP_LOCALLAB_COMPREFRA"), multiImage))),
     LocalcurveEditorwavcompre(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAVCOMPRE"))),
     wavshapecompre(static_cast<FlatCurveEditor*>(LocalcurveEditorwavcompre->addCurve(CT_Flat, "", nullptr, false, false))),
     sigmadr(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 2.5, 0.01, 1.))),
     threswav(Gtk::manage(new Adjuster(M("TP_LOCALLAB_THRESWAV"), 0.9, 2., 0.01, 1.4))),
     residcomp(Gtk::manage(new Adjuster(M("TP_LOCALLAB_RESIDCOMP"), -1., 1., 0.01, 0.))),
-    wavcomp(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_COMPFRA")))),
+    wavcomp(Gtk::manage(new CheckBox(M("TP_LOCALLAB_COMPFRA"), multiImage))),
     sigmadc(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMAWAV"), 0.2, 3., 0.01, 1.))),
     deltad(Gtk::manage(new Adjuster(M("TP_LOCALLAB_DELTAD"), -3., 3., 0.1, 0.))),//, Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     LocalcurveEditorwavcomp(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_WAVCOMP"))),
     wavshapecomp(static_cast<FlatCurveEditor*>(LocalcurveEditorwavcomp->addCurve(CT_Flat, "", nullptr, false, false))),
     //fatres(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FATRES"), 0., 100., 1., 0.))),
-    fftwlc(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTW")))),
+    fftwlc(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTW"), multiImage))),
     exprecovw(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_DENOI2_EXP")))),
     maskusablew(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUSABLE")))),
     maskunusablew(Gtk::manage(new Gtk::Label(M("TP_LOCALLAB_MASKUNUSABLE")))),
@@ -2982,7 +2833,7 @@ LocallabContrast::LocallabContrast():
 
     expmasklc(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWLC")))),
     showmasklcMethod(Gtk::manage(new MyComboBoxText())),
-    enalcMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enalcMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //    masklcCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
     masklcCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmasklcshape(static_cast<FlatCurveEditor*>(masklcCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -3077,8 +2928,8 @@ LocallabContrast::LocallabContrast():
     clarisoft->setLogScale(10, 0);
     clarisoft->setAdjusterListener(this);
 
-    origlcConn = origlc->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::origlcChanged));
-    processwavConn = processwav->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::processwavChanged));
+    origlc->setCheckBoxListener(this);
+    processwav->setCheckBoxListener(this);
 
     Gtk::Box *TittleVBox;
     TittleVBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
@@ -3101,7 +2952,7 @@ LocallabContrast::LocallabContrast():
     setExpandAlignProperties(expcontrastpyr, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
 
 
-    wavgradlConn = wavgradl->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavgradlChanged));
+    wavgradl->setCheckBoxListener(this);
 
     sigmalc2->setAdjusterListener(this);
 
@@ -3110,7 +2961,7 @@ LocallabContrast::LocallabContrast():
     angwav->setAdjusterListener(this);
     featherwav->setAdjusterListener(this);
 
-    wavedgConn = wavedg->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavedgChanged));
+    wavedg->setCheckBoxListener(this);
 
     strengthw->setAdjusterListener(this);
 
@@ -3126,7 +2977,7 @@ LocallabContrast::LocallabContrast():
 
     gradw->setAdjusterListener(this);
 
-    waveshowConn = waveshow->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::waveshowChanged));
+    waveshow->setCheckBoxListener(this);
 
     radiusw->setAdjusterListener(this);
 
@@ -3152,7 +3003,7 @@ LocallabContrast::LocallabContrast():
     localneiMethod->set_active(0);
     localneiMethodConn = localneiMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabContrast::localneiMethodChanged));
 
-    wavblurConn = wavblur->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavblurChanged));
+    wavblur->setCheckBoxListener(this);
 
     levelblur->setAdjusterListener(this);
 
@@ -3169,7 +3020,7 @@ LocallabContrast::LocallabContrast():
 
     residblur->setAdjusterListener(this);
 
-    blurlcConn = blurlc->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::blurlcChanged));
+    blurlc->setCheckBoxListener(this);
 
     Gtk::Box *TittleVBox2;
     TittleVBox2 = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL));
@@ -3192,7 +3043,7 @@ LocallabContrast::LocallabContrast():
 
     setExpandAlignProperties(expcontrastpyr2, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
 
-    wavcontConn = wavcont->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavcontChanged));
+    wavcont->setCheckBoxListener(this);
 
     sigma->setAdjusterListener(this);
 
@@ -3207,7 +3058,7 @@ LocallabContrast::LocallabContrast():
 
     LocalcurveEditorwavcon->curveListComplete();
 
-    wavcompreConn = wavcompre->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavcompreChanged));
+    wavcompre->setCheckBoxListener(this);
 
     LocalcurveEditorwavcompre->setCurveListener(this);
 
@@ -3223,7 +3074,7 @@ LocallabContrast::LocallabContrast():
 
     residcomp->setAdjusterListener(this);
 
-    wavcompConn = wavcomp->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::wavcompChanged));
+    wavcomp->setCheckBoxListener(this);
 
     sigmadc->setAdjusterListener(this);
 
@@ -3239,7 +3090,7 @@ LocallabContrast::LocallabContrast():
 
     //fatres->setAdjusterListener(this);
 
-    fftwlcConn = fftwlc->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::fftwlcChanged));
+    fftwlc->setCheckBoxListener(this);
 
     recothresw->setAdjusterListener(this);
     lowthresw->setAdjusterListener(this);
@@ -3264,7 +3115,7 @@ LocallabContrast::LocallabContrast():
     showmasklcMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmasklcMethodConn = showmasklcMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabContrast::showmasklcMethodChanged));
 
-    enalcMaskConn = enalcMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabContrast::enalcMaskChanged));
+    enalcMask->setCheckBoxListener(this);
 
     masklcCurveEditorG->setCurveListener(this);
 
@@ -3521,7 +3372,7 @@ void LocallabContrast::updateguicont(int spottype)
                 sensilc->hide();
                 previewlc->hide();
                 previewlc->set_active(false);
-                enalcMask->set_active(false);
+                enalcMask->setValue(false);
                 exprecovw->hide();
                 expmasklc->hide();
             } else {
@@ -3719,21 +3570,9 @@ void LocallabContrast::disableListener()
     LocallabTool::disableListener();
 
     localcontMethodConn.block(true);
-    origlcConn.block(true);
-    processwavConn.block(true);
-    wavgradlConn.block(true);
-    wavedgConn.block(true);
     localedgMethodConn.block(true);
-    waveshowConn.block(true);
     localneiMethodConn.block(true);
-    wavblurConn.block(true);
-    blurlcConn.block(true);
-    wavcontConn.block(true);
-    wavcompreConn.block(true);
-    wavcompConn.block(true);
-    fftwlcConn.block(true);
     showmasklcMethodConn.block(true);
-    enalcMaskConn.block(true);
 }
 
 void LocallabContrast::enableListener()
@@ -3741,21 +3580,9 @@ void LocallabContrast::enableListener()
     LocallabTool::enableListener();
 
     localcontMethodConn.block(false);
-    origlcConn.block(false);
-    processwavConn.block(false);
-    wavgradlConn.block(false);
-    wavedgConn.block(false);
     localedgMethodConn.block(false);
-    waveshowConn.block(false);
     localneiMethodConn.block(false);
-    wavblurConn.block(false);
-    blurlcConn.block(false);
-    wavcontConn.block(false);
-    wavcompreConn.block(false);
-    wavcompConn.block(false);
-    fftwlcConn.block(false);
     showmasklcMethodConn.block(false);
-    enalcMaskConn.block(false);
 }
 
 void LocallabContrast::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -3779,7 +3606,7 @@ void LocallabContrast::read(const rtengine::procparams::ProcParams* pp, const Pa
             localcontMethod->set_active(1);
         }
 
-        fftwlc->set_active(spot.fftwlc);
+        fftwlc->setValue(spot.fftwlc);
         // Update Local contrast GUI according to fftwlc button state
         // Note: Contrary to the others, shall be called before setting lcradius value
         updateContrastGUI3();
@@ -3806,19 +3633,19 @@ void LocallabContrast::read(const rtengine::procparams::ProcParams* pp, const Pa
         clarilres->setValue(spot.clarilres);
         claricres->setValue(spot.claricres);
         clarisoft->setValue(spot.clarisoft);
-        origlc->set_active(spot.origlc);
-        processwav->set_active(spot.processwav);
-        wavgradl->set_active(spot.wavgradl);
+        origlc->setValue(spot.origlc);
+        processwav->setValue(spot.processwav);
+        wavgradl->setValue(spot.wavgradl);
         sigmalc2->setValue(spot.sigmalc2);
         strwav->setValue(spot.strwav);
         angwav->setValue(spot.angwav);
         featherwav->setValue(spot.featherwav);
-        wavedg->set_active(spot.wavedg);
+        wavedg->setValue(spot.wavedg);
         strengthw->setValue(spot.strengthw);
         sigmaed->setValue(spot.sigmaed);
         wavshapeedg->setCurve(spot.locedgwavcurve);
         gradw->setValue(spot.gradw);
-        waveshow->set_active(spot.waveshow);
+        waveshow->setValue(spot.waveshow);
         radiusw->setValue(spot.radiusw);
         detailw->setValue(spot.detailw);
 
@@ -3843,29 +3670,29 @@ void LocallabContrast::read(const rtengine::procparams::ProcParams* pp, const Pa
             localneiMethod->set_active(2);
         }
 
-        wavblur->set_active(spot.wavblur);
+        wavblur->setValue(spot.wavblur);
         levelblur->setValue(spot.levelblur);
         sigmabl->setValue(spot.sigmabl);
         chromablu->setValue(spot.chromablu);
         wavshapelev->setCurve(spot.loclevwavcurve);
         residblur->setValue(spot.residblur);
-        blurlc->set_active(spot.blurlc);
-        wavcont->set_active(spot.wavcont);
+        blurlc->setValue(spot.blurlc);
+        wavcont->setValue(spot.wavcont);
         sigma->setValue(spot.sigma);
         offset->setValue(spot.offset);
         chromalev->setValue(spot.chromalev);
         wavshapecon->setCurve(spot.locconwavcurve);
-        wavcompre->set_active(spot.wavcompre);
+        wavcompre->setValue(spot.wavcompre);
         wavshapecompre->setCurve(spot.loccomprewavcurve);
         sigmadr->setValue(spot.sigmadr);
         threswav->setValue(spot.threswav);
         residcomp->setValue(spot.residcomp);
-        wavcomp->set_active(spot.wavcomp);
+        wavcomp->setValue(spot.wavcomp);
         sigmadc->setValue(spot.sigmadc);
         deltad->setValue(spot.deltad);
         wavshapecomp->setCurve(spot.loccompwavcurve);
         //fatres->setValue(spot.fatres);
-        enalcMask->set_active(spot.enalcMask);
+        enalcMask->setValue(spot.enalcMask);
         CCmasklcshape->setCurve(spot.CCmasklccurve);
         LLmasklcshape->setCurve(spot.LLmasklccurve);
         HHmasklcshape->setCurve(spot.HHmasklccurve);
@@ -3934,19 +3761,19 @@ void LocallabContrast::write(rtengine::procparams::ProcParams* pp, ParamsEdited*
         spot.clarilres = clarilres->getValue();
         spot.claricres = claricres->getValue();
         spot.clarisoft = clarisoft->getValue();
-        spot.origlc = origlc->get_active();
-        spot.processwav = processwav->get_active();
-        spot.wavgradl = wavgradl->get_active();
+        spot.origlc = origlc->getLastActive();
+        spot.processwav = processwav->getLastActive();
+        spot.wavgradl = wavgradl->getLastActive();
         spot.sigmalc2 = sigmalc2->getValue();
         spot.strwav = strwav->getValue();
         spot.angwav = angwav->getValue();
         spot.featherwav = featherwav->getValue();
-        spot.wavedg = wavedg->get_active();
+        spot.wavedg = wavedg->getLastActive();
         spot.strengthw = strengthw->getValue();
         spot.sigmaed = sigmaed->getValue();
         spot.locedgwavcurve = wavshapeedg->getCurve();
         spot.gradw = gradw->getValue();
-        spot.waveshow = waveshow->get_active();
+        spot.waveshow = waveshow->getLastActive();
         spot.radiusw = radiusw->getValue();
         spot.detailw = detailw->getValue();
 
@@ -3971,30 +3798,30 @@ void LocallabContrast::write(rtengine::procparams::ProcParams* pp, ParamsEdited*
             spot.localneiMethod = "high";
         }
 
-        spot.wavblur = wavblur->get_active();
+        spot.wavblur = wavblur->getLastActive();
         spot.levelblur = levelblur->getValue();
         spot.sigmabl = sigmabl->getValue();
         spot.chromablu = chromablu->getValue();
         spot.loclevwavcurve = wavshapelev->getCurve();
         spot.residblur = residblur->getValue();
-        spot.blurlc = blurlc->get_active();
-        spot.wavcont = wavcont->get_active();
+        spot.blurlc = blurlc->getLastActive();
+        spot.wavcont = wavcont->getLastActive();
         spot.sigma = sigma->getValue();
         spot.offset = offset->getValue();
         spot.chromalev = chromalev->getValue();
         spot.locconwavcurve = wavshapecon->getCurve();
-        spot.wavcompre = wavcompre->get_active();
+        spot.wavcompre = wavcompre->getLastActive();
         spot.loccomprewavcurve = wavshapecompre->getCurve();
         spot.sigmadr = sigmadr->getValue();
         spot.threswav = threswav->getValue();
         spot.residcomp = residcomp->getValue();
-        spot.wavcomp = wavcomp->get_active();
+        spot.wavcomp = wavcomp->getLastActive();
         spot.sigmadc = sigmadc->getValue();
         spot.deltad = deltad->getValue();
         spot.loccompwavcurve = wavshapecomp->getCurve();
         //spot.fatres = fatres->getValue();
-        spot.fftwlc = fftwlc->get_active();
-        spot.enalcMask = enalcMask->get_active();
+        spot.fftwlc = fftwlc->getLastActive();
+        spot.enalcMask = enalcMask->getLastActive();
         spot.CCmasklccurve = CCmasklcshape->getCurve();
         spot.LLmasklccurve = LLmasklcshape->getCurve();
         spot.HHmasklccurve = HHmasklcshape->getCurve();
@@ -4573,19 +4400,19 @@ void LocallabContrast::convertParamToNormal()
     gamlc->setValue(defSpot.gamlc);
 
     // Set hidden GUI widgets in Normal mode to default spot values
-    origlc->set_active(defSpot.origlc);
-    processwav->set_active(defSpot.processwav);
-    wavgradl->set_active(defSpot.wavgradl);
+    origlc->setValue(defSpot.origlc);
+    processwav->setValue(defSpot.processwav);
+    wavgradl->setValue(defSpot.wavgradl);
     sigmalc2->setValue(defSpot.sigmalc2);
     strwav->setValue(defSpot.strwav);
     angwav->setValue(defSpot.angwav);
     featherwav->setValue(defSpot.featherwav);
-    wavedg->set_active(defSpot.wavedg);
+    wavedg->setValue(defSpot.wavedg);
     strengthw->setValue(defSpot.strengthw);
     sigmaed->setValue(defSpot.sigmaed);
     wavshapeedg->setCurve(defSpot.locedgwavcurve);
     gradw->setValue(defSpot.gradw);
-    waveshow->set_active(defSpot.waveshow);
+    waveshow->setValue(defSpot.waveshow);
     radiusw->setValue(defSpot.radiusw);
     detailw->setValue(defSpot.detailw);
     offslc->setValue(defSpot.offslc);
@@ -4611,29 +4438,29 @@ void LocallabContrast::convertParamToNormal()
         localneiMethod->set_active(2);
     }
 
-    wavblur->set_active(defSpot.wavblur);
+    wavblur->setValue(defSpot.wavblur);
     levelblur->setValue(defSpot.levelblur);
     sigmabl->setValue(defSpot.sigmabl);
     chromablu->setValue(defSpot.chromablu);
     wavshapelev->setCurve(defSpot.loclevwavcurve);
     residblur->setValue(defSpot.residblur);
-    blurlc->set_active(defSpot.blurlc);
-    wavcont->set_active(defSpot.wavcont);
+    blurlc->setValue(defSpot.blurlc);
+    wavcont->setValue(defSpot.wavcont);
     sigma->setValue(defSpot.sigma);
     offset->setValue(defSpot.offset);
     chromalev->setValue(defSpot.chromalev);
     wavshapecon->setCurve(defSpot.locconwavcurve);
-    wavcompre->set_active(defSpot.wavcompre);
+    wavcompre->setValue(defSpot.wavcompre);
     wavshapecompre->setCurve(defSpot.loccomprewavcurve);
     sigmadr->setValue(defSpot.sigmadr);
     threswav->setValue(defSpot.threswav);
     residcomp->setValue(defSpot.residcomp);
-    wavcomp->set_active(defSpot.wavcomp);
+    wavcomp->setValue(defSpot.wavcomp);
     sigmadc->setValue(defSpot.sigmadc);
     deltad->setValue(defSpot.deltad);
     wavshapecomp->setCurve(defSpot.loccompwavcurve);
     //fatres->setValue(defSpot.fatres);
-    fftwlc->set_active(defSpot.fftwlc);
+    fftwlc->setValue(defSpot.fftwlc);
     decayw->setValue(defSpot.decayw);
 
     // Enable all listeners
@@ -4661,7 +4488,7 @@ void LocallabContrast::convertParamToSimple()
     }
 */
     showmasklcMethod->set_active(0);
-    enalcMask->set_active(defSpot.enalcMask);
+    enalcMask->setValue(defSpot.enalcMask);
 //    CCmasklcshape->setCurve(defSpot.CCmasklccurve);
 //    LLmasklcshape->setCurve(defSpot.LLmasklccurve);
 //    HHmasklcshape->setCurve(defSpot.HHmasklccurve);
@@ -4714,7 +4541,7 @@ void LocallabContrast::updateGUIToMode(const modeType new_type)
             exprecovw->show();
             decayw->hide();
             offslc->hide();
-            if (enalcMask->get_active()) {
+            if (enalcMask->getLastActive()) {
                 maskusablew->show();
                 maskunusablew->hide();
 
@@ -4747,7 +4574,7 @@ void LocallabContrast::updateGUIToMode(const modeType new_type)
             exprecovw->show();
             decayw->show();
 
-            if (enalcMask->get_active()) {
+            if (enalcMask->getLastActive()) {
                 maskusablew->show();
                 maskunusablew->hide();
 
@@ -4789,66 +4616,8 @@ void LocallabContrast::localcontMethodChanged()
     }
 }
 
-void LocallabContrast::origlcChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (origlc->get_active()) {
-                listener->panelChanged(Evlocallaboriglc,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallaboriglc,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabContrast::processwavChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (processwav->get_active()) {
-                listener->panelChanged(Evlocallabprocesswav,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabprocesswav,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void LocallabContrast::wavgradlChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavgradl->get_active()) {
-                listener->panelChanged(Evlocallabwavgradl,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavgradl,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabContrast::wavedgChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavedg->get_active()) {
-                listener->panelChanged(Evlocallabwavedg,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavedg,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabContrast::localedgMethodChanged()
 {
@@ -4856,24 +4625,6 @@ void LocallabContrast::localedgMethodChanged()
         if (listener) {
             listener->panelChanged(EvlocallablocaledgMethod,
                                    localedgMethod->get_active_text() + " (" + escapeHtmlChars(getSpotName()) + ")");
-        }
-    }
-}
-
-void LocallabContrast::waveshowChanged()
-{
-    // Update Local contrast GUI according to waveshow button state
-    updateContrastGUI2();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (waveshow->get_active()) {
-                listener->panelChanged(Evlocallabwaveshow,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwaveshow,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
         }
     }
 }
@@ -4888,98 +4639,11 @@ void LocallabContrast::localneiMethodChanged()
     }
 }
 
-void LocallabContrast::wavblurChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavblur->get_active()) {
-                listener->panelChanged(Evlocallabwavblur,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavblur,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabContrast::blurlcChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (blurlc->get_active()) {
-                listener->panelChanged(Evlocallabblurlc,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabblurlc,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabContrast::wavcontChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavcont->get_active()) {
-                listener->panelChanged(Evlocallabwavcont,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavcont,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabContrast::wavcompreChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavcompre->get_active()) {
-                listener->panelChanged(Evlocallabwavcompre,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavcompre,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabContrast::wavcompChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (wavcomp->get_active()) {
-                listener->panelChanged(Evlocallabwavcomp,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabwavcomp,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabContrast::fftwlcChanged()
-{
-    // Update Local contrast GUI according to fftwlc button state
-    updateContrastGUI3();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftwlc->get_active()) {
-                listener->panelChanged(Evlocallabfftwlc,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabfftwlc,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabContrast::showmasklcMethodChanged()
 {
@@ -4995,29 +4659,6 @@ void LocallabContrast::showmasklcMethodChanged()
     }
 }
 
-void LocallabContrast::enalcMaskChanged()
-{
-    if (enalcMask->get_active()) {
-        maskusablew->show();
-        maskunusablew->hide();
-
-    } else {
-        maskusablew->hide();
-        maskunusablew->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enalcMask->get_active()) {
-                listener->panelChanged(EvLocallabEnalcMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnalcMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabContrast::updateContrastGUI1()
 {
@@ -5067,7 +4708,7 @@ void LocallabContrast::updateContrastGUI1()
 void LocallabContrast::updateContrastGUI2()
 {
     // Update Local contrast GUI according to waveshow button state
-    if (waveshow->get_active()) {
+    if (waveshow->getLastActive()) {
         edgsBoxshow->show();
     } else {
         edgsBoxshow->hide();
@@ -5079,13 +4720,83 @@ void LocallabContrast::updateContrastGUI3()
     // Update Local contrast GUI according to fftwlc button state
     const double temp = lcradius->getValue();
 
-    if (fftwlc->get_active()) {
+    if (fftwlc->getLastActive()) {
         lcradius->setLimits(20, 1500, 1, 80);
     } else {
         lcradius->setLimits(20, 100, 1, 80);
     }
 
     lcradius->setValue(temp);
+}
+
+void LocallabContrast::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+
+    if (c == origlc) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallaboriglc,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == processwav) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabprocesswav,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavgradl) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavgradl,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavedg) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavedg,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == waveshow) {
+        updateContrastGUI2();
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwaveshow,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavblur) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavblur,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == blurlc) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabblurlc,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavcont) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavcont,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavcompre) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavcompre,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == wavcomp) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabwavcomp,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == fftwlc) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(Evlocallabfftwlc,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    } else if (c == enalcMask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnalcMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
 }
 
 /* ==== LocallabCBDL ==== */
@@ -5128,7 +4839,7 @@ higthrescb(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKLCTHR"), 20., 99., 0.5, 8
 decaycb(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
 expmaskcb(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWCB")))),
 showmaskcbMethod(Gtk::manage(new MyComboBoxText())),
-enacbMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+enacbMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //  maskcbCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASK"))),
 maskcbCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
 CCmaskcbshape(static_cast<FlatCurveEditor*>(maskcbCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -5184,7 +4895,7 @@ lumacontrastPlusButton(Gtk::manage(new Gtk::Button(M("TP_DIRPYREQUALIZER_LUMACON
     showmaskcbMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskcbMethodConn = showmaskcbMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabCBDL::showmaskcbMethodChanged));
 
-    enacbMaskConn = enacbMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabCBDL::enacbMaskChanged));
+    enacbMask->setCheckBoxListener(this);
 
     maskcbCurveEditorG->setCurveListener(this);
 
@@ -5324,7 +5035,7 @@ void LocallabCBDL::updateguicbdl(int spottype)
                 sensicb->hide();
                 exprecovcb->hide();
                 expmaskcb->hide();
-                enacbMask->set_active(false);
+                enacbMask->setValue(false);
             } else {
                 exprecovcb->show();
                 expmaskcb->show();
@@ -5413,7 +5124,6 @@ void LocallabCBDL::disableListener()
     LocallabTool::disableListener();
 
     showmaskcbMethodConn.block(true);
-    enacbMaskConn.block(true);
 
     lumacontrastMinusPressedConn.block(true);
     lumaneutralPressedConn.block(true);
@@ -5425,7 +5135,6 @@ void LocallabCBDL::enableListener()
     LocallabTool::enableListener();
 
     showmaskcbMethodConn.block(false);
-    enacbMaskConn.block(false);
 
     lumacontrastMinusPressedConn.block(false);
     lumaneutralPressedConn.block(false);
@@ -5457,7 +5166,7 @@ void LocallabCBDL::read(const rtengine::procparams::ProcParams* pp, const Params
         contresid->setValue((double)spot.contresid);
         softradiuscb->setValue(spot.softradiuscb);
         sensicb->setValue((double)spot.sensicb);
-        enacbMask->set_active(spot.enacbMask);
+        enacbMask->setValue(spot.enacbMask);
         CCmaskcbshape->setCurve(spot.CCmaskcbcurve);
         LLmaskcbshape->setCurve(spot.LLmaskcbcurve);
         HHmaskcbshape->setCurve(spot.HHmaskcbcurve);
@@ -5504,7 +5213,7 @@ void LocallabCBDL::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
         spot.contresid = contresid->getIntValue();
         spot.softradiuscb = softradiuscb->getValue();
         spot.sensicb = sensicb->getIntValue();
-        spot.enacbMask = enacbMask->get_active();
+        spot.enacbMask = enacbMask->getLastActive();
         spot.LLmaskcbcurve = LLmaskcbshape->getCurve();
         spot.CCmaskcbcurve = CCmaskcbshape->getCurve();
         spot.HHmaskcbcurve = HHmaskcbshape->getCurve();
@@ -5762,7 +5471,7 @@ void LocallabCBDL::convertParamToSimple()
     // Set hidden specific GUI widgets in Simple mode to default spot values
     softradiuscb->setValue(defSpot.softradiuscb);
     showmaskcbMethod->set_active(0);
-    enacbMask->set_active(defSpot.enacbMask);
+    enacbMask->setValue(defSpot.enacbMask);
 //    CCmaskcbshape->setCurve(defSpot.CCmaskcbcurve);
 //    LLmaskcbshape->setCurve(defSpot.LLmaskcbcurve);
 //    HHmaskcbshape->setCurve(defSpot.HHmaskcbcurve);
@@ -5804,7 +5513,7 @@ void LocallabCBDL::updateGUIToMode(const modeType new_type)
             exprecovcb->show();
             decaycb->hide();
 
-            if (enacbMask->get_active()) {
+            if (enacbMask->getLastActive()) {
                 maskusablecb->show();
                 maskunusablecb->hide();
 
@@ -5823,7 +5532,7 @@ void LocallabCBDL::updateGUIToMode(const modeType new_type)
             exprecovcb->show();
             decaycb->show();
 
-            if (enacbMask->get_active()) {
+            if (enacbMask->getLastActive()) {
                 maskusablecb->show();
                 maskunusablecb->hide();
 
@@ -5865,28 +5574,6 @@ void LocallabCBDL::showmaskcbMethodChanged()
     }
 }
 
-void LocallabCBDL::enacbMaskChanged()
-{
-    if (enacbMask->get_active()) {
-        maskusablecb->show();
-        maskunusablecb->hide();
-    } else {
-        maskusablecb->hide();
-        maskunusablecb->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enacbMask->get_active()) {
-                listener->panelChanged(EvLocallabEnacbMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnacbMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabCBDL::lumacontrastMinusPressed()
 {
@@ -5919,14 +5606,25 @@ void LocallabCBDL::lumacontrastPlusPressed()
     // Raise event (only for first multiplier because associated event concerns all multipliers)
     adjusterChanged(multiplier[0], multiplier[0]->getValue()); // Value isn't used
 }
-
+void LocallabCBDL::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+    if (c == enacbMask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnacbMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
+}
 /* ==== LocallabLog ==== */
 LocallabLog::LocallabLog():
     LocallabTool(this, M("TP_LOCALLAB_LOG_TOOLNAME"), M("TP_LOCALLAB_LOG"), false),
 
     // Log encoding specific widgets
     repar(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGREPART"), 1.0, 100.0, 0.5, 100.0))),
-    ciecam(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_CIEC")))),
+    ciecam(Gtk::manage(new CheckBox(M("TP_LOCALLAB_CIEC"), multiImage))),
     autocompute(Gtk::manage(new Gtk::ToggleButton(M("TP_LOCALLAB_LOGAUTO")))),
     logPFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGPFRA")))),
     logPFrame2(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGPFRA2")))),
@@ -5936,11 +5634,11 @@ LocallabLog::LocallabLog():
     blackslog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGBLACKSSCIE"), -100, 100, 1, 0))),
     comprlog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_COMPRCIE"), 0., 1., 0.01, 0.4))),
     strelog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRENGTHCIELOG"), 0., 100., 0.5, 100.))),
-    satlog(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SATCIE")))),
+    satlog(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SATCIE"), multiImage))),
 
-    fullimage(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FULLIMAGE")))),
+    fullimage(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FULLIMAGE"), multiImage))),
     logFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGFRA")))),
-    Autogray(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AUTOGRAY")))),
+    Autogray(Gtk::manage(new CheckBox(M("TP_LOCALLAB_AUTOGRAY"), multiImage))),
     sourceGray(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_GRAY"), 1.0, 100.0, 0.1, 10.0))),
     sourceabs(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 2000.0))),
     sursour(Gtk::manage(new MyComboBoxText())),
@@ -5981,7 +5679,7 @@ LocallabLog::LocallabLog():
     featherlog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_FEATVALUE"), 10., 100., 0.1, 25.))),
     expmaskL(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWC")))),
     showmaskLMethod(Gtk::manage(new MyComboBoxText())),
-    enaLMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enaLMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //   maskCurveEditorL(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASKCOL"))),
     maskCurveEditorL(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskshapeL(static_cast<FlatCurveEditor*>(maskCurveEditorL->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -6007,7 +5705,6 @@ LocallabLog::LocallabLog():
     set_orientation(Gtk::ORIENTATION_VERTICAL);
 
     // Parameter Log encoding specific widgets
-    autoconn = autocompute->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::autocomputeToggled));
     const LocallabParams::LocallabSpot defSpot;
     repar->setAdjusterListener(this);
 
@@ -6022,12 +5719,12 @@ LocallabLog::LocallabLog():
     comprlog->setAdjusterListener(this);
     strelog->setAdjusterListener(this);
 
-    ciecamconn = ciecam->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::ciecamChanged));
+    ciecam->setCheckBoxListener(this);
 
-    fullimageConn = fullimage->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::fullimageChanged));
-    satlogconn = satlog->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::satlogChanged));
+    fullimage->setCheckBoxListener(this);
+    satlog->setCheckBoxListener(this);
 
-    AutograyConn = Autogray->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::AutograyChanged));
+    Autogray->setCheckBoxListener(this);
 
     sourceGray->setAdjusterListener(this);
     sourceGray->setLogScale(10, 18, true);
@@ -6128,7 +5825,7 @@ LocallabLog::LocallabLog():
     showmaskLMethodConn  = showmaskLMethod->signal_changed().connect(sigc::mem_fun(*this, &LocallabLog::showmaskLMethodChanged));
 
 
-    enaLMaskConn = enaLMask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabLog::enaLMaskChanged));
+    enaLMask->setCheckBoxListener(this);
 
     maskCurveEditorL->setCurveListener(this);
 
@@ -6289,7 +5986,7 @@ void LocallabLog::updateguilog(int spottype)
                 sensilog->hide();
                 previewlog->hide();
                 previewlog->set_active(false);
-                enaLMask->set_active(false);
+                enaLMask->setValue(false);
                 exprecovl->hide();
                 expmaskL->hide();
             } else {
@@ -6437,13 +6134,8 @@ void LocallabLog::disableListener()
     LocallabTool::disableListener();
 
     autoconn.block(true);
-    fullimageConn.block(true);
-    ciecamconn.block(true);
-    satlogconn.block(true);
-    enaLMaskConn.block(true);
     surroundconn.block(true);
     sursourconn.block(true);
-    AutograyConn.block(true);
     showmaskLMethodConn.block(true);
 }
 
@@ -6452,13 +6144,8 @@ void LocallabLog::enableListener()
     LocallabTool::enableListener();
 
     autoconn.block(false);
-    fullimageConn.block(false);
-    ciecamconn.block(false);
-    satlogconn.block(false);
-    enaLMaskConn.block(false);
     surroundconn.block(false);
     sursourconn.block(false);
-    AutograyConn.block(false);
     showmaskLMethodConn.block(false);
 }
 
@@ -6547,10 +6234,10 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         higthresl->setValue((double)spot.higthresl);
         decayl->setValue((double)spot.decayl);
 
-        ciecam->set_active(spot.ciecam);
-        satlog->set_active(spot.satlog);
-        fullimage->set_active(spot.fullimage);
-        Autogray->set_active(spot.Autogray);
+        ciecam->setValue(spot.ciecam);
+        satlog->setValue(spot.satlog);
+        fullimage->setValue(spot.fullimage);
+        Autogray->setValue(spot.Autogray);
         sourceGray->setValue(spot.sourceGray);
         sourceabs->setValue(spot.sourceabs);
         catad->setValue(spot.catad);
@@ -6574,7 +6261,7 @@ void LocallabLog::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         CCmaskshapeL->setCurve(spot.CCmaskcurveL);
         LLmaskshapeL->setCurve(spot.LLmaskcurveL);
         HHmaskshapeL->setCurve(spot.HHmaskcurveL);
-        enaLMask->set_active(spot.enaLMask);
+        enaLMask->setValue(spot.enaLMask);
         blendmaskL->setValue(spot.blendmaskL);
         radmaskL->setValue(spot.radmaskL);
         chromaskL->setValue(spot.chromaskL);
@@ -6615,10 +6302,10 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.blackslog = blackslog->getIntValue();
         spot.comprlog = comprlog->getValue();
         spot.strelog = strelog->getValue();
-        spot.fullimage = fullimage->get_active();
-        spot.ciecam = ciecam->get_active();
-        spot.satlog = satlog->get_active();
-        spot.Autogray = Autogray->get_active();
+        spot.fullimage = fullimage->getLastActive();
+        spot.ciecam = ciecam->getLastActive();
+        spot.satlog = satlog->getLastActive();
+        spot.Autogray = Autogray->getLastActive();
         spot.sourceGray = sourceGray->getValue();
         spot.sourceabs = sourceabs->getValue();
         spot.targabs = targabs->getValue();
@@ -6642,7 +6329,7 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.CCmaskcurveL = CCmaskshapeL->getCurve();
         spot.LLmaskcurveL = LLmaskshapeL->getCurve();
         spot.HHmaskcurveL = HHmaskshapeL->getCurve();
-        spot.enaLMask = enaLMask->get_active();
+        spot.enaLMask = enaLMask->getLastActive();
         spot.blendmaskL = blendmaskL->getValue();
         spot.radmaskL = radmaskL->getValue();
         spot.chromaskL = chromaskL->getValue();
@@ -6678,31 +6365,6 @@ void LocallabLog::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
     // Note: No need to manage pedited as batch mode is deactivated for Locallab
 }
 
-void LocallabLog::enaLMaskChanged()
-{
-    if (enaLMask->get_active()) {
-        maskusablel->show();
-        maskunusablel->hide();
-
-    } else {
-        maskusablel->hide();
-        maskunusablel->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enaLMask->get_active()) {
-                listener->panelChanged(EvLocallabEnaLMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaLMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-
 
 void LocallabLog::updateGUIToMode(const modeType new_type)
 {
@@ -6711,7 +6373,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
         case Simple:
             // Expert and Normal mode widgets are hidden in Simple mode
             ciecam->hide();
-            ciecam->set_active(true);
+            ciecam->setValue(true);
             sourceabs->hide();
             targabs->hide();
             saturl->hide();
@@ -6738,7 +6400,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
         case Normal:
             // Expert mode widgets are hidden in Normal mode
             ciecam->hide();
-            ciecam->set_active(true);
+            ciecam->setValue(true);
 
             sourceabs->show();
             targabs->show();
@@ -6757,7 +6419,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
             expmaskL->show();
             gradlogFrame->show();
 
-            if (enaLMask->get_active()) {
+            if (enaLMask->getLastActive()) {
                 maskusablel->show();
                 maskunusablel->hide();
 
@@ -6774,7 +6436,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
         case Expert:
             // Show widgets hidden in Normal and Simple mode
             ciecam->hide();
-            ciecam->set_active(true);
+            ciecam->setValue(true);
             sourceabs->show();
             targabs->show();
             catad->show();
@@ -6792,7 +6454,7 @@ void LocallabLog::updateGUIToMode(const modeType new_type)
             gradlogFrame->show();
             surHBox->show();
 
-            if (enaLMask->get_active()) {
+            if (enaLMask->getLastActive()) {
                 maskusablel->show();
                 maskunusablel->hide();
 
@@ -6816,7 +6478,7 @@ void LocallabLog::convertParamToSimple()
 
     // Disable all listeners
     disableListener();
-    ciecam->set_active(false);
+    ciecam->setValue(false);
     contq->setValue(defSpot.contq);
     contthres->setValue(defSpot.contthres);
     colorfl->setValue(defSpot.colorfl);
@@ -6826,7 +6488,7 @@ void LocallabLog::convertParamToSimple()
     strlog->setValue(defSpot.strlog);
     anglog->setValue(defSpot.anglog);
     featherlog->setValue(defSpot.featherlog);
-    enaLMask->set_active(false);
+    enaLMask->setValue(false);
     showmaskLMethod->set_active(0);
     recothresl->setValue(defSpot.recothresl);
     lowthresl->setValue(defSpot.lowthresl);
@@ -6843,13 +6505,13 @@ void LocallabLog::convertParamToNormal()
 
     // Disable all listeners
     disableListener();
-    ciecam->set_active(true);
+    ciecam->setValue(true);
     contq->setValue(defSpot.contq);
     colorfl->setValue(defSpot.colorfl);
     lightl->setValue(defSpot.lightl);
     lightq->setValue(defSpot.lightq);
     sursour->set_active(0);
-//    enaLMask->set_active(true);
+//    enaLMask->setValue(true);
     decayl->setValue(defSpot.decayl);
     // Enable all listeners
     enableListener();
@@ -7282,78 +6944,6 @@ void LocallabLog::autocomputeToggled()
     }
 }
 
-void LocallabLog::ciecamChanged()
-{
-    /*
-    if(ciecam->get_active()){
-        sourceabs->set_sensitive(true);
-        targabs->set_sensitive(true);
-        catad->set_sensitive(true);
-        surrHBox->set_sensitive(true);
-
-        sourceabs->show();
-        targabs->show();
-        catad->show();
-        saturl->show();
-        lightl->show();
-        contl->show();
-        contq->show();
-        surrHBox->show();
-    } else {
-        sourceabs->hide();
-        targabs->hide();
-        saturl->hide();
-        contl->hide();
-        lightl->hide();
-        contq->hide();
-        catad->hide();
-        surrHBox->hide();
-    }
-    */
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (ciecam->get_active()) {
-                listener->panelChanged(Evlocallabciecam,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabciecam,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void LocallabLog::satlogChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (satlog->get_active()) {
-                listener->panelChanged(Evlocallabsatlog,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsatlog,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-
-void LocallabLog::fullimageChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fullimage->get_active()) {
-                listener->panelChanged(Evlocallabfullimage,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabfullimage,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
 void LocallabLog::updateMaskBackground(const double normChromar, const double normLumar, const double normHuer, const double normHuerjz)
 {
     idle_register.add(
@@ -7373,25 +6963,11 @@ void LocallabLog::updateMaskBackground(const double normChromar, const double no
 
 
 
-void LocallabLog::AutograyChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (Autogray->get_active()) {
-                listener->panelChanged(EvlocallabAutogray,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabAutogray,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabLog::updateLogGUI2()
 {
     /*
-    if(ciecam->get_active()){
+    if(ciecam->getLastActive()){
         sourceabs->show();
         targabs->show();
         catad->show();
@@ -7450,6 +7026,18 @@ void LocallabLog::updateLogGUI()
 
 }
 
+void LocallabLog::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+    if (c == enaLMask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaLMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
+}
 
 /* ==== LocallabMask ==== */
 LocallabMask::LocallabMask():
@@ -7462,7 +7050,7 @@ LocallabMask::LocallabMask():
     blendmaskab(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLENDMASKMASKAB"), -100., 100., 0.1, -10.))),
     softradiusmask(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOFTRADIUSCOL"), 0.0, 100.0, 0.5, 1.))),
     showmask_Method(Gtk::manage(new MyComboBoxText())),
-    enamask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
+    enamask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
 //    mask_CurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, M("TP_LOCALLAB_MASKCOL"))),
     mask_CurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmask_shape(static_cast<FlatCurveEditor*>(mask_CurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
@@ -7470,9 +7058,9 @@ LocallabMask::LocallabMask():
     HHmask_shape(static_cast<FlatCurveEditor *>(mask_CurveEditorG->addCurve(CT_Flat, "LC(h)", nullptr, false, true))),
     struFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABSTRUM")))),
     strumaskmask(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRUMASKCOL"), 0., 200., 0.1, 0.))),
-    toolmask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_TOOLCOL")))),
+    toolmask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_TOOLCOL"), multiImage))),
     blurFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABBLURM")))),
-    fftmask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTCOL_MASK")))),
+    fftmask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTCOL_MASK"), multiImage))),
     contmask(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTCOL"), 0., 200., 0.5, 0.))),
     blurmask(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLURCOL"), 0.2, 100., 0.5, 0.2))),
     toolmaskFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_TOOLMASK")))),
@@ -7527,7 +7115,7 @@ LocallabMask::LocallabMask():
     showmask_Method->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmask_MethodConn = showmask_Method->signal_changed().connect(sigc::mem_fun(*this, &LocallabMask::showmask_MethodChanged));
 
-    enamaskConn = enamask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabMask::enamaskChanged));
+    enamask->setCheckBoxListener(this);
 
     mask_CurveEditorG->setCurveListener(this);
 
@@ -7550,11 +7138,11 @@ LocallabMask::LocallabMask():
 
     strumaskmask->setAdjusterListener(this);
 
-    toolmaskConn  = toolmask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabMask::toolmaskChanged));
+    toolmask->setCheckBoxListener(this);
 
     blurFrame->set_label_align(0.025, 0.5);
 
-    fftmaskConn = fftmask->signal_toggled().connect(sigc::mem_fun(*this, &LocallabMask::fftmaskChanged));
+    fftmask->setCheckBoxListener(this);
 
     contmask->setAdjusterListener(this);
 
@@ -7705,7 +7293,7 @@ void LocallabMask::updateguimask(int spottype)
                 softradiusmask->hide();
                 showmask_Method->hide();
                 enamask->hide();
-                enamask->set_active(false);
+                enamask->setValue(false);
                 mask_CurveEditorG->hide();
                 struFrame->hide();
                 blurFrame->hide();
@@ -7822,9 +7410,6 @@ void LocallabMask::disableListener()
     LocallabTool::disableListener();
 
     showmask_MethodConn.block(true);
-    enamaskConn.block(true);
-    toolmaskConn.block(true);
-    fftmaskConn.block(true);
 }
 
 void LocallabMask::enableListener()
@@ -7832,9 +7417,6 @@ void LocallabMask::enableListener()
     LocallabTool::enableListener();
 
     showmask_MethodConn.block(false);
-    enamaskConn.block(false);
-    toolmaskConn.block(false);
-    fftmaskConn.block(false);
 }
 
 void LocallabMask::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -7856,13 +7438,13 @@ void LocallabMask::read(const rtengine::procparams::ProcParams* pp, const Params
         blendmask->setValue(spot.blendmask);
         blendmaskab->setValue(spot.blendmaskab);
         softradiusmask->setValue(spot.softradiusmask);
-        enamask->set_active(spot.enamask);
+        enamask->setValue(spot.enamask);
         CCmask_shape->setCurve(spot.CCmask_curve);
         LLmask_shape->setCurve(spot.LLmask_curve);
         HHmask_shape->setCurve(spot.HHmask_curve);
         strumaskmask->setValue(spot.strumaskmask);
-        toolmask->set_active(spot.toolmask);
-        fftmask->set_active(spot.fftmask);
+        toolmask->setValue(spot.toolmask);
+        fftmask->setValue(spot.fftmask);
         contmask->setValue(spot.contmask);
         // Update Common mask GUI according to fftmask button state
         // Note: Contrary to the others, shall be called before setting blurmask value
@@ -7907,13 +7489,13 @@ void LocallabMask::write(rtengine::procparams::ProcParams* pp, ParamsEdited* ped
         spot.blendmask = blendmask->getValue();
         spot.blendmaskab = blendmaskab->getValue();
         spot.softradiusmask = softradiusmask->getValue();
-        spot.enamask = enamask->get_active();
+        spot.enamask = enamask->getLastActive();
         spot.CCmask_curve = CCmask_shape->getCurve();
         spot.LLmask_curve = LLmask_shape->getCurve();
         spot.HHmask_curve = HHmask_shape->getCurve();
         spot.strumaskmask = strumaskmask->getValue();
-        spot.toolmask = toolmask->get_active();
-        spot.fftmask = fftmask->get_active();
+        spot.toolmask = toolmask->getLastActive();
+        spot.fftmask = fftmask->getLastActive();
         spot.contmask = contmask->getValue();
         spot.blurmask = blurmask->getValue();
         spot.radmask = radmask->getValue();
@@ -8202,8 +7784,8 @@ void LocallabMask::convertParamToNormal()
     // Set hidden GUI widgets in Normal mode to default spot values
     softradiusmask->setValue(defSpot.softradiusmask);
     strumaskmask->setValue(defSpot.strumaskmask);
-    toolmask->set_active(defSpot.toolmask);
-    fftmask->set_active(defSpot.fftmask);
+    toolmask->setValue(defSpot.toolmask);
+    fftmask->setValue(defSpot.fftmask);
     contmask->setValue(defSpot.contmask);
     blurmask->setValue(defSpot.blurmask);
     lapmask->setValue(defSpot.lapmask);
@@ -8330,59 +7912,14 @@ void LocallabMask::showmask_MethodChanged()
     }
 }
 
-void LocallabMask::enamaskChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enamask->get_active()) {
-                listener->panelChanged(EvLocallabEnaMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnaMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabMask::toolmaskChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (toolmask->get_active()) {
-                listener->panelChanged(EvLocallabtoolmask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabtoolmask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void LocallabMask::fftmaskChanged()
-{
-    // Update Common mask GUI according to fftmask button state
-    updateMaskGUI();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftmask->get_active()) {
-                listener->panelChanged(EvLocallabfftmask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabfftmask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void LocallabMask::updateMaskGUI()
 {
     const double temp = blurmask->getValue();
 
-    if (fftmask->get_active()) {
+    if (fftmask->getLastActive()) {
         blurmask->setLimits(0.2, 1000., 0.5, 0.2);
     } else {
         blurmask->setLimits(0.2, 100., 0.5, 0.2);
@@ -8390,7 +7927,18 @@ void LocallabMask::updateMaskGUI()
 
     blurmask->setValue(temp);
 }
-
+void LocallabMask::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
+    }
+    if (c == enamask) {
+        if (isLocActivated && exp->getEnabled()) {
+            listener->panelChanged(EvLocallabEnaMask,
+                                   c->getLastActive() ? M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")" : M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+        }
+    }
+}
 /*==== Locallabcie ====*/
 Locallabcie::Locallabcie():
     LocallabTool(this, M("TP_LOCALLAB_CIE_TOOLNAME"), M("TP_LOCALLAB_CIE"), false),
@@ -8398,7 +7946,7 @@ Locallabcie::Locallabcie():
     sensicie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SENSI"), 0, 100, 1, 60))),
     previewcie(Gtk::manage(new Gtk::ToggleButton(M("TP_LOCALLAB_PREVIEW")))),
     reparcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGREPART"), 1.0, 100.0, 1., 100.0))),
-    jabcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_JAB")))),
+    jabcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_JAB"), multiImage))),
     modecam(Gtk::manage(new MyComboBoxText())),
     modeQJ(Gtk::manage(new MyComboBoxText())),
     modecie(Gtk::manage(new MyComboBoxText())),
@@ -8408,7 +7956,7 @@ Locallabcie::Locallabcie():
     modeHBoxcie(Gtk::manage(new Gtk::Box())),
     cieFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGFRA")))),
     expcamscene(Gtk::manage(new MyExpander(false, Gtk::manage(new Gtk::Box())))),
-    Autograycie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_AUTOGRAYCIE")))),
+    Autograycie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_AUTOGRAYCIE"), multiImage))),
     sourceGraycie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_GRAY"), 1.0, 100.0, 0.1, 18.0))),
     sourceabscie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SOURCE_ABS"), 0.01, 16384.0, 0.01, 2000.0))),
     sursourcie(Gtk::manage(new MyComboBoxText())),
@@ -8420,7 +7968,7 @@ Locallabcie::Locallabcie():
     czlightFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_CIELIGHTCONTFRA")))),
     czcolorFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_CIECOLORFRA")))),
     PQFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_JZPQFRA")))),
-    qtoj(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_JZQTOJ")))),
+    qtoj(Gtk::manage(new CheckBox(M("TP_LOCALLAB_JZQTOJ"), multiImage))),
     lightlcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGLIGHTL"), -100., 100., 0.01, 0.))),
     lightjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZLIGHT"), -100., 100., 0.01, 0.))),
     contjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZCONT"), -100., 100., 0.5, 0.))),
@@ -8455,30 +8003,30 @@ Locallabcie::Locallabcie():
     contsigqcie(Gtk::manage(new Adjuster(M(""), -100., 100., 0.5, 0.))),
     contthrescie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_LOGCONTHRES"), -1., 1., 0.01, 0.))),
     logjzFrame(Gtk::manage(new Gtk::Frame())),
-    logjz(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_JZLOG")))),
+    logjz(Gtk::manage(new CheckBox(M("TP_LOCALLAB_JZLOG"), multiImage))),
     blackEvjz(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLACK_EV"), -16.00, 0.00, 0.01, -5.00))),
     whiteEvjz(Gtk::manage(new Adjuster(M("TP_LOCALLAB_WHITE_EV"), 0.00, 32.000, 0.01, 10.00))),
     targetjz(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZTARGET_EV"), 4., 80.0, 0.1, 18.0))),
     bevwevFrame(Gtk::manage(new Gtk::Frame())),
-    sigybjz12(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGMOIDNORMCIE")))),
+    sigybjz12(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGMOIDNORMCIE"), multiImage))),
     sigBox12(Gtk::manage(new ToolParamBlock())),
     sigmoidFrame12(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SIGFRA")))),
-    sigq12(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGFRA")))),
+    sigq12(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGFRA"), multiImage))),
     slopesmoq(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SLOPESMOOTH"), 0.6, 2.0, 0.01, 1.))),
     sigmoidldacie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDLAMBDA"), 0.5, 3.5, 0.01, 1.8))),
     sigmoidthcie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDTH"), -1., 1., 0.01, 0., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     sigmoidblcie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDBL"), 50., 1000., 0.5, 100.))),
     autocomprHBox(Gtk::manage(new Gtk::Box())),
     comprcieauto(Gtk::manage(new Gtk::ToggleButton(M("TP_LOCALLAB_SIGMOIDLOGAUTO")))),
-    normcie12(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGMOIDNORMCIE")))),
-    normcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGMOIDNORMCIE11")))),
+    normcie12(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGMOIDNORMCIE"), multiImage))),
+    normcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGMOIDNORMCIE11"), multiImage))),
     modeHBoxbwev12(Gtk::manage(new Gtk::Box())),
     bwevMethod12(Gtk::manage(new MyComboBoxText())),
     modeHBoxbwev(Gtk::manage(new Gtk::Box())),
     bwevMethod(Gtk::manage(new MyComboBoxText())),
     sigBox(Gtk::manage(new ToolParamBlock())),
     sigmoidFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SIGFRA")))),
-    sigq(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGFRA11")))),
+    sigq(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGFRA11"), multiImage))),
     sigmoidnormFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SIGNORM")))),
     sigmoidldacie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDLAMBDA"), 0.0, 1., 0.01, 0.5))),
     sigmoidthcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDTH11"), 0.1, 4., 0.01, 1.2, Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
@@ -8486,12 +8034,12 @@ Locallabcie::Locallabcie():
     sigmoidblcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDBL11"), 0.05, 1., 0.01, 0.75))),
    
     logcieFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LOGCIE")))),
-    logcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LOGCIE")))),
+    logcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_LOGCIE"), multiImage))),
     comprBox(Gtk::manage(new ToolParamBlock())),
     comprcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_COMPRCIE"), 0., 1., 0.01, 0.4))),
     strcielog(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRENGTHCIELOG"), 0., 100., 0.5, 80.))),
-    satcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SATCIE")))),
-    logcieq(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_LOGCIEQ")))),
+    satcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SATCIE"), multiImage))),
+    logcieq(Gtk::manage(new CheckBox(M("TP_LOCALLAB_LOGCIEQ"), multiImage))),
     comprcieth(Gtk::manage(new Adjuster(M("TP_LOCALLAB_COMPRCIETH"), 0., 25., 0.01, 6.))),
 
     expprecam(Gtk::manage(new MyExpander(true, Gtk::manage(new Gtk::Box())))),
@@ -8504,14 +8052,14 @@ Locallabcie::Locallabcie():
     midtciemet(Gtk::manage(new MyComboBoxText())),
     
     midtcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MIDTCIE"), -100, 100, 1, 0))),
-    smoothcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_SCA")))),
-    smoothcielnk(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_LNK")))),
-    smoothcieinv(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_INV")))),
-    smoothcietrc(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_TRC")))),
-    smoothcietrcrel(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_TRCREL")))),
-    smoothcieyb(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_YB")))),
-    smoothcielum(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_LUM")))),
-    smoothciehigh(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SMOOTHCIE_HIGH")))),
+    smoothcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_SCA"), multiImage))),
+    smoothcielnk(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_LNK"), multiImage))),
+    smoothcieinv(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_INV"), multiImage))),
+    smoothcietrc(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_TRC"), multiImage))),
+    smoothcietrcrel(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_TRCREL"), multiImage))),
+    smoothcieyb(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_YB"), multiImage))),
+    smoothcielum(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_LUM"), multiImage))),
+    smoothciehigh(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SMOOTHCIE_HIGH"), multiImage))),
     smoothcieth(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SMOOTHCIETH"), 0.5, 1.5, 0.01, 1.0))),
     ciesmoothBox(Gtk::manage(new ToolParamBlock())),
     smoothBox(Gtk::manage(new Gtk::Box())),
@@ -8553,23 +8101,23 @@ Locallabcie::Locallabcie():
     catBox(Gtk::manage(new Gtk::Box())),
     catMethod(Gtk::manage(new MyComboBoxText())),
     gamutcieBox(Gtk::manage(new Gtk::Box())),
-    gamutcie(Gtk::manage(new Gtk::CheckButton(M("TP_ICM_GAMUT")))),
+    gamutcie(Gtk::manage(new CheckBox(M("TP_ICM_GAMUT"), multiImage))),
     shiftxl(Gtk::manage(new Adjuster(M("TC_LOCALLAB_PRIM_SHIFTX"), -0.20, 0.20, 0.0001, 0.))),
     shiftyl(Gtk::manage(new Adjuster(M("TC_LOCALLAB_PRIM_SHIFTY"), -0.20, 0.20, 0.0001, 0.))),
     bwcieBox(Gtk::manage(new Gtk::Box())),
-    bwcie(Gtk::manage(new Gtk::CheckButton(M("TP_ICM_BW")))),
+    bwcie(Gtk::manage(new CheckBox(M("TP_ICM_BW"), multiImage))),
 
     sigmoidjzFrame12(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SIGJZFRA")))),
     sigmoidjzFrame(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_SIGJZFRA")))),
     sigmoid2Frame12(Gtk::manage(new Gtk::Frame(M("")))),
     sigmoid2Frame(Gtk::manage(new Gtk::Frame(M("")))),
-    sigcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGCIE")))),
-    sigjz12(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGJZFRA")))),
+    sigcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGCIE"), multiImage))),
+    sigjz12(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGJZFRA"), multiImage))),
     sigmoidldajzcie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDLAMBDA"), 0.5, 3.5, 0.01, 1.3))),
     sigmoidthjzcie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDTH"), -1., 1., 0.01, 0., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     sigmoidbljzcie12(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDBL"), 50., 1000., 0.5, 100.))),
-    sigjz(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_SIGJZFRA11")))),
-    forcebw(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_BWFORCE")))),
+    sigjz(Gtk::manage(new CheckBox(M("TP_LOCALLAB_SIGJZFRA11"), multiImage))),
+    forcebw(Gtk::manage(new CheckBox(M("TP_LOCALLAB_BWFORCE"), multiImage))),
     sigmoidldajzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDLAMBDA"), 0., 1.0, 0.01, 0.5))),
     sigmoidthjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDTH11"), 0.1, 4., 0.01, 1., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     sigmoidbljzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_SIGMOIDBL11"), 0.5, 1.5, 0.01, 1.))),
@@ -8602,7 +8150,7 @@ Locallabcie::Locallabcie():
     LHshapejz(static_cast<FlatCurveEditor*>(jz2CurveEditorG->addCurve(CT_Flat, "Jz(Hz)", nullptr, false, true))),
     softjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZSOFTCIE"), 0., 100., 0.1, 0.))),
     thrhjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZTHRHCIE"), 40., 150., 0.5, 60.))),
-    chjzcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_JZCH")))),
+    chjzcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_JZCH"), multiImage))),
     strsoftjzcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_JZSTRSOFTCIE"), 0, 100., 0.5, 100.))),
 
     expLcie(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_CIETOOLEXP")))),
@@ -8628,17 +8176,17 @@ Locallabcie::Locallabcie():
     decaycie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_MASKDDECAY"), 0.5, 4., 0.1, 2.))),
     expmaskcie(Gtk::manage(new MyExpander(false, M("TP_LOCALLAB_SHOWS")))),
     showmaskcieMethod(Gtk::manage(new MyComboBoxText())),
-    enacieMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASK")))),
-    enacieMaskall(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_ENABLE_MASKALL")))),
+    enacieMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASK"), multiImage))),
+    enacieMaskall(Gtk::manage(new CheckBox(M("TP_LOCALLAB_ENABLE_MASKALL"), multiImage))),
     maskcieCurveEditorG(new CurveEditorGroup(App::get().mut_options().lastlocalCurvesDir, "", 1)),
     CCmaskcieshape(static_cast<FlatCurveEditor*>(maskcieCurveEditorG->addCurve(CT_Flat, "C", nullptr, false, false))),
     LLmaskcieshape(static_cast<FlatCurveEditor*>(maskcieCurveEditorG->addCurve(CT_Flat, "L", nullptr, false, false))),
     HHmaskcieshape(static_cast<FlatCurveEditor*>(maskcieCurveEditorG->addCurve(CT_Flat, "LC(h)", nullptr, false, true))),
     struFramecie(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABSTRUM")))),
     strumaskcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_STRUMASKCOL"), 0., 200., 0.1, 0.))),
-    toolcie(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_TOOLCOL")))),
+    toolcie(Gtk::manage(new CheckBox(M("TP_LOCALLAB_TOOLCOL"), multiImage))),
     blurFramecie(Gtk::manage(new Gtk::Frame(M("TP_LOCALLAB_LABBLURM")))),
-    fftcieMask(Gtk::manage(new Gtk::CheckButton(M("TP_LOCALLAB_FFTCOL_MASK")))),
+    fftcieMask(Gtk::manage(new CheckBox(M("TP_LOCALLAB_FFTCOL_MASK"), multiImage))),
     contcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_CONTCOL"), 0., 200., 0.5, 0.))),
     blurcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLURCOL"), 0.2, 100., 0.5, 0.2))),
     blendmaskcie(Gtk::manage(new Adjuster(M("TP_LOCALLAB_BLENDMASKCOL"), -100, 100, 1, 0))),
@@ -8961,12 +8509,12 @@ Locallabcie::Locallabcie():
     catMethodconn = catMethod->signal_changed().connect(sigc::mem_fun(*this, &Locallabcie::catMethodChanged));
     gamutcieBox->pack_start(*gamutcie, Gtk::PACK_EXPAND_WIDGET);
 
-    gamutcieconn = gamutcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::gamutcieChanged));
+    gamutcie->setCheckBoxListener(this);
 
 
     bwcieBox->pack_start(*bwcie, Gtk::PACK_EXPAND_WIDGET);
 
-    bwcieconn = bwcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::bwcieChanged));
+    bwcie->setCheckBoxListener(this);
 
     modeHBoxbwev12->set_spacing(2);
     ToolParamBlock* const gamcieBox = Gtk::manage(new ToolParamBlock());
@@ -9311,34 +8859,33 @@ Locallabcie::Locallabcie():
 
     expjz->add(*jzallBox, false);
 
-    jabcieConn = jabcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::jabcieChanged));
-    AutograycieConn = Autograycie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::AutograycieChanged));
-    comprcieautoconn = comprcieauto->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::comprcieautoChanged));
-    normcie12conn = normcie12->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::normcie12Changed));
-    normcieconn = normcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::normcieChanged));
+    jabcie->setCheckBoxListener(this);
+    Autograycie->setCheckBoxListener(this);
+    normcie12->setCheckBoxListener(this);
+    normcie->setCheckBoxListener(this);
     expprecamconn = expprecam->signal_enabled_toggled().connect(sigc::mem_fun(*this, &Locallabcie::expprecamChanged));
 
-    sigcieconn = sigcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigcieChanged));
-    logcieconn = logcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::logcieChanged));
-    satcieconn = satcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::satcieChanged));
-    logcieqconn = logcieq->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::logcieqChanged));
-    smoothcieconn = smoothcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcieChanged));
-    smoothcielnkconn = smoothcielnk->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcielnkChanged));
-    smoothcieinvconn = smoothcieinv->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcieinvChanged));
-    smoothcietrcconn = smoothcietrc->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcietrcChanged));
-    smoothcietrcrelconn = smoothcietrcrel->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcietrcrelChanged));
-    smoothcieybconn = smoothcieyb->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcieybChanged));
-    smoothcielumconn = smoothcielum->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothcielumChanged));
-    smoothciehighconn = smoothciehigh->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::smoothciehighChanged));
-    logjzconn = logjz->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::logjzChanged));
-    sigjz12conn = sigjz12->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigjz12Changed));
-    sigjzconn = sigjz->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigjzChanged));
-    forcebwconn = forcebw->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::forcebwChanged));
-    sigq12conn = sigq12->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigq12Changed));
-    sigqconn = sigq->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigqChanged));
-    qtojConn = qtoj->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::qtojChanged));
-    chjzcieconn = chjzcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::chjzcieChanged));
-    sigybjz12Conn = sigybjz12->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::sigybjz12Changed));
+    sigcie->setCheckBoxListener(this);
+    logcie->setCheckBoxListener(this);
+    satcie->setCheckBoxListener(this);
+    logcieq->setCheckBoxListener(this);
+    smoothcie->setCheckBoxListener(this);
+    smoothcielnk->setCheckBoxListener(this);
+    smoothcieinv->setCheckBoxListener(this);
+    smoothcietrc->setCheckBoxListener(this);
+    smoothcietrcrel->setCheckBoxListener(this);
+    smoothcieyb->setCheckBoxListener(this);
+    smoothcielum->setCheckBoxListener(this);
+    smoothciehigh->setCheckBoxListener(this);
+    logjz->setCheckBoxListener(this);
+    sigjz12->setCheckBoxListener(this);
+    sigjz->setCheckBoxListener(this);
+    forcebw->setCheckBoxListener(this);
+    sigq12->setCheckBoxListener(this);
+    sigq->setCheckBoxListener(this);
+    qtoj->setCheckBoxListener(this);
+    chjzcie->setCheckBoxListener(this);
+    sigybjz12->setCheckBoxListener(this);
 
     sourceGraycie->setAdjusterListener(this);
     sourceGraycie->setLogScale(10, 18, true);
@@ -9599,8 +9146,8 @@ Locallabcie::Locallabcie():
     showmaskcieMethod->set_tooltip_markup(M("TP_LOCALLAB_SHOWMASKCOL_TOOLTIP"));
     showmaskcieMethodConn = showmaskcieMethod->signal_changed().connect(sigc::mem_fun(*this, &Locallabcie::showmaskcieMethodChanged));
 
-    enacieMaskConn = enacieMask->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::enacieMaskChanged));
-    enacieMaskallConn = enacieMaskall->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::enacieMaskallChanged));
+    enacieMask->setCheckBoxListener(this);
+    enacieMaskall->setCheckBoxListener(this);
 
     maskcieCurveEditorG->setCurveListener(this);
     CCmaskcieshape->setIdentityValue(0.);
@@ -9622,11 +9169,11 @@ Locallabcie::Locallabcie():
 
     strumaskcie->setAdjusterListener(this);
 
-    toolcieConn  = toolcie->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::toolcieChanged));
+    toolcie->setCheckBoxListener(this);
 
     blurFramecie->set_label_align(0.025, 0.5);
 
-    fftcieMaskConn = fftcieMask->signal_toggled().connect(sigc::mem_fun(*this, &Locallabcie::fftcieMaskChanged));
+    fftcieMask->setCheckBoxListener(this);
 
     contcie->setAdjusterListener(this);
 
@@ -9795,8 +9342,8 @@ void Locallabcie::updateguicie(int spottype)
                 previewcie->hide();
                 exprecovcie->hide();
                 expmaskcie->hide();
-                enacieMask->set_active(false);
-                enacieMaskall->set_active(false);
+                enacieMask->setValue(false);
+                enacieMaskall->setValue(false);
                 previewcie->set_active(false);
             } else {
                 sensicie->show();
@@ -10025,39 +9572,11 @@ void Locallabcie::updateAdviceTooltips(const bool showTooltips)
 void Locallabcie::disableListener()
 {
     LocallabTool::disableListener();
-    AutograycieConn.block(true);
-    sigybjz12Conn.block(true);
-    qtojConn.block(true);
-    jabcieConn.block(true);
-    comprcieautoconn.block(true);
-    normcie12conn.block(true);
-    normcieconn.block(true);
     expprecamconn.block(true);
-    gamutcieconn.block(true);
-    bwcieconn.block(true);
     primMethodconn.block(true);
     illMethodconn.block(true);
     smoothciemetconn.block(true);
     catMethodconn.block(true);
-    sigcieconn.block(true);
-    logcieconn.block(true);
-    satcieconn.block(true);
-    logcieqconn.block(true);
-    smoothcieconn.block(true);
-    smoothcielnkconn.block(true);
-    smoothcieinvconn.block(true);
-    smoothcietrcconn.block(true);
-    smoothcietrcrelconn.block(true);
-    smoothcieybconn.block(true);
-    smoothcielumconn.block(true);
-    smoothciehighconn.block(true);
-    logjzconn.block(true);
-    sigjz12conn.block(true);
-    sigjzconn.block(true);
-    forcebwconn.block(true);
-    sigq12conn.block(true);
-    sigqconn.block(true);
-    chjzcieconn.block(true);
     sursourcieconn.block(true);
     surroundcieconn.block(true);
     modecieconn.block(true);
@@ -10069,48 +9588,19 @@ void Locallabcie::disableListener()
     toneMethodcieConn.block(true);
     toneMethodcieConn2.block(true);
     showmaskcieMethodConn.block(true);
-    toolcieConn.block(true);
-    enacieMaskConn.block(true);
-    enacieMaskallConn.block(true);
-    fftcieMaskConn.block(true);
+    comprcieautoconn.block(true);
+    previewcieConn.block(true);
+    sigmoidqjcieconn.block(true);
 }
 
 void Locallabcie::enableListener()
 {
     LocallabTool::enableListener();
-    AutograycieConn.block(false);
-    sigybjz12Conn.block(false);
-    qtojConn.block(false);
-    jabcieConn.block(false);
-    comprcieautoconn.block(false);
-    normcie12conn.block(false);
-    normcieconn.block(false);
     expprecamconn.block(false);
-    gamutcieconn.block(false);
-    bwcieconn.block(false);
     primMethodconn.block(false);
     illMethodconn.block(false);
     smoothciemetconn.block(false);
     catMethodconn.block(false);
-    sigcieconn.block(false);
-    logcieconn.block(false);
-    satcieconn.block(false);
-    logcieqconn.block(false);
-    smoothcieconn.block(false);
-    smoothcielnkconn.block(false);
-    smoothcieinvconn.block(false);
-    smoothcietrcconn.block(false);
-    smoothcietrcrelconn.block(false);
-    smoothcieybconn.block(false);
-    smoothcielumconn.block(false);
-    smoothciehighconn.block(false);
-    logjzconn.block(false);
-    sigjz12conn.block(false);
-    sigjzconn.block(false);
-    forcebwconn.block(false);
-    sigq12conn.block(false);
-    sigqconn.block(false);
-    chjzcieconn.block(false);
     sursourcieconn.block(false);
     surroundcieconn.block(false);
     modecieconn.block(false);
@@ -10122,10 +9612,9 @@ void Locallabcie::enableListener()
     toneMethodcieConn.block(false);
     toneMethodcieConn2.block(false);
     showmaskcieMethodConn.block(false);
-    toolcieConn.block(false);
-    enacieMaskConn.block(false);
-    enacieMaskallConn.block(false);
-    fftcieMaskConn.block(false);
+    comprcieautoconn.block(false);
+    previewcieConn.block(false);
+    sigmoidqjcieconn.block(false);
 }
 
 void Locallabcie::showmaskcieMethodChanged()
@@ -10146,36 +9635,13 @@ void Locallabcie::showmaskcieMethodChanged()
 
 
 
-void Locallabcie::enacieMaskChanged()
-{
-    if (enacieMask->get_active()) {
-        maskusablecie->show();
-        maskunusablecie->hide();
-
-    } else {
-        maskusablecie->hide();
-        maskunusablecie->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enacieMask->get_active()) {
-                listener->panelChanged(EvLocallabEnacieMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabEnacieMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
 void Locallabcie::enacieMaskallChanged2()
 {
     const LocallabParams::LocallabSpot defSpot;
 
-        if(!enacieMaskall->get_active()) {
+        if(!enacieMaskall->getLastActive()) {
             lapmaskcie->setValue(defSpot.lapmaskcie);
             gammaskcie->setValue(defSpot.gammaskcie);
             slomaskcie->setValue(defSpot.slomaskcie);
@@ -10183,8 +9649,8 @@ void Locallabcie::enacieMaskallChanged2()
             shadmaskcie->setValue(defSpot.shadmaskcie);
             HHhmaskcieshape->setCurve(defSpot.HHhmaskciecurve);
             strumaskcie->setValue(defSpot.strumaskcie);
-            toolcie->set_active(defSpot.toolcie);
-            fftcieMask->set_active(defSpot.fftcieMask);
+            toolcie->setValue(defSpot.toolcie);
+            fftcieMask->setValue(defSpot.fftcieMask);
             LLmaskcieshapewav->setCurve(defSpot.LLmaskciecurvewav);
             lapmaskcie->hide();
             gammaskcie->hide();
@@ -10219,57 +9685,11 @@ void Locallabcie::enacieMaskallChanged2()
         }
 }
 
-void Locallabcie::enacieMaskallChanged()
-{
-    
-    enacieMaskallChanged2();
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (enacieMaskall->get_active()) {
-                listener->panelChanged(EvlocallabenacieMaskall,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabenacieMaskall,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
 
-void Locallabcie::toolcieChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (toolcie->get_active()) {
-                listener->panelChanged(EvLocallabtoolcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabtoolcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::fftcieMaskChanged()
-{
-    // updateColorGUI3(); // Update GUI according to fftColorMash button state
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (fftcieMask->get_active()) {
-                listener->panelChanged(EvLocallabfftcieMask,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvLocallabfftcieMask,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
 void Locallabcie::read(const rtengine::procparams::ProcParams* pp, const ParamsEdited* pedited)
@@ -10329,13 +9749,13 @@ void Locallabcie::read(const rtengine::procparams::ProcParams* pp, const ParamsE
             toneMethodcie2->set_active(2);
         }
 
-        Autograycie->set_active(spot.Autograycie);
-        sigybjz12->set_active(spot.sigybjz12);
-        qtoj->set_active(spot.qtoj);
+        Autograycie->setValue(spot.Autograycie);
+        sigybjz12->setValue(spot.sigybjz12);
+        qtoj->setValue(spot.qtoj);
         sourceGraycie->setValue(spot.sourceGraycie);
         comprcieauto->set_active(spot.comprcieauto);
 
-        if (Autograycie->get_active()) {
+        if (Autograycie->getLastActive()) {
             comprcieauto->set_active(true);
         }
 
@@ -10437,58 +9857,39 @@ void Locallabcie::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         }
 
 
-        normcie12->set_active(spot.normcie12);
-        normcie->set_active(spot.normcie);
-        gamutcie->set_active(spot.gamutcie);
-        bwcie->set_active(spot.bwcie);
-        sigcie->set_active(spot.sigcie);
-        logcie->set_active(spot.logcie);
-        satcie->set_active(spot.satcie);
-        logcieq->set_active(spot.logcieq);
-        smoothcie->set_active(spot.smoothcie);
-        smoothcielnk->set_active(spot.smoothcielnk);
-        smoothcieinv->set_active(spot.smoothcieinv);
-        smoothcietrc->set_active(spot.smoothcietrc);
-        smoothcietrcrel->set_active(spot.smoothcietrcrel);
-        smoothcieyb->set_active(spot.smoothcieyb);
-        smoothcielum->set_active(spot.smoothcielum);
-        smoothciehigh->set_active(spot.smoothciehigh);
-        logjz->set_active(spot.logjz);
-        sigjz12->set_active(spot.sigjz12);
-        sigjz->set_active(spot.sigjz);
-        forcebw->set_active(spot.forcebw);
-        sigq12->set_active(spot.sigq12);
-        sigq->set_active(spot.sigq);
-        chjzcie->set_active(true);//force to true to avoid other mode
+        normcie12->setValue(spot.normcie12);
+        normcie->setValue(spot.normcie);
+        gamutcie->setValue(spot.gamutcie);
+        bwcie->setValue(spot.bwcie);
+        sigcie->setValue(spot.sigcie);
+        logcie->setValue(spot.logcie);
+        satcie->setValue(spot.satcie);
+        logcieq->setValue(spot.logcieq);
+        smoothcie->setValue(spot.smoothcie);
+        smoothcielnk->setValue(spot.smoothcielnk);
+        smoothcieinv->setValue(spot.smoothcieinv);
+        smoothcietrc->setValue(spot.smoothcietrc);
+        smoothcietrcrel->setValue(spot.smoothcietrcrel);
+        smoothcieyb->setValue(spot.smoothcieyb);
+        smoothcielum->setValue(spot.smoothcielum);
+        smoothciehigh->setValue(spot.smoothciehigh);
+        logjz->setValue(spot.logjz);
+        sigjz12->setValue(spot.sigjz12);
+        sigjz->setValue(spot.sigjz);
+        forcebw->setValue(spot.forcebw);
+        sigq12->setValue(spot.sigq12);
+        sigq->setValue(spot.sigq);
+        chjzcie->setValue(true);//force to true to avoid other mode
         sourceabscie->setValue(spot.sourceabscie);
-        jabcie->set_active(spot.jabcie);
-        jabcieChanged();
+        jabcie->setValue(spot.jabcie);
         modecamChanged();
         modeQJChanged();
         sursourcieChanged();
         bwevMethod12Changed();
         bwevMethodChanged();
         midtciemetChanged();
-        normcie12Changed();
-        normcieChanged();
         expprecamChanged();
-        gamutcieChanged();
-        bwcieChanged();
-        sigcieChanged();
         comprcieautoChanged();
-        sigq12Changed();
-        sigqChanged();
-        logcieChanged();
-        satcieChanged();
-        logcieqChanged();
-        smoothcieChanged();
-        smoothcielnkChanged();
-        smoothcieinvChanged();
-        smoothcietrcChanged();
-        smoothcietrcrelChanged();
-        smoothcieybChanged();
-        smoothcielumChanged();
-        smoothciehighChanged();
         primMethodChanged();
         illMethodChanged();
         smoothciemetChanged();
@@ -10653,8 +10054,8 @@ void Locallabcie::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         anggradcie->setValue((double)spot.anggradcie);
         feathercie->setValue((double)spot.feathercie);
 
-        enacieMask->set_active(spot.enacieMask);
-        enacieMaskall->set_active(spot.enacieMaskall);
+        enacieMask->setValue(spot.enacieMask);
+        enacieMaskall->setValue(spot.enacieMaskall);
         CCmaskcieshape->setCurve(spot.CCmaskciecurve);
         LLmaskcieshape->setCurve(spot.LLmaskciecurve);
         HHmaskcieshape->setCurve(spot.HHmaskciecurve);
@@ -10673,8 +10074,8 @@ void Locallabcie::read(const rtengine::procparams::ProcParams* pp, const ParamsE
         higthrescie->setValue((double)spot.higthrescie);
         decaycie->setValue((double)spot.decaycie);
         strumaskcie->setValue(spot.strumaskcie);
-        toolcie->set_active(spot.toolcie);
-        fftcieMask->set_active(spot.fftcieMask);
+        toolcie->setValue(spot.toolcie);
+        fftcieMask->setValue(spot.fftcieMask);
         contcie->setValue(spot.contcie);
         blurcie->setValue(spot.blurcie);
         LLmaskcieshapewav->setCurve(spot.LLmaskciecurvewav);
@@ -10765,36 +10166,36 @@ void Locallabcie::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
                               spot.labgridcieMy
                               );
 
-        spot.Autograycie = Autograycie->get_active();
-        spot.sigybjz12 = sigybjz12->get_active();
-        spot.qtoj = qtoj->get_active();
-        spot.jabcie = jabcie->get_active();
+        spot.Autograycie = Autograycie->getLastActive();
+        spot.sigybjz12 = sigybjz12->getLastActive();
+        spot.qtoj = qtoj->getLastActive();
+        spot.jabcie = jabcie->getLastActive();
         spot.sourceGraycie = sourceGraycie->getValue();
         spot.sourceabscie = sourceabscie->getValue();
         spot.comprcieauto = comprcieauto->get_active();
-        spot.normcie12 = normcie12->get_active();
-        spot.normcie = normcie->get_active();
-        spot.gamutcie = gamutcie->get_active();
-        spot.bwcie = bwcie->get_active();
-        spot.sigcie = sigcie->get_active();
-        spot.logcie = logcie->get_active();
-        spot.satcie = satcie->get_active();
-        spot.logcieq = logcieq->get_active();
-        spot.smoothcie = smoothcie->get_active();
-        spot.smoothcielnk = smoothcielnk->get_active();
-        spot.smoothcieinv = smoothcieinv->get_active();
-        spot.smoothcietrc = smoothcietrc->get_active();
-        spot.smoothcietrcrel = smoothcietrcrel->get_active();
-        spot.smoothcieyb = smoothcieyb->get_active();
-        spot.smoothcielum = smoothcielum->get_active();
-        spot.smoothciehigh = smoothciehigh->get_active();
-        spot.logjz = logjz->get_active();
-        spot.sigjz = sigjz->get_active();
-        spot.forcebw = forcebw->get_active();
-        spot.sigjz12 = sigjz12->get_active();
-        spot.chjzcie = chjzcie->get_active();
-        spot.sigq12 = sigq12->get_active();
-        spot.sigq = sigq->get_active();
+        spot.normcie12 = normcie12->getLastActive();
+        spot.normcie = normcie->getLastActive();
+        spot.gamutcie = gamutcie->getLastActive();
+        spot.bwcie = bwcie->getLastActive();
+        spot.sigcie = sigcie->getLastActive();
+        spot.logcie = logcie->getLastActive();
+        spot.satcie = satcie->getLastActive();
+        spot.logcieq = logcieq->getLastActive();
+        spot.smoothcie = smoothcie->getLastActive();
+        spot.smoothcielnk = smoothcielnk->getLastActive();
+        spot.smoothcieinv = smoothcieinv->getLastActive();
+        spot.smoothcietrc = smoothcietrc->getLastActive();
+        spot.smoothcietrcrel = smoothcietrcrel->getLastActive();
+        spot.smoothcieyb = smoothcieyb->getLastActive();
+        spot.smoothcielum = smoothcielum->getLastActive();
+        spot.smoothciehigh = smoothciehigh->getLastActive();
+        spot.logjz = logjz->getLastActive();
+        spot.sigjz = sigjz->getLastActive();
+        spot.forcebw = forcebw->getLastActive();
+        spot.sigjz12 = sigjz12->getLastActive();
+        spot.chjzcie = chjzcie->getLastActive();
+        spot.sigq12 = sigq12->getLastActive();
+        spot.sigq = sigq->getLastActive();
 
         if (sursourcie->get_active_row_number() == 0) {
             spot.sursourcie = "Average";
@@ -11011,8 +10412,8 @@ void Locallabcie::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.anggradcie = anggradcie->getValue();
         spot.feathercie = feathercie->getValue();
 
-        spot.enacieMask = enacieMask->get_active();
-        spot.enacieMaskall = enacieMaskall->get_active();
+        spot.enacieMask = enacieMask->getLastActive();
+        spot.enacieMaskall = enacieMaskall->getLastActive();
         spot.LLmaskciecurve = LLmaskcieshape->getCurve();
         spot.CCmaskciecurve = CCmaskcieshape->getCurve();
         spot.HHmaskciecurve = HHmaskcieshape->getCurve();
@@ -11031,8 +10432,8 @@ void Locallabcie::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedi
         spot.higthrescie = higthrescie->getValue();
         spot.decaycie = decaycie->getValue();
         spot.strumaskcie = strumaskcie->getValue();
-        spot.toolcie = toolcie->get_active();
-        spot.fftcieMask = fftcieMask->get_active();
+        spot.toolcie = toolcie->getLastActive();
+        spot.fftcieMask = fftcieMask->getLastActive();
         spot.contcie = contcie->getValue();
         spot.blurcie = blurcie->getValue();
         spot.LLmaskciecurvewav = LLmaskcieshapewav->getCurve();
@@ -11186,7 +10587,7 @@ void Locallabcie::updateiPrimloc(const float r_x, const float r_y, const float g
 void Locallabcie::updateAutocompute(const float blackev, const float whiteev, const float sourceg, const float sourceab, const float targetg, const float jz1)
 {
 
-    if (Autograycie->get_active()) {
+    if (Autograycie->getLastActive()) {
         idle_register.add(
         [this, blackev, whiteev, sourceg, sourceab, jz1]() -> bool {
             GThreadLock lock; // All GUI access from idle_add callbacks or separate thread HAVE to be protected
@@ -11210,92 +10611,10 @@ void Locallabcie::updateAutocompute(const float blackev, const float whiteev, co
     }
 }
 
-void Locallabcie::AutograycieChanged()
-{
-
-    if (Autograycie->get_active()) {
-        sourceGraycie->set_sensitive(false);
-        sourceabscie->set_sensitive(false);
-        adapjzcie->set_sensitive(false);
-        jz100->set_sensitive(false);
-        blackEvjz->set_sensitive(false);
-        whiteEvjz->set_sensitive(false);
-
-        comprcieauto->set_active(true);
-        whitescie->set_sensitive(true);
-        blackscie->set_sensitive(true);
-
-    } else {
-        sourceGraycie->set_sensitive(true);
-        sourceabscie->set_sensitive(true);
-        adapjzcie->set_sensitive(true);
-        jz100->set_sensitive(true);
-        blackEvjz->set_sensitive(true);
-        whiteEvjz->set_sensitive(true);
-        whitescie->set_sensitive(false);
-        blackscie->set_sensitive(false);
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (Autograycie->get_active()) {
-                listener->panelChanged(EvlocallabAutograycie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(EvlocallabAutograycie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::sigybjz12Changed()
-{
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigybjz12->get_active()) {
-                listener->panelChanged(Evlocallabsigybjz12,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigybjz12,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
-void Locallabcie::qtojChanged()
-{
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (qtoj->get_active()) {
-                listener->panelChanged(Evlocallabqtoj,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabqtoj,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::jabcieChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (jabcie->get_active()) {
-                listener->panelChanged(Evlocallabjabcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabjabcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 void Locallabcie::comprcieautoChanged()
 {
@@ -11313,80 +10632,9 @@ void Locallabcie::comprcieautoChanged()
     }
 }
 
-void Locallabcie::normcie12Changed()
-{
 
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (normcie12->get_active()) {
-                listener->panelChanged(Evlocallabnormcie12,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabnormcie12,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
 
-}
-
-void Locallabcie::normcieChanged()
-{
-
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (normcie->get_active()) {
-                listener->panelChanged(Evlocallabnormcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabnormcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-
-}
-
-void Locallabcie::gamutcieChanged()
-{
-    if (gamutcie->get_active()) {
-        catBox->set_sensitive(true);
-    } else {
-        catBox->set_sensitive(false);
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (gamutcie->get_active()) {
-                listener->panelChanged(Evlocallabgamutcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabgamutcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-
-}
-
-void Locallabcie::bwcieChanged()
-{
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (bwcie->get_active()) {
-                listener->panelChanged(Evlocallabbwcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabbwcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-
-}
 
 
 void Locallabcie::expprecamChanged()
@@ -11406,100 +10654,18 @@ void Locallabcie::expprecamChanged()
 }
 
 
-void Locallabcie::sigcieChanged()
-{
-    contsigqcie->hide();
-    lightsigqcie->hide();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigcie->get_active()) {
-                listener->panelChanged(Evlocallabsigcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-
-}
 
 
-void Locallabcie::logcieChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (logcie->get_active()) {
-                listener->panelChanged(Evlocallablogcie_12,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallablogcie_12,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::satcieChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (satcie->get_active()) {
-                listener->panelChanged(Evlocallabsatcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsatcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::logcieqChanged()
-{
-    if (logcieq->get_active()) {
-        satcie->hide();
-        sigmoidnormFrame->hide();
-    } else {
-        satcie->show();
-        sigmoidnormFrame->show();
-    }
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (logcieq->get_active()) {
-                listener->panelChanged(Evlocallablogcieq,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallablogcieq,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::smoothcieChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcie->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
+
 
 void Locallabcie::updatecielnkGUI()
 {
     
-    if(smoothcielnk->get_active()) {
+    if(smoothcielnk->getLastActive()) {
         slopesmob->setValue(slopesmog->getValue());
         slopesmor->setValue(slopesmog->getValue());
 
@@ -11509,235 +10675,21 @@ void Locallabcie::updatecielnkGUI()
     
 }
 
-void Locallabcie::smoothcielnkChanged()   
-{
-    updatecielnkGUI();
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcielnk->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcielnk,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcielnk,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothcieinvChanged()   
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcieinv->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcieinv,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcieinv,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothcietrcChanged()
-{  
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcietrc->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcietrc,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcietrc,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothcietrcrelChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcietrcrel->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcietrcrel,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcietrcrel,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothcieybChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcieyb->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcieyb,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcieyb,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothcielumChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothcielum->get_active()) {
-                listener->panelChanged(Evlocallabsmoothcielum,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothcielum,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::smoothciehighChanged()
-{
-    /*
-    if (smoothciehigh->get_active()) {
-        smoothcieth->show();
-    } else {
-        smoothcieth->hide();
-    }
- */   
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (smoothciehigh->get_active()) {
-                listener->panelChanged(Evlocallabsmoothciehigh,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsmoothciehigh,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::logjzChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (logjz->get_active()) {
-                listener->panelChanged(Evlocallablogjz,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallablogjz,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::sigjz12Changed()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigjz12->get_active()) {
-                listener->panelChanged(Evlocallabsigjz12,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigjz12,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::forcebwChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (forcebw->get_active()) {
-                listener->panelChanged(Evlocallabforcebw,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabforcebw,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::sigjzChanged()
-{
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigjz->get_active()) {
-                listener->panelChanged(Evlocallabsigjz,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigjz,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::sigq12Changed()
-{
-    contsigqcie->hide();
-    lightsigqcie->hide();
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigq12->get_active()) {
-                listener->panelChanged(Evlocallabsigq_12,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigq_12,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
-
-void Locallabcie::sigqChanged()
-{
-
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (sigq->get_active()) {
-                listener->panelChanged(Evlocallabsigq,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabsigq,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
 
 
-void Locallabcie::chjzcieChanged()
-{
-    if (chjzcie->get_active()) {
-        thrhjzcie->set_sensitive(true);
-    } else {
-        thrhjzcie->set_sensitive(false);
-    }
 
-    if (isLocActivated && exp->getEnabled()) {
-        if (listener) {
-            if (chjzcie->get_active()) {
-                listener->panelChanged(Evlocallabchjzcie,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            } else {
-                listener->panelChanged(Evlocallabchjzcie,
-                                       M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
-            }
-        }
-    }
-}
+
+
+
+
+
+
+
+
+
+
 
 void Locallabcie::modeQJChanged()
 {
@@ -11925,7 +10877,7 @@ void Locallabcie::modecamChanged()
             enacieMaskallChanged2();
             qjmodjz();
 
-            if (chjzcie->get_active()) {
+            if (chjzcie->getLastActive()) {
                 thrhjzcie->set_sensitive(true);
             } else {
                 thrhjzcie->set_sensitive(false);
@@ -12106,7 +11058,7 @@ void Locallabcie::smoothciemetChanged()
        smoothcielnk->show();
        smoothcieinv->show();
        smoothcieyb->show();
-     //  if (smoothciehigh->get_active()) {
+     //  if (smoothciehigh->getLastActive()) {
             smoothcieth->show();
      //   } else {
       //      smoothcieth->hide();
@@ -12325,16 +11277,16 @@ void Locallabcie::qjmodcam()  // enable - disable function 5.11 or 5.12 Q Cam16 
             sigmoidFrame12->show();
             sigmoidFrame->hide();
             logcieq->hide();
-            logcieq->set_active(false);
+            logcieq->setValue(false);
 
-            if(sigq->get_active()) {
-                sigq->set_active(false);
+            if(sigq->getLastActive()) {
+                sigq->setValue(false);
             }        
         } else { //511
             sigmoidFrame12->hide();
             sigmoidFrame->show();
-            if(sigq12->get_active()) {
-                sigq12->set_active(false);
+            if(sigq12->getLastActive()) {
+                sigq12->setValue(false);
             }
             if(mode == Expert){           
                 logcieq->show();
@@ -12345,7 +11297,7 @@ void Locallabcie::qjmodcam()  // enable - disable function 5.11 or 5.12 Q Cam16 
             sigmoidFrame12->hide();
             sigmoidFrame->hide();
             logcieq->hide();        
-            logcieq->set_active(false);
+            logcieq->setValue(false);
    }
     
 }
@@ -12359,15 +11311,15 @@ void Locallabcie::qjmodjz() // enable - disable function 5.11 or 5.12 J Jz tone 
         if (modeQJ->get_active_row_number() == 1) {      
             sigmoidjzFrame12->show();
             sigmoidjzFrame->hide();
-            if(sigjz->get_active()) {
-                sigjz->set_active(false);
+            if(sigjz->getLastActive()) {
+                sigjz->setValue(false);
             }
                
         } else {
             sigmoidjzFrame12->hide();
             sigmoidjzFrame->show();
-            if(sigjz12->get_active()) {
-                sigjz12->set_active(false);
+            if(sigjz12->getLastActive()) {
+                sigjz12->setValue(false);
             }              
         }
     } else {//nothing in basic (Simple) and Standard
@@ -12510,7 +11462,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
                     smoothcielnk->show();
                     smoothcieinv->show();
                     smoothciehigh->show();
-                //    if (smoothciehigh->get_active()) {
+                //    if (smoothciehigh->getLastActive()) {
                        smoothcieth->show();
                 //    } else {
                 //        smoothcieth->hide();
@@ -12691,7 +11643,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
             sigmoidblcie12->hide();
 
 
-            if (enacieMask->get_active()) {
+            if (enacieMask->getLastActive()) {
                 maskusablecie->show();
                 maskunusablecie->hide();
 
@@ -12749,7 +11701,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
                     smoothcielnk->show();
                     smoothcieinv->show();
                     smoothcieyb->hide();
-                 //   if (smoothciehigh->get_active()) {
+                 //   if (smoothciehigh->getLastActive()) {
                         smoothcieth->show();
                  //   } else {
                  //       smoothcieth->hide();
@@ -12892,7 +11844,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
             logcieFrame->show();
             comprcieth->show();
             comprcieauto->show();
-            if (logcieq->get_active()) {
+            if (logcieq->getLastActive()) {
                 satcie->hide();
                 sigmoidnormFrame->hide();
             } else {
@@ -12919,7 +11871,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
             wavFramecie->show();
             comprBox->show();
 
-            if (enacieMask->get_active()) {
+            if (enacieMask->getLastActive()) {
                 maskusablecie->show();
                 maskunusablecie->hide();
 
@@ -12977,7 +11929,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
                     smoothcielnk->show();
                     smoothcieinv->show();
                     smoothcieyb->show();
-                 //   if (smoothciehigh->get_active()) {
+                 //   if (smoothciehigh->getLastActive()) {
                         smoothcieth->show();
                  //   } else {
                   //      smoothcieth->hide();
@@ -13139,7 +12091,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
                     smoothcielnk->show();
                     smoothcieinv->show();
                     smoothcieyb->show();
-               //     if (smoothciehigh->get_active()) {
+               //     if (smoothciehigh->getLastActive()) {
                         smoothcieth->show();
                //     } else {
                 //        smoothcieth->hide();
@@ -13238,7 +12190,7 @@ void Locallabcie::updateGUIToMode(const modeType new_type)
                 enacieMaskallChanged2();
                 enacieMaskall->show();
 
-                if (chjzcie->get_active()) {
+                if (chjzcie->getLastActive()) {
                     thrhjzcie->set_sensitive(true);
                 } else {
                     thrhjzcie->set_sensitive(false);
@@ -13348,7 +12300,7 @@ void Locallabcie::updatecieGUI()
                 smoothcielum->hide();
                 smoothcieyb->hide();
             }
-         //   if (smoothciehigh->get_active()) {
+         //   if (smoothciehigh->getLastActive()) {
                 smoothcieth->show();
          //   } else {
          //       smoothcieth->hide();
@@ -13438,7 +12390,7 @@ void Locallabcie::updatecieGUI()
     sourceGraycie->show();
     expcamscene->show();
 
-    if (enacieMask->get_active() && mode != Simple) {
+    if (enacieMask->getLastActive() && mode != Simple) {
         maskusablecie->show();
         maskunusablecie->hide();
 
@@ -13448,7 +12400,7 @@ void Locallabcie::updatecieGUI()
     }
 
 
-    if (Autograycie->get_active()) {
+    if (Autograycie->getLastActive()) {
         sourceGraycie->set_sensitive(false);
         sourceabscie->set_sensitive(false);
         adapjzcie->set_sensitive(false);
@@ -13535,20 +12487,20 @@ void Locallabcie::convertParamToSimple()
     // Disable all listeners
     disableListener();
     sigmoidblcie12->setValue(defSpot.sigmoidblcie12);
-    normcie12->set_active(defSpot.normcie12);
-    normcie->set_active(defSpot.normcie);
-    logcieq->set_active(defSpot.logcieq);
+    normcie12->setValue(defSpot.normcie12);
+    normcie->setValue(defSpot.normcie);
+    logcieq->setValue(defSpot.logcieq);
     blackEvjz->setValue(defSpot.blackEvjz);
     whiteEvjz->setValue(defSpot.whiteEvjz);
     whitescie->setValue(defSpot.whitescie);
     blackscie->setValue(defSpot.blackscie);
-    smoothcielum->set_active(defSpot.smoothcielum);
-    smoothcieyb->set_active(defSpot.smoothcieyb);
-    sigq12->set_active(defSpot.sigq12);
+    smoothcielum->setValue(defSpot.smoothcielum);
+    smoothcieyb->setValue(defSpot.smoothcieyb);
+    sigq12->setValue(defSpot.sigq12);
     pqremapcam16->setValue(defSpot.pqremapcam16);
     showmaskcieMethod->set_active(0);
-    enacieMask->set_active(defSpot.enacieMask);
-    enacieMaskall->set_active(defSpot.enacieMaskall);
+    enacieMask->setValue(defSpot.enacieMask);
+    enacieMaskall->setValue(defSpot.enacieMaskall);
     //strgradcie->setValue(defSpot.strgradcie);
     //anggradcie->setValue(defSpot.anggradcie);
     //feathercie->setValue(defSpot.feathercie);
@@ -13570,15 +12522,15 @@ void Locallabcie::convertParamToNormal()
     disableListener();
     contqcie->setValue(defSpot.contqcie);
     sigmoidblcie12->setValue(defSpot.sigmoidblcie12);
-    normcie12->set_active(defSpot.normcie12);
-    normcie->set_active(defSpot.normcie);
-    logcieq->set_active(defSpot.logcieq);
-    smoothcielum->set_active(defSpot.smoothcielum);
-    smoothcieyb->set_active(defSpot.smoothcieyb);
+    normcie12->setValue(defSpot.normcie12);
+    normcie->setValue(defSpot.normcie);
+    logcieq->setValue(defSpot.logcieq);
+    smoothcielum->setValue(defSpot.smoothcielum);
+    smoothcieyb->setValue(defSpot.smoothcieyb);
     colorflcie->setValue(defSpot.colorflcie);
     lightqcie->setValue(defSpot.lightqcie);
     chromlcie->setValue(defSpot.chromlcie);
-    jabcie->set_active(defSpot.jabcie);
+    jabcie->setValue(defSpot.jabcie);
     LHshapejz->setCurve(defSpot.LHcurvejz);
     CHshapejz->setCurve(defSpot.CHcurvejz);
     HHshapejz->setCurve(defSpot.HHcurvejz);
@@ -13606,15 +12558,11 @@ void Locallabcie::convertParamToNormal()
     whitsig->setValue(defSpot.whitsig);
 
     pqremapcam16->setValue(defSpot.pqremapcam16);
-    logcieChanged();
-    satcieChanged();
-    logcieqChanged();
-
     if (modecam->get_active_row_number() == 1) {
         showmaskcieMethod->set_active(0);
-        enacieMask->set_active(defSpot.enacieMask);
-        logjz->set_active(defSpot.logjz);
-        sigjz12->set_active(defSpot.sigjz12);
+        enacieMask->setValue(defSpot.enacieMask);
+        logjz->setValue(defSpot.logjz);
+        sigjz12->setValue(defSpot.sigjz12);
         lapmaskcie->setValue(defSpot.lapmaskcie);
         enacieMaskallChanged2();
 
@@ -13627,8 +12575,8 @@ void Locallabcie::convertParamToNormal()
     shadmaskcie->setValue(defSpot.shadmaskcie);
     HHhmaskcieshape->setCurve(defSpot.HHhmaskciecurve);
     strumaskcie->setValue(defSpot.strumaskcie);
-    toolcie->set_active(defSpot.toolcie);
-    fftcieMask->set_active(defSpot.fftcieMask);
+    toolcie->setValue(defSpot.toolcie);
+    fftcieMask->setValue(defSpot.fftcieMask);
     contcie->setValue(defSpot.contcie);
     blurcie->setValue(defSpot.blurcie);
     LLmaskcieshapewav->setCurve(defSpot.LLmaskciecurvewav);
@@ -14358,7 +13306,7 @@ void Locallabcie::adjusterChanged(Adjuster* a, double newval)
 
 
         if (a == slopesmog ) {
-            if(smoothcielnk->get_active()) {
+            if(smoothcielnk->getLastActive()) {
                 BlockAdjusterEvents block_slopesmob(slopesmob);
                 BlockAdjusterEvents block_slopesmor(slopesmor);
                 slopesmob->setValue(newval);
@@ -14379,7 +13327,7 @@ void Locallabcie::adjusterChanged(Adjuster* a, double newval)
 
 
         if (a == slopesmor ) {
-            if(smoothcielnk->get_active()) {
+            if(smoothcielnk->getLastActive()) {
                 BlockAdjusterEvents block_slopesmob(slopesmob);
                 BlockAdjusterEvents block_slopesmog(slopesmog);
                 slopesmob->setValue(newval);
@@ -14399,7 +13347,7 @@ void Locallabcie::adjusterChanged(Adjuster* a, double newval)
         }
 
         if (a == slopesmob ) {
-            if(smoothcielnk->get_active()) {
+            if(smoothcielnk->getLastActive()) {
                 BlockAdjusterEvents block_slopesmor(slopesmor);
                 BlockAdjusterEvents block_slopesmog(slopesmog);
                 slopesmor->setValue(newval);
@@ -14724,5 +13672,11 @@ void Locallabcie::enabledChanged()
                                        M("GENERAL_DISABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
             }
         }
+    }
+}
+void Locallabcie::checkBoxToggled(CheckBox* c, CheckValue newval)
+{
+    if (!listener) {
+        return;
     }
 }

--- a/rtgui/tools/prsharpening.cc
+++ b/rtgui/tools/prsharpening.cc
@@ -49,6 +49,7 @@ PrSharpening::PrSharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_PRSHARP
     method = Gtk::manage (new MyComboBoxText ());
     method->append (M("TP_SHARPENING_USM"));
     method->append (M("TP_SHARPENING_RLD"));
+    method->setToolPanel(this);
     method->show ();
     hb->pack_start(*ml, Gtk::PACK_SHRINK, 4);
     hb->pack_start(*method);
@@ -91,7 +92,8 @@ PrSharpening::PrSharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_PRSHARP
     threshold->show ();
 
     Gtk::Separator* hsep6 = Gtk::manage (new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
-    edgesonly = Gtk::manage (new Gtk::CheckButton (M("TP_SHARPENING_ONLYEDGES")));
+    edgesonly = Gtk::manage (new MyCheckButton (M("TP_SHARPENING_ONLYEDGES")));
+    edgesonly->setToolPanel(this);
     edgesonly->set_active (false);
     edgebox = new Gtk::Box(Gtk::ORIENTATION_VERTICAL);
     eradius = Gtk::manage (new Adjuster (M("TP_SHARPENING_EDRADIUS"), 0.5, 2.5, 0.1, 1.9));
@@ -110,7 +112,8 @@ PrSharpening::PrSharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_PRSHARP
     etolerance->show();
 
     Gtk::Separator* hsep6b = Gtk::manage (new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
-    halocontrol = Gtk::manage (new Gtk::CheckButton (M("TP_SHARPENING_HALOCONTROL")));
+    halocontrol = Gtk::manage (new MyCheckButton (M("TP_SHARPENING_HALOCONTROL")));
+    halocontrol->setToolPanel(this);
     halocontrol->set_active (false);
     hcbox = new Gtk::Box(Gtk::ORIENTATION_VERTICAL);
     hcamount = Gtk::manage (new Adjuster (M("TP_SHARPENING_HCAMOUNT"), 1, 100, 1, 75));

--- a/rtgui/tools/prsharpening.h
+++ b/rtgui/tools/prsharpening.h
@@ -51,10 +51,10 @@ protected:
     Gtk::Box* edgebox;
     Gtk::Box* hcbox;
     ThresholdAdjuster* threshold;
-    Gtk::CheckButton* edgesonly;
+    MyCheckButton* edgesonly;
     bool lastEdgesOnly;
     sigc::connection eonlyConn;
-    Gtk::CheckButton* halocontrol;
+    MyCheckButton* halocontrol;
     bool lastHaloControl;
     sigc::connection hcConn;
     rtengine::ProcEvent EvPrShrContrast;

--- a/rtgui/tools/resize.cc
+++ b/rtgui/tools/resize.cc
@@ -45,6 +45,7 @@ Resize::Resize () : FoldableToolPanel(this, TOOL_NAME, M("TP_RESIZE_LABEL"), fal
     combos->set_row_spacing(4);
 
     appliesTo = Gtk::manage (new MyComboBoxText ());
+    appliesTo->setToolPanel(this);
     appliesTo->append (M("TP_RESIZE_CROPPEDAREA"));
     appliesTo->append (M("TP_RESIZE_FULLIMAGE"));
     appliesTo->set_active (0);
@@ -52,12 +53,13 @@ Resize::Resize () : FoldableToolPanel(this, TOOL_NAME, M("TP_RESIZE_LABEL"), fal
     appliesTo->set_halign(Gtk::ALIGN_FILL);
 
     Gtk::Label *label = Gtk::manage (new Gtk::Label (M("TP_RESIZE_APPLIESTO"), Gtk::ALIGN_START));
-    
+
     combos->attach(*label, 0, 0, 1, 1);
     combos->attach(*appliesTo, 1, 0, 1, 1);
 
     // See Resize::methodChanged() when adding a new method.
     method = Gtk::manage (new MyComboBoxText ());
+    method->setToolPanel(this);
     method->append (M("TP_RESIZE_LANCZOS"));
     method->append (M("TP_RESIZE_NEAREST"));
     method->set_active (0);
@@ -65,11 +67,12 @@ Resize::Resize () : FoldableToolPanel(this, TOOL_NAME, M("TP_RESIZE_LABEL"), fal
     method->set_halign(Gtk::ALIGN_FILL);
 
     label = Gtk::manage (new Gtk::Label (M("TP_RESIZE_METHOD"), Gtk::ALIGN_START));
-    
+
     combos->attach(*label, 0, 1, 1, 1);
     combos->attach(*method, 1, 1, 1, 1);
 
     spec = Gtk::manage (new MyComboBoxText ());
+    spec->setToolPanel(this);
     spec->append (M("TP_RESIZE_SCALE"));
     spec->append (M("TP_RESIZE_WIDTH"));
     spec->append (M("TP_RESIZE_HEIGHT"));
@@ -104,15 +107,19 @@ Resize::Resize () : FoldableToolPanel(this, TOOL_NAME, M("TP_RESIZE_LABEL"), fal
     w = Gtk::manage (new MySpinButton ());
     w->set_width_chars(5);
     setExpandAlignProperties(w, false, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
+    w->setToolPanel(this);
     h = Gtk::manage (new MySpinButton ());
     h->set_width_chars(5);
     setExpandAlignProperties(h, false, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
+    h->setToolPanel(this);
     le = Gtk::manage (new MySpinButton ());
     le->set_width_chars(5);
     setExpandAlignProperties(le, false, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
+    le->setToolPanel(this);
     se = Gtk::manage (new MySpinButton ());
     se->set_width_chars(5);
     setExpandAlignProperties(se, false, false, Gtk::ALIGN_END, Gtk::ALIGN_CENTER);
+    se->setToolPanel(this);
 
     wbox->pack_start (*Gtk::manage (new Gtk::Label (M("TP_RESIZE_W"))), Gtk::PACK_SHRINK, 0);
     wbox->pack_start (*w);
@@ -140,7 +147,8 @@ Resize::Resize () : FoldableToolPanel(this, TOOL_NAME, M("TP_RESIZE_LABEL"), fal
     sizeBox->show_all ();
     sizeBox->reference ();
 
-    allowUpscaling = Gtk::manage(new Gtk::CheckButton(M("TP_RESIZE_ALLOW_UPSCALING")));
+    allowUpscaling = Gtk::manage(new MyCheckButton(M("TP_RESIZE_ALLOW_UPSCALING")));
+    allowUpscaling->setToolPanel(this);
     pack_start(*allowUpscaling);
     allowUpscaling->signal_toggled().connect(sigc::mem_fun(*this, &Resize::allowUpscalingChanged));
 

--- a/rtgui/tools/resize.h
+++ b/rtgui/tools/resize.h
@@ -80,7 +80,7 @@ private:
     MySpinButton*      h;
     MySpinButton*      le;
     MySpinButton*      se;
-    Gtk::CheckButton *allowUpscaling;
+    MyCheckButton *allowUpscaling;
     int                maxw, maxh;
     int                cropw, croph;
     sigc::connection   sconn, aconn, wconn, hconn, leconn, seconn;

--- a/rtgui/tools/retinex.cc
+++ b/rtgui/tools/retinex.cc
@@ -436,7 +436,7 @@ Retinex::Retinex () : FoldableToolPanel (this, TOOL_NAME, M ("TP_RETINEX_LABEL")
     limd->show ();
 
     // Transmission median filter
-    medianmap = Gtk::manage (new Gtk::CheckButton (M ("TP_RETINEX_MEDIAN")));
+    medianmap = Gtk::manage (new MyCheckButton (M ("TP_RETINEX_MEDIAN")));
     setExpandAlignProperties (medianmap, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_START);
     medianmap->set_active (true);
     medianmapConn  = medianmap->signal_toggled().connect ( sigc::mem_fun (*this, &Retinex::medianmapChanged) );
@@ -564,6 +564,14 @@ Retinex::Retinex () : FoldableToolPanel (this, TOOL_NAME, M ("TP_RETINEX_LABEL")
 
     skal->setAdjusterListener (this);
     skal->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
+
+    medianmap->setToolPanel(this);
+    complexmethod->setToolPanel(this);
+    retinexMethod->setToolPanel(this);
+    retinexcolorspace->setToolPanel(this);
+    viewMethod->setToolPanel(this);
+    mapMethod->setToolPanel(this);
+    gammaretinex->setToolPanel(this);
 
     disableListener();
     retinexColorSpaceChanged();

--- a/rtgui/tools/retinex.h
+++ b/rtgui/tools/retinex.h
@@ -72,7 +72,7 @@ protected:
     MyComboBoxText*   gammaretinex;
     MyComboBoxText*   mapMethod;
     MyComboBoxText*   viewMethod;
-    Gtk::CheckButton* medianmap;
+    MyCheckButton* medianmap;
     MyComboBoxText* complexmethod;
     sigc::connection  complexmethodconn;
     

--- a/rtgui/tools/rgbcurves.cc
+++ b/rtgui/tools/rgbcurves.cc
@@ -32,7 +32,8 @@ const Glib::ustring RGBCurves::TOOL_NAME = "rgbcurves";
 RGBCurves::RGBCurves () : FoldableToolPanel(this, TOOL_NAME, M("TP_RGBCURVES_LABEL"), false, true), lastLumamode(false)
 {
 
-    lumamode = Gtk::manage (new Gtk::CheckButton (M("TP_RGBCURVES_LUMAMODE")));
+    lumamode = Gtk::manage (new MyCheckButton (M("TP_RGBCURVES_LUMAMODE")));
+    lumamode->setToolPanel(this);
     lumamode->set_tooltip_markup (M("TP_RGBCURVES_LUMAMODE_TOOLTIP"));
     lumamode->set_active (false);
     lumamode->show ();

--- a/rtgui/tools/rgbcurves.h
+++ b/rtgui/tools/rgbcurves.h
@@ -22,6 +22,7 @@
 
 #include "colorprovider.h"
 #include "curvelistener.h"
+#include "guiutils.h"
 #include "toolpanel.h"
 
 class CurveEditorGroup;
@@ -40,7 +41,7 @@ protected:
     DiagonalCurveEditor* Gshape;
     DiagonalCurveEditor* Bshape;
 
-    Gtk::CheckButton* lumamode;
+    MyCheckButton* lumamode;
     bool lastLumamode;
     sigc::connection lumamodeConn;
 

--- a/rtgui/tools/shadowshighlights.cc
+++ b/rtgui/tools/shadowshighlights.cc
@@ -35,6 +35,7 @@ ShadowsHighlights::ShadowsHighlights () : FoldableToolPanel(this, TOOL_NAME, M("
     Gtk::Box* hb = Gtk::manage (new Gtk::Box ());
     hb->pack_start(*Gtk::manage(new Gtk::Label(M("TP_DIRPYRDENOISE_MAIN_COLORSPACE") + ": ")), Gtk::PACK_SHRINK);
     colorspace = Gtk::manage(new MyComboBoxText());
+    colorspace->setToolPanel(this);
     colorspace->append(M("TP_DIRPYRDENOISE_MAIN_COLORSPACE_RGB"));
     colorspace->append(M("TP_DIRPYRDENOISE_MAIN_COLORSPACE_LAB"));
     hb->pack_start(*colorspace);

--- a/rtgui/tools/sharpenedge.cc
+++ b/rtgui/tools/sharpenedge.cc
@@ -44,7 +44,8 @@ SharpenEdge::SharpenEdge () : FoldableToolPanel(this, TOOL_NAME, M("TP_SHARPENED
 
     amount->setDelay(std::max(options.adjusterMinDelay, options.adjusterMaxDelay));
 
-    threechannels = Gtk::manage(new Gtk::CheckButton((M("TP_SHARPENEDGE_THREE"))));// L + a + b
+    threechannels = Gtk::manage(new MyCheckButton((M("TP_SHARPENEDGE_THREE"))));// L + a + b
+    threechannels->setToolPanel(this);
     threechannels->set_active (false);
     pack_start( *passes, Gtk::PACK_SHRINK, 0);//passes
     pack_start( *amount, Gtk::PACK_SHRINK, 0);//amount

--- a/rtgui/tools/sharpenedge.h
+++ b/rtgui/tools/sharpenedge.h
@@ -38,7 +38,7 @@ protected:
 
     Adjuster* passes;
     Adjuster* amount;
-    Gtk::CheckButton* threechannels;
+    MyCheckButton* threechannels;
 
     sigc::connection chanthreeconn;
     bool lastchanthree;

--- a/rtgui/tools/sharpening.cc
+++ b/rtgui/tools/sharpening.cc
@@ -45,6 +45,7 @@ Sharpening::Sharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_SHARPENING_
     Gtk::Label* ml = Gtk::manage (new Gtk::Label (M("TP_SHARPENING_METHOD") + ":"));
     ml->show ();
     method = Gtk::manage (new MyComboBoxText ());
+    method->setToolPanel(this);
     method->append (M("TP_SHARPENING_USM"));
     method->append (M("TP_SHARPENING_RLD"));
     method->show ();
@@ -89,7 +90,8 @@ Sharpening::Sharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_SHARPENING_
     amount->show ();
 
     Gtk::Separator* hsep6 = Gtk::manage (new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
-    edgesonly = Gtk::manage (new Gtk::CheckButton (M("TP_SHARPENING_ONLYEDGES")));
+    edgesonly = Gtk::manage (new MyCheckButton (M("TP_SHARPENING_ONLYEDGES")));
+    edgesonly->setToolPanel(this);
     edgesonly->set_active (false);
     edgebox = new Gtk::Box(Gtk::ORIENTATION_VERTICAL);
     eradius = Gtk::manage (new Adjuster (M("TP_SHARPENING_EDRADIUS"), 0.5, 2.5, 0.1, 1.9));
@@ -108,7 +110,8 @@ Sharpening::Sharpening () : FoldableToolPanel(this, TOOL_NAME, M("TP_SHARPENING_
     etolerance->show();
 
     Gtk::Separator* hsep6b = Gtk::manage (new Gtk::Separator(Gtk::ORIENTATION_HORIZONTAL));
-    halocontrol = Gtk::manage (new Gtk::CheckButton (M("TP_SHARPENING_HALOCONTROL")));
+    halocontrol = Gtk::manage (new MyCheckButton (M("TP_SHARPENING_HALOCONTROL")));
+    halocontrol->setToolPanel(this);
     halocontrol->set_active (false);
     hcbox = new Gtk::Box(Gtk::ORIENTATION_VERTICAL);
     hcamount = Gtk::manage (new Adjuster (M("TP_SHARPENING_HCAMOUNT"), 1, 100, 1, 75));

--- a/rtgui/tools/sharpening.h
+++ b/rtgui/tools/sharpening.h
@@ -52,10 +52,10 @@ protected:
     Gtk::Box* edgebox;
     Gtk::Box* hcbox;
     ThresholdAdjuster* threshold;
-    Gtk::CheckButton* edgesonly;
+    MyCheckButton* edgesonly;
     bool lastEdgesOnly;
     sigc::connection eonlyConn;
-    Gtk::CheckButton* halocontrol;
+    MyCheckButton* halocontrol;
     bool lastHaloControl;
     sigc::connection hcConn;
 

--- a/rtgui/tools/sharpenmicro.cc
+++ b/rtgui/tools/sharpenmicro.cc
@@ -53,7 +53,8 @@ SharpenMicro::SharpenMicro () : FoldableToolPanel(this, TOOL_NAME, M("TP_SHARPEN
     pack_start( *amount, Gtk::PACK_SHRINK, 0);
     pack_start( *uniformity, Gtk::PACK_SHRINK, 0);
 
-    matrix = Gtk::manage (new Gtk::CheckButton (M("TP_SHARPENMICRO_MATRIX")));
+    matrix = Gtk::manage (new MyCheckButton (M("TP_SHARPENMICRO_MATRIX")));
+    matrix->setToolPanel(this);
     matrix->set_active (true);
     pack_start(*matrix, Gtk::PACK_SHRINK, 0);
     matrix->show ();

--- a/rtgui/tools/sharpenmicro.h
+++ b/rtgui/tools/sharpenmicro.h
@@ -36,7 +36,7 @@ class SharpenMicro final :
 
 protected:
 
-    Gtk::CheckButton* matrix;
+    MyCheckButton* matrix;
     Adjuster* amount;
     Adjuster* uniformity;
     Adjuster* contrast;

--- a/rtgui/tools/spot.cc
+++ b/rtgui/tools/spot.cc
@@ -278,6 +278,7 @@ void Spot::editToggled ()
 {
     if (listener) {
         if (edit->get_active()) {
+            enableTool();
             listener->setTweakOperator(this);
             listener->refreshPreview(EvSpotEnabledOPA); // reprocess the preview w/o creating History entry
             subscribe();

--- a/rtgui/tools/toneequalizer.cc
+++ b/rtgui/tools/toneequalizer.cc
@@ -63,6 +63,7 @@ ToneEqualizer::ToneEqualizer(): FoldableToolPanel(this, TOOL_NAME, M("TP_TONE_EQ
     show_colormap = Gtk::manage(new CheckBox(M("TP_TONE_EQUALIZER_SHOW_COLOR_MAP"), multiImage));
     pack_start(*show_colormap);
     show_colormap->setCheckBoxListener(this);
+    show_colormap->setEnableOnlyWhenActivated(true);
 
     show_all_children ();
 }
@@ -217,9 +218,6 @@ void ToneEqualizer::checkBoxToggled(CheckBox *c, CheckValue newval)
 
 void ToneEqualizer::colormapToggled()
 {
-    if (show_colormap->getLastActive()) {
-      enableTool();
-    }
     for (size_t i = 0; i < bands.size(); ++i) {
         bands[i]->showIcons(show_colormap->getLastActive());
     }

--- a/rtgui/tools/toneequalizer.cc
+++ b/rtgui/tools/toneequalizer.cc
@@ -217,7 +217,9 @@ void ToneEqualizer::checkBoxToggled(CheckBox *c, CheckValue newval)
 
 void ToneEqualizer::colormapToggled()
 {
-    enableTool();
+    if (show_colormap->getLastActive()) {
+      enableTool();
+    }
     for (size_t i = 0; i < bands.size(); ++i) {
         bands[i]->showIcons(show_colormap->getLastActive());
     }

--- a/rtgui/tools/toneequalizer.cc
+++ b/rtgui/tools/toneequalizer.cc
@@ -217,6 +217,7 @@ void ToneEqualizer::checkBoxToggled(CheckBox *c, CheckValue newval)
 
 void ToneEqualizer::colormapToggled()
 {
+    enableTool();
     for (size_t i = 0; i < bands.size(); ++i) {
         bands[i]->showIcons(show_colormap->getLastActive());
     }

--- a/rtgui/tools/vibrance.cc
+++ b/rtgui/tools/vibrance.cc
@@ -56,15 +56,18 @@ Vibrance::Vibrance () : FoldableToolPanel(this, TOOL_NAME, M("TP_VIBRANCE_LABEL"
     psThreshold->set_sensitive(false);
     pack_start( *psThreshold, Gtk::PACK_SHRINK, 0);
 
-    protectSkins = Gtk::manage (new Gtk::CheckButton (M("TP_VIBRANCE_PROTECTSKINS")));
+    protectSkins = Gtk::manage (new MyCheckButton (M("TP_VIBRANCE_PROTECTSKINS")));
+    protectSkins->setToolPanel(this);
     protectSkins->set_active (true);
     pack_start(*protectSkins, Gtk::PACK_SHRINK, 0);
 
-    avoidColorShift = Gtk::manage (new Gtk::CheckButton (M("TP_VIBRANCE_AVOIDCOLORSHIFT")));
+    avoidColorShift = Gtk::manage (new MyCheckButton (M("TP_VIBRANCE_AVOIDCOLORSHIFT")));
+    avoidColorShift->setToolPanel(this);
     avoidColorShift->set_active (true);
     pack_start(*avoidColorShift, Gtk::PACK_SHRINK, 0);
 
-    pastSatTog = Gtk::manage (new Gtk::CheckButton (M("TP_VIBRANCE_PASTSATTOG")));
+    pastSatTog = Gtk::manage (new MyCheckButton (M("TP_VIBRANCE_PASTSATTOG")));
+    pastSatTog->setToolPanel(this);
     pastSatTog->set_active (true);
     pack_start(*pastSatTog, Gtk::PACK_SHRINK, 0);
 

--- a/rtgui/tools/vibrance.h
+++ b/rtgui/tools/vibrance.h
@@ -43,9 +43,9 @@ protected:
     Adjuster* pastels;
     Adjuster* saturated;
     ThresholdAdjuster* psThreshold;
-    Gtk::CheckButton* protectSkins;
-    Gtk::CheckButton* avoidColorShift;
-    Gtk::CheckButton* pastSatTog;
+    MyCheckButton* protectSkins;
+    MyCheckButton* avoidColorShift;
+    MyCheckButton* pastSatTog;
     DiagonalCurveEditor* skinTonesCurve;
 
     bool lastProtectSkins;

--- a/rtgui/tools/wavelet.cc
+++ b/rtgui/tools/wavelet.cc
@@ -83,16 +83,16 @@ Wavelet::Wavelet() :
     CurveEditorwavhue(new CurveEditorGroup(App::get().mut_options().lastWaveletCurvesDir, M("TP_WAVELET_DENOISEHUE"))),
     opacityCurveEditorW(new CurveEditorGroup(App::get().mut_options().lastWaveletCurvesDir, M("TP_WAVELET_OPACITYW"))),
     opacityCurveEditorWL(new CurveEditorGroup(App::get().mut_options().lastWaveletCurvesDir, M("TP_WAVELET_OPACITYWL"))),
-    median(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_MEDI")))),
-    medianlev(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_MEDILEV")))),
-    linkedg(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_LINKEDG")))),
-    cbenab(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_CBENAB")))),
-    lipst(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_LIPST")))),
-    avoid(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_AVOID")))),
-    tmr(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_BALCHRO")))),
-    showmask(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_SHOWMASK")))),
-    oldsh(Gtk::manage(new Gtk::CheckButton(M("TP_WAVELET_OLDSH")))),
-    neutralchButton(Gtk::manage(new Gtk::Button(M("TP_WAVELET_NEUTRAL")))),
+    median(Gtk::manage(new MyCheckButton(M("TP_WAVELET_MEDI")))),
+    medianlev(Gtk::manage(new MyCheckButton(M("TP_WAVELET_MEDILEV")))),
+    linkedg(Gtk::manage(new MyCheckButton(M("TP_WAVELET_LINKEDG")))),
+    cbenab(Gtk::manage(new MyCheckButton(M("TP_WAVELET_CBENAB")))),
+    lipst(Gtk::manage(new MyCheckButton(M("TP_WAVELET_LIPST")))),
+    avoid(Gtk::manage(new MyCheckButton(M("TP_WAVELET_AVOID")))),
+    tmr(Gtk::manage(new MyCheckButton(M("TP_WAVELET_BALCHRO")))),
+    showmask(Gtk::manage(new MyCheckButton(M("TP_WAVELET_SHOWMASK")))),
+    oldsh(Gtk::manage(new MyCheckButton(M("TP_WAVELET_OLDSH")))),
+    neutralchButton(Gtk::manage(new MyButton(M("TP_WAVELET_NEUTRAL")))),
     sigma(Gtk::manage(new Adjuster(M("TP_WAVELET_SIGMA"), 0.05, 2.5, 0.01, 1.))),
     offset(Gtk::manage(new Adjuster(M("TP_WAVELET_WAVOFFSET"), 0.33, 1.66, 0.01, 1., Gtk::manage(new RTImage("circle-black-small")), Gtk::manage(new RTImage("circle-white-small"))))),
     lowthr(Gtk::manage(new Adjuster(M("TP_WAVELET_WAVLOWTHR"), 20., 100., 0.5, 40.))),
@@ -413,15 +413,18 @@ Wavelet::Wavelet() :
     buttonBox->set_homogeneous(true);
     levBox->pack_start(*buttonBox, Gtk::PACK_SHRINK, 2);
 
-    Gtk::Button* const contrastMinusButton = Gtk::manage(new Gtk::Button(M("TP_WAVELET_CONTRAST_MINUS")));
+    MyButton* const contrastMinusButton = Gtk::manage(new MyButton(M("TP_WAVELET_CONTRAST_MINUS")));
+    contrastMinusButton->setToolPanel(this);
     buttonBox->pack_start(*contrastMinusButton);
     contrastMinusPressedConn = contrastMinusButton->signal_pressed().connect(sigc::mem_fun(*this, &Wavelet::contrastMinusPressed));
 
-    Gtk::Button* const neutralButton = Gtk::manage(new Gtk::Button(M("TP_WAVELET_NEUTRAL")));
+    MyButton* const neutralButton = Gtk::manage(new MyButton(M("TP_WAVELET_NEUTRAL")));
+    neutralButton->setAutoEnableTool(false);
     buttonBox->pack_start(*neutralButton);
     neutralPressedConn = neutralButton->signal_pressed().connect(sigc::mem_fun(*this, &Wavelet::neutralPressed));
 
-    Gtk::Button* const contrastPlusButton = Gtk::manage(new Gtk::Button(M("TP_WAVELET_CONTRAST_PLUS")));
+    MyButton* const contrastPlusButton = Gtk::manage(new MyButton(M("TP_WAVELET_CONTRAST_PLUS")));
+    contrastPlusButton->setToolPanel(this);
     buttonBox->pack_start(*contrastPlusButton);
     contrastPlusPressedConn = contrastPlusButton->signal_pressed().connect(sigc::mem_fun(*this, &Wavelet::contrastPlusPressed));
 
@@ -559,6 +562,7 @@ Wavelet::Wavelet() :
     Gtk::Box* const buttonchBox = Gtk::manage(new Gtk::Box());
     buttonchBox->set_spacing(10);
     buttonchBox->set_homogeneous(true);
+    neutralchButton->setAutoEnableTool(false);
     neutralchPressedConn = neutralchButton->signal_pressed().connect(sigc::mem_fun(*this, &Wavelet::neutralchPressed));
     chBox->pack_start(*separatorNeutral, Gtk::PACK_SHRINK, 2);
     buttonchBox->pack_start(*neutralchButton);
@@ -1170,7 +1174,8 @@ Wavelet::Wavelet() :
     resBox->pack_start(*chanMixerMidFrame, Gtk::PACK_SHRINK);
     resBox->pack_start(*chanMixerShadowsFrame, Gtk::PACK_SHRINK);
 
-    Gtk::Button* const neutral = Gtk::manage(new Gtk::Button(M("TP_COLORTONING_NEUTRAL")));
+    MyButton* const neutral = Gtk::manage(new MyButton(M("TP_COLORTONING_NEUTRAL")));
+    neutral->setAutoEnableTool(false);
     neutral->set_tooltip_text(M("TP_COLORTONING_NEUTRAL_TOOLTIP"));
     neutralconn = neutral->signal_pressed().connect(sigc::mem_fun(*this, &Wavelet::neutral_pressed));
     neutral->show();
@@ -1328,6 +1333,36 @@ Wavelet::Wavelet() :
     expfinal->add(*finalBox, false);
     expfinal->setLevel(2);
     pack_start(*expfinal);
+
+    Lmethod->setToolPanel(this);
+    CHmethod->setToolPanel(this);
+    CHSLmethod->setToolPanel(this);
+    EDmethod->setToolPanel(this);
+    BAmethod->setToolPanel(this);
+    NPmethod->setToolPanel(this);
+    TMmethod->setToolPanel(this);
+    HSmethod->setToolPanel(this);
+    CLmethod->setToolPanel(this);
+    Backmethod->setToolPanel(this);
+    complexmethod->setToolPanel(this);
+    Tilesmethod->setToolPanel(this);
+    daubcoeffmethod->setToolPanel(this);
+    Dirmethod->setToolPanel(this);
+    Medgreinf->setToolPanel(this);
+    ushamethod->setToolPanel(this);
+    mixmethod->setToolPanel(this);
+    quamethod->setToolPanel(this);
+    slimethod->setToolPanel(this);
+    median->setToolPanel(this);
+    medianlev->setToolPanel(this);
+    linkedg->setToolPanel(this);
+    cbenab->setToolPanel(this);
+    lipst->setToolPanel(this);
+    avoid->setToolPanel(this);
+    tmr->setToolPanel(this);
+    showmask->setToolPanel(this);
+    oldsh->setToolPanel(this);
+    registerExpanders(this, {});
 }
 
 Wavelet::~Wavelet()

--- a/rtgui/tools/wavelet.h
+++ b/rtgui/tools/wavelet.h
@@ -224,17 +224,17 @@ private:
 
     FlatCurveEditor* ccshape;
     FlatCurveEditor* blshape;
-    Gtk::CheckButton* const median;
-    Gtk::CheckButton* const medianlev;
-    Gtk::CheckButton* const linkedg;
-    Gtk::CheckButton* const cbenab;
-    Gtk::CheckButton* const lipst;
-    Gtk::CheckButton* const avoid;
-    Gtk::CheckButton* const tmr;
-    Gtk::CheckButton* const showmask;
-    Gtk::CheckButton* const oldsh;
+    MyCheckButton* const median;
+    MyCheckButton* const medianlev;
+    MyCheckButton* const linkedg;
+    MyCheckButton* const cbenab;
+    MyCheckButton* const lipst;
+    MyCheckButton* const avoid;
+    MyCheckButton* const tmr;
+    MyCheckButton* const showmask;
+    MyCheckButton* const oldsh;
 
-    Gtk::Button* const neutralchButton;
+    MyButton* const neutralchButton;
     Adjuster* correction[9];
     Adjuster* correctionch[9];
     Adjuster* const sigma;

--- a/rtgui/tools/whitebalance.cc
+++ b/rtgui/tools/whitebalance.cc
@@ -148,6 +148,7 @@ WhiteBalance::WhiteBalance () : FoldableToolPanel(this, TOOL_NAME, M("TP_WBALANC
     refTreeModel = Gtk::TreeStore::create(methodColumns);
     // Create the Combobox
     method = Gtk::manage (new MyComboBox ());
+    method->setToolPanel(this);
     setExpandAlignProperties(method, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     // Assign the model to the Combobox
     method->set_model(refTreeModel);
@@ -278,6 +279,7 @@ WhiteBalance::WhiteBalance () : FoldableToolPanel(this, TOOL_NAME, M("TP_WBALANC
     setExpandAlignProperties(wbsizehelper, false, false, Gtk::ALIGN_START, Gtk::ALIGN_CENTER);
 
     spotsize = Gtk::manage (new MyComboBoxText ());
+    spotsize->setToolPanel(this);
     setExpandAlignProperties(spotsize, true, false, Gtk::ALIGN_FILL, Gtk::ALIGN_CENTER);
     spotsize->append ("2");
 
@@ -377,6 +379,7 @@ WhiteBalance::WhiteBalance () : FoldableToolPanel(this, TOOL_NAME, M("TP_WBALANC
 
 
     itcwb_prim = Gtk::manage (new MyComboBoxText ());
+    itcwb_prim->setToolPanel(this);
     itcwb_prim->append(M("TP_WBALANCE_ITCWB_PRIM_SRGB"));
     itcwb_prim->append(M("TP_WBALANCE_ITCWB_PRIM_BETA"));
     itcwb_prim->append(M("TP_WBALANCE_ITCWB_PRIM_XYZCAM"));
@@ -464,6 +467,7 @@ void WhiteBalance::itcwb_prim_changed ()
 
 void WhiteBalance::itcwb_alg_toggled ()
 {
+    enableTool();
     if (batchMode) {
         if (itcwb_alg->get_inconsistent()) {
             itcwb_alg->set_inconsistent (false);
@@ -554,8 +558,11 @@ void WhiteBalance::adjusterChanged(Adjuster* a, double newval)
 
 void WhiteBalance::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (!(getEnabled() && listener)) {
-        return;
+    if (!getEnabled()) {
+      enableTool();
+    }
+    if (!listener) {
+      return;
     }
 
     if (c == observer10) {

--- a/rtgui/tools/whitebalance.cc
+++ b/rtgui/tools/whitebalance.cc
@@ -372,9 +372,9 @@ WhiteBalance::WhiteBalance () : FoldableToolPanel(this, TOOL_NAME, M("TP_WBALANC
     itcwb_green = Gtk::manage (new Adjuster (M("TP_WBALANCE_ITCWGREEN"), -0.35, 0.35, 0.005, 0.));
     itcwb_green ->set_tooltip_markup (M("TP_WBALANCE_ITCWGREEN_TOOLTIP"));
 
-    itcwb_alg = Gtk::manage (new Gtk::CheckButton (M("TP_WBALANCE_ITCWB_ALG")));
+    itcwb_alg = Gtk::manage (new CheckBox (M("TP_WBALANCE_ITCWB_ALG"), multiImage));
     itcwb_alg ->set_tooltip_markup (M("TP_WBALANCE_ITCWALG_TOOLTIP"));
-    itcwb_alg ->set_active (false);
+    itcwb_alg ->setValue (false);
 
 
 
@@ -434,7 +434,7 @@ WhiteBalance::WhiteBalance () : FoldableToolPanel(this, TOOL_NAME, M("TP_WBALANC
 
     spotbutton->signal_pressed().connect( sigc::mem_fun(*this, &WhiteBalance::spotPressed) );
     methconn = method->signal_changed().connect( sigc::mem_fun(*this, &WhiteBalance::optChanged) );
-    itcwb_algconn = itcwb_alg->signal_toggled().connect( sigc::mem_fun(*this, &WhiteBalance::itcwb_alg_toggled) );
+    itcwb_alg->setCheckBoxListener(this);
 
     resetButton->signal_pressed().connect( sigc::mem_fun(*this, &WhiteBalance::resetWB) );
     spotsize->signal_changed().connect( sigc::mem_fun(*this, &WhiteBalance::spotSizeChanged) );
@@ -464,30 +464,6 @@ void WhiteBalance::itcwb_prim_changed ()
     }
 }
 
-
-void WhiteBalance::itcwb_alg_toggled ()
-{
-    enableTool();
-    if (batchMode) {
-        if (itcwb_alg->get_inconsistent()) {
-            itcwb_alg->set_inconsistent (false);
-            itcwb_algconn.block (true);
-            itcwb_alg->set_active (false);
-            itcwb_algconn.block (false);
-        } else if (lastitcwb_alg) {
-            itcwb_alg->set_inconsistent (true);
-        }
-
-        lastitcwb_alg = itcwb_alg->get_active ();
-    }
-    if (listener && getEnabled()) {
-        if (itcwb_alg->get_active ()) {
-            listener->panelChanged (EvWBitcwbalg, M("GENERAL_ENABLED"));
-        } else {
-            listener->panelChanged (EvWBitcwbalg, M("GENERAL_DISABLED"));
-        }
-    }
-}
 
 void WhiteBalance::adjusterChanged(Adjuster* a, double newval)
 {
@@ -558,9 +534,6 @@ void WhiteBalance::adjusterChanged(Adjuster* a, double newval)
 
 void WhiteBalance::checkBoxToggled(CheckBox* c, CheckValue newval)
 {
-    if (!getEnabled()) {
-      enableTool();
-    }
     if (!listener) {
       return;
     }
@@ -586,6 +559,12 @@ void WhiteBalance::checkBoxToggled(CheckBox* c, CheckValue newval)
             : c->getValue() == CheckValue::off
                 ? M("GENERAL_DISABLED")
                 : M("GENERAL_UNCHANGED"));
+    } else if (c == itcwb_alg) {
+        if (listener && getEnabled()) {
+            listener->panelChanged(
+                EvWBitcwbalg,
+                c->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        }
     }
 }
 
@@ -770,10 +749,7 @@ void WhiteBalance::read (const ProcParams* pp, const ParamsEdited* pedited)
     tempBias->setValue (pp->wb.tempBias);
     tempBias->set_sensitive(true);
 
-    itcwb_algconn.block (true);
-    itcwb_alg->set_active (pp->wb.itcwb_alg);
-    itcwb_algconn.block (false);
-    lastitcwb_alg = pp->wb.itcwb_alg;
+    itcwb_alg->setValue (pp->wb.itcwb_alg);
     itcwb_green->setValue (pp->wb.itcwb_green);
 
     compatVersionAdjuster->setValue(pp->wb.compat_version);
@@ -813,7 +789,7 @@ void WhiteBalance::read (const ProcParams* pp, const ParamsEdited* pedited)
         equal->setEditedState (pedited->wb.equal ? Edited : UnEdited);
         tempBias->setEditedState (pedited->wb.tempBias ? Edited : UnEdited);
         observer10->setEdited(pedited->wb.observer);
-        itcwb_alg->set_inconsistent (!pedited->wb.itcwb_alg);
+        itcwb_alg->setEdited(pedited->wb.itcwb_alg);
         itcwb_green->setEditedState (pedited->wb.itcwb_green ? Edited : UnEdited);
         compatVersionAdjuster->setEditedState(pedited->wb.compat_version ? Edited : UnEdited);
     }
@@ -966,7 +942,7 @@ void WhiteBalance::write (ProcParams* pp, ParamsEdited* pedited)
         pedited->wb.equal = equal->getEditedState ();
         pedited->wb.tempBias = tempBias->getEditedState ();
         pedited->wb.observer = observer10->getEdited();
-        pedited->wb.itcwb_alg = !itcwb_alg->get_inconsistent();
+        pedited->wb.itcwb_alg = itcwb_alg->getEdited();
         pedited->wb.method = row[methodColumns.colLabel] != M("GENERAL_UNCHANGED");
         pedited->wb.enabled = !get_inconsistent();
         pedited->wb.itcwb_prim  = itcwb_prim->get_active_text() != M("GENERAL_UNCHANGED");
@@ -1004,7 +980,7 @@ void WhiteBalance::write (ProcParams* pp, ParamsEdited* pedited)
         : observer10->getValue() == CheckValue::off
             ? rtengine::StandardObserver::TWO_DEGREES
             : pp->wb.observer;
-    pp->wb.itcwb_alg = itcwb_alg->get_active ();
+    pp->wb.itcwb_alg = itcwb_alg->getLastActive();
     pp->wb.tempBias = tempBias->getValue ();
     pp->wb.itcwb_green = itcwb_green->getValue ();
     pp->wb.compat_version = compatVersionAdjuster->getIntValue();

--- a/rtgui/tools/whitebalance.h
+++ b/rtgui/tools/whitebalance.h
@@ -82,12 +82,10 @@ protected:
     Adjuster* tempBias;
     CheckBox* observer10;
     Gtk::Frame* itcwbFrame;
-    Gtk::CheckButton* itcwb_alg;
+    CheckBox* itcwb_alg;
     MyComboBoxText* itcwb_prim;
     Adjuster* itcwb_green;
     std::unique_ptr<Adjuster> compatVersionAdjuster;
-    
-    bool lastitcwb_alg;
 
     Gtk::Button* spotbutton;
     int opt;
@@ -95,7 +93,7 @@ protected:
     double nextGreen;
     WBProvider *wbp;  // pointer to a ToolPanelCoordinator object, or its subclass BatchToolPanelCoordinator
     SpotWBListener* wblistener;
-    sigc::connection methconn, itcwb_algconn, itcwb_primconn;
+    sigc::connection methconn, itcwb_primconn;
     int custom_temp;
     double custom_green;
     double custom_equal;
@@ -142,7 +140,6 @@ public:
     void setWB (int temp, double green);
     void resetWB ();
     void WBChanged           (int met, double temp, double green, double rw, double gw, double bw, float temp0, float delta, int bia, int dread, float studgood, float minchrom, int kmin, float histmin, float histmax, AWBMode aWBMode) override;
-    void itcwb_alg_toggled ();
     void itcwb_prim_changed ();
     void setAdjusterBehavior (bool tempadd, bool greenadd, bool equaladd, bool tempbiasadd);
     void trimValues          (rtengine::procparams::ProcParams* pp) override;

--- a/rtgui/widgets/basic/adjuster.cc
+++ b/rtgui/widgets/basic/adjuster.cc
@@ -69,8 +69,7 @@ Adjuster::Adjuster(
     logPivot(0),
     logAnchorMiddle(false),
     value2slider(value2slider ? value2slider : &one2one),
-    slider2value(slider2value ? slider2value : &one2one),
-    autoEnableTool(true)
+    slider2value(slider2value ? slider2value : &one2one)
 {
     set_hexpand(true);
     set_vexpand(false);
@@ -662,22 +661,9 @@ AdjusterListener* Adjuster::getAdjusterListener() const
 {
     return adjusterListener;
 }
-void Adjuster::setAutoEnableTool(bool autoEnable)
+FoldableToolPanel* Adjuster::getToolPanel() const
 {
-    autoEnableTool = autoEnable;
-}
-bool Adjuster::getAutoEnableTool() const
-{
-    return autoEnableTool;
-}
-void Adjuster::tryEnableTool()
-{
-    if (!autoEnableTool || !adjusterListener) {
-        return;
-    }
-    if (auto* foldablePanel = dynamic_cast<FoldableToolPanel*>(adjusterListener)) {
-        foldablePanel->enableTool();
-    }
+    return dynamic_cast<FoldableToolPanel*>(adjusterListener);
 }
 double Adjuster::getValue() const
 {

--- a/rtgui/widgets/basic/adjuster.cc
+++ b/rtgui/widgets/basic/adjuster.cc
@@ -257,6 +257,7 @@ void Adjuster::autoToggled ()
 {
 
     if (adjusterListener && !blocked) {
+        tryEnableTool();
         adjusterListener->adjusterAutoToggled(this, automatic->get_active());
     }
 }

--- a/rtgui/widgets/basic/adjuster.cc
+++ b/rtgui/widgets/basic/adjuster.cc
@@ -25,6 +25,7 @@
 #include "options.h"
 #include "rtimage.h"
 #include "rtscalable.h"
+#include "toolpanel.h"
 #include "rtengine/rt_math.h"
 
 namespace {
@@ -68,8 +69,8 @@ Adjuster::Adjuster(
     logPivot(0),
     logAnchorMiddle(false),
     value2slider(value2slider ? value2slider : &one2one),
-    slider2value(slider2value ? slider2value : &one2one)
-
+    slider2value(slider2value ? slider2value : &one2one),
+    autoEnableTool(true)
 {
     set_hexpand(true);
     set_vexpand(false);
@@ -380,6 +381,7 @@ void Adjuster::spinChanged()
             if (automatic) {
                 setAutoValue(false);
             }
+            tryEnableTool();
             adjusterListener->adjusterChanged(this, spin->get_value());
         }
     }
@@ -404,6 +406,7 @@ void Adjuster::sliderChanged ()
             if (automatic) {
                 setAutoValue(false);
             }
+            tryEnableTool();
             adjusterListener->adjusterChanged(this, spin->get_value());
         }
     }
@@ -447,6 +450,7 @@ bool Adjuster::notifyListener ()
         if (automatic) {
             setAutoValue(false);
         }
+        tryEnableTool();
         adjusterListener->adjusterChanged(this, spin->get_value());
     }
 
@@ -538,6 +542,7 @@ void Adjuster::editedToggled ()
         if (automatic) {
             setAutoValue(false);
         }
+        tryEnableTool();
         adjusterListener->adjusterChanged(this, spin->get_value());
     }
 }
@@ -653,7 +658,27 @@ void Adjuster::setAdjusterListener (AdjusterListener* alistener)
 {
     adjusterListener = alistener;
 }
-
+AdjusterListener* Adjuster::getAdjusterListener() const
+{
+    return adjusterListener;
+}
+void Adjuster::setAutoEnableTool(bool autoEnable)
+{
+    autoEnableTool = autoEnable;
+}
+bool Adjuster::getAutoEnableTool() const
+{
+    return autoEnableTool;
+}
+void Adjuster::tryEnableTool()
+{
+    if (!autoEnableTool || !adjusterListener) {
+        return;
+    }
+    if (auto* foldablePanel = dynamic_cast<FoldableToolPanel*>(adjusterListener)) {
+        foldablePanel->enableTool();
+    }
+}
 double Adjuster::getValue() const
 {
     return shapeValue(spin->get_value());

--- a/rtgui/widgets/basic/adjuster.h
+++ b/rtgui/widgets/basic/adjuster.h
@@ -75,7 +75,8 @@ protected:
 
     double getSliderValue() const;
     void setSliderValue(double val);
-
+    bool autoEnableTool;
+    void tryEnableTool();
 public:
     Adjuster(
         Glib::ustring vlabel,
@@ -101,6 +102,9 @@ public:
     void setAutoInconsistent(bool i);
     bool getAutoInconsistent() const;
     void setAdjusterListener(AdjusterListener* alistener);
+    AdjusterListener* getAdjusterListener() const;
+    void setAutoEnableTool(bool autoEnable);
+    bool getAutoEnableTool() const;
     // return the value trimmed to the limits at construction time
     double getValue() const;
     // return the value trimmed to the limits at construction time

--- a/rtgui/widgets/basic/adjuster.h
+++ b/rtgui/widgets/basic/adjuster.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <vector>
 #include "editedstate.h"
 #include "delayed.h"
 #include "guiutils.h"
@@ -34,7 +35,7 @@ public:
 
 typedef double(*double2double_fun)(double val);
 
-class Adjuster final : public Gtk::Grid
+class Adjuster final : public Gtk::Grid, public ToolAutoEnable
 {
 protected:
     Glib::ustring adjustmentName;
@@ -75,8 +76,7 @@ protected:
 
     double getSliderValue() const;
     void setSliderValue(double val);
-    bool autoEnableTool;
-    void tryEnableTool();
+    FoldableToolPanel* getToolPanel() const override;
 public:
     Adjuster(
         Glib::ustring vlabel,
@@ -103,8 +103,6 @@ public:
     bool getAutoInconsistent() const;
     void setAdjusterListener(AdjusterListener* alistener);
     AdjusterListener* getAdjusterListener() const;
-    void setAutoEnableTool(bool autoEnable);
-    bool getAutoEnableTool() const;
     // return the value trimmed to the limits at construction time
     double getValue() const;
     // return the value trimmed to the limits at construction time

--- a/rtgui/widgets/basic/checkbox.cc
+++ b/rtgui/widgets/basic/checkbox.cc
@@ -22,12 +22,15 @@
 #include "multilangmgr.h"
 #include "checkbox.h"
 #include "guiutils.h"
+#include "toolpanel.h"
 
 CheckBox::CheckBox (Glib::ustring label, bool const& multiImageVal)
     : Gtk::CheckButton (label)
+    , ToolAutoEnable()
     , listener (nullptr)
     , lastActive (false)
     , multiImage (multiImageVal)
+    , enableOnlyWhenActivated (false)
 {
     conn = signal_toggled().connect( sigc::mem_fun(*this, &CheckBox::buttonToggled) );
 }
@@ -51,6 +54,8 @@ void CheckBox::buttonToggled ()
         newValue = get_active () ? CheckValue::on : CheckValue::off;
     }
     setLastActive();
+
+    tryEnableTool();
 
     if (listener) {
         listener->checkBoxToggled(this, newValue);
@@ -152,4 +157,19 @@ bool CheckBox::getEdited ()
 void CheckBox::setCheckBoxListener (CheckBoxListener* cblistener)
 {
     listener = cblistener;
+}
+
+FoldableToolPanel* CheckBox::getToolPanel() const
+{
+    return dynamic_cast<FoldableToolPanel*>(listener);
+}
+
+bool CheckBox::canEnableTool() const
+{
+    return !enableOnlyWhenActivated || get_active();
+}
+
+void CheckBox::setEnableOnlyWhenActivated (bool onlyWhenActivated)
+{
+    enableOnlyWhenActivated = onlyWhenActivated;
 }

--- a/rtgui/widgets/basic/checkbox.h
+++ b/rtgui/widgets/basic/checkbox.h
@@ -24,6 +24,7 @@
 #include "guiutils.h"
 
 class CheckBox;
+class FoldableToolPanel;
 
 enum class CheckValue {
     on,
@@ -40,17 +41,22 @@ public:
 
 
 /**
- * @brief subclass of Gtk::CheckButton for convenience
+ * @brief subclass of Gtk::CheckButton for convenience with batch editing and auto-enable support
  */
-class CheckBox : public Gtk::CheckButton  // Should ideally be private, but in this case build fail on the instantiation
+class CheckBox : public Gtk::CheckButton, public ToolAutoEnable
 {
 
     CheckBoxListener *listener;
     bool lastActive;
     bool const& multiImage;
+    bool enableOnlyWhenActivated;
     sigc::connection conn;
     void buttonToggled ();
     void setLastActive();
+
+protected:
+    FoldableToolPanel* getToolPanel() const override;
+    bool canEnableTool() const override;
 
 public:
     //using CheckButton::CheckButton;
@@ -64,6 +70,7 @@ public:
     Glib::ustring getValueAsStr ();
 
     void setCheckBoxListener (CheckBoxListener* cblistener);
+    void setEnableOnlyWhenActivated (bool onlyWhenActivated);
 
     /* Used if the Gtk::CheckButton parent class can be private
      *

--- a/rtgui/widgets/basic/thresholdadjuster.cc
+++ b/rtgui/widgets/basic/thresholdadjuster.cc
@@ -24,6 +24,7 @@
 #include "options.h"
 #include "guiutils.h"
 #include "rtimage.h"
+#include "toolpanel.h"
 
 #define MIN_RESET_BUTTON_HEIGHT 17
 
@@ -77,9 +78,7 @@ void ThresholdAdjuster::initObject (Glib::ustring label, bool editedcb)
     adjusterListener = nullptr;
     afterReset = false;
     blocked = false;
-
     addMode = false;
-
     delay = App::get().options().adjusterMinDelay;
 
     set_name("ThresholdAdjuster");
@@ -193,6 +192,7 @@ void ThresholdAdjuster::selectorChanged ()
 
     if (delay == 0) {
         if (adjusterListener && !blocked) {
+            tryEnableTool();
             sendToListener ();
         }
     } else {
@@ -264,6 +264,7 @@ bool ThresholdAdjuster::notifyListener ()
 
     if (adjusterListener != nullptr && !blocked) {
         GThreadLock lock;
+        tryEnableTool();
         sendToListener();
     }
 
@@ -370,6 +371,10 @@ void ThresholdAdjuster::set_tooltip_markup(const Glib::ustring& markup)
 void ThresholdAdjuster::set_tooltip_text(const Glib::ustring& text)
 {
     tSelector.set_tooltip_text(text);
+}
+FoldableToolPanel* ThresholdAdjuster::getToolPanel() const
+{
+    return dynamic_cast<FoldableToolPanel*>(adjusterListener);
 }
 
 /* For better readability, this method create the history string of the parameter column,

--- a/rtgui/widgets/basic/thresholdadjuster.h
+++ b/rtgui/widgets/basic/thresholdadjuster.h
@@ -46,7 +46,7 @@ public:
 };
 
 
-class ThresholdAdjuster : public Gtk::Box
+class ThresholdAdjuster : public Gtk::Box, public ToolAutoEnable
 {
 
 protected:
@@ -70,6 +70,7 @@ protected:
     bool separatedMode;
     int delay;
 
+    FoldableToolPanel* getToolPanel() const override;
     double shapeValue (double a);
     void refreshLabelStyle ();
     void initObject (Glib::ustring label, bool editedcb);

--- a/rtgui/widgets/curves/curveeditorgroup.cc
+++ b/rtgui/widgets/curves/curveeditorgroup.cc
@@ -33,7 +33,7 @@
 #include "widgets/basic/popuptogglebutton.h"
 
 CurveEditorGroup::CurveEditorGroup (Glib::ustring& curveDir, const Glib::ustring& groupLabel, int blank) : curveDir(curveDir), line(0), curve_reset(nullptr),
-    displayedCurve(nullptr), flatSubGroup(nullptr), diagonalSubGroup(nullptr), cl(nullptr), numberOfPackedCurve(0), autoEnableTool(true)
+    displayedCurve(nullptr), flatSubGroup(nullptr), diagonalSubGroup(nullptr), cl(nullptr), numberOfPackedCurve(0)
 {
 
     // We set the label to the one provided as parameter, even if it's an empty string
@@ -553,20 +553,7 @@ Glib::ustring CurveEditorSubGroup::inputFile ()
     fname = "";
     return fname;
 }
-void CurveEditorGroup::setAutoEnableTool(bool autoEnable)
+FoldableToolPanel* CurveEditorGroup::getToolPanel() const
 {
-    autoEnableTool = autoEnable;
-}
-bool CurveEditorGroup::getAutoEnableTool() const
-{
-    return autoEnableTool;
-}
-void CurveEditorGroup::tryEnableTool()
-{
-    if (!autoEnableTool || !cl) {
-        return;
-    }
-    if (auto* foldablePanel = dynamic_cast<FoldableToolPanel*>(cl)) {
-        foldablePanel->enableTool();
-    }
+    return dynamic_cast<FoldableToolPanel*>(cl);
 }

--- a/rtgui/widgets/curves/curveeditorgroup.cc
+++ b/rtgui/widgets/curves/curveeditorgroup.cc
@@ -29,10 +29,11 @@
 #include "pathutils.h"
 #include "rtimage.h"
 #include "rtscalable.h"
+#include "toolpanel.h"
 #include "widgets/basic/popuptogglebutton.h"
 
 CurveEditorGroup::CurveEditorGroup (Glib::ustring& curveDir, const Glib::ustring& groupLabel, int blank) : curveDir(curveDir), line(0), curve_reset(nullptr),
-    displayedCurve(nullptr), flatSubGroup(nullptr), diagonalSubGroup(nullptr), cl(nullptr), numberOfPackedCurve(0)
+    displayedCurve(nullptr), flatSubGroup(nullptr), diagonalSubGroup(nullptr), cl(nullptr), numberOfPackedCurve(0), autoEnableTool(true)
 {
 
     // We set the label to the one provided as parameter, even if it's an empty string
@@ -231,6 +232,7 @@ void CurveEditorGroup::typeSelectionChanged (CurveEditor* ce, int n)
         if (n == ce->subGroup->valLinear || n == ce->subGroup->valUnchanged) {
             // Since we do not activate the curve when the user switch the toggled off button to 'Linear', we have to
             // to call the curve listener manually, because 'curveChanged' uses displayedCurve...
+            tryEnableTool();
             if (cl) {
                 if (cl->isMulti()) {
                     cl->curveChanged (ce);
@@ -336,7 +338,7 @@ void CurveEditorGroup::curveChanged ()
 {
 
     displayedCurve->subGroup->storeDisplayedCurve();
-
+    tryEnableTool();
     if (cl) {
         if (cl->isMulti()) {
             cl->curveChanged (displayedCurve);
@@ -550,4 +552,21 @@ Glib::ustring CurveEditorSubGroup::inputFile ()
 
     fname = "";
     return fname;
+}
+void CurveEditorGroup::setAutoEnableTool(bool autoEnable)
+{
+    autoEnableTool = autoEnable;
+}
+bool CurveEditorGroup::getAutoEnableTool() const
+{
+    return autoEnableTool;
+}
+void CurveEditorGroup::tryEnableTool()
+{
+    if (!autoEnableTool || !cl) {
+        return;
+    }
+    if (auto* foldablePanel = dynamic_cast<FoldableToolPanel*>(cl)) {
+        foldablePanel->enableTool();
+    }
 }

--- a/rtgui/widgets/curves/curveeditorgroup.h
+++ b/rtgui/widgets/curves/curveeditorgroup.h
@@ -63,7 +63,8 @@ protected:
     CurveListener* cl;
 
     unsigned int numberOfPackedCurve;
-
+    bool autoEnableTool;
+    void tryEnableTool();
 public:
     /**
      * @param curveDir The folder used by load and save dialogs for the curve.
@@ -81,6 +82,12 @@ public:
     {
         cl = l;
     }
+    CurveListener* getCurveListener() const
+    {
+        return cl;
+    }
+    void setAutoEnableTool(bool autoEnable);
+    bool getAutoEnableTool() const;
     void setTooltip (Glib::ustring ttip);
     CurveEditor* getDisplayedCurve ()
     {

--- a/rtgui/widgets/curves/curveeditorgroup.h
+++ b/rtgui/widgets/curves/curveeditorgroup.h
@@ -29,6 +29,7 @@
 
 #include <fstream>
 #include <string>
+#include <vector>
 
 class CurveEditor;
 class DiagonalCurveEditorSubGroup;
@@ -40,7 +41,7 @@ class FlatCurveEditorSubGroup;
  * - to start a new line of curve button, use the 'newLine' method
  * - if you add more than one curve, you must add a "CurveEditor* ce" parameter to your listener
  */
-class CurveEditorGroup final : public Gtk::Grid, public CurveListener
+class CurveEditorGroup final : public Gtk::Grid, public CurveListener, public ToolAutoEnable
 {
 
     friend class CurveEditor;
@@ -63,8 +64,7 @@ protected:
     CurveListener* cl;
 
     unsigned int numberOfPackedCurve;
-    bool autoEnableTool;
-    void tryEnableTool();
+    FoldableToolPanel* getToolPanel() const override;
 public:
     /**
      * @param curveDir The folder used by load and save dialogs for the curve.
@@ -86,8 +86,6 @@ public:
     {
         return cl;
     }
-    void setAutoEnableTool(bool autoEnable);
-    bool getAutoEnableTool() const;
     void setTooltip (Glib::ustring ttip);
     CurveEditor* getDisplayedCurve ()
     {


### PR DESCRIPTION
## Summary

This PR implements automatic tool enabling when users interact with disabled tools, improving workflow by eliminating the need to manually toggle tools on before adjusting their parameters. When users interact with sliders, curves, grids, or other controls in a disabled tool, the tool automatically enables itself.

## Motivation

The current workflow requires users to first enable a tool before they can adjust its parameters. This creates an unnecessary extra step and can create confusion. Auto-enable on user input is the default behavior in other raw editors including Darktable, Lightroom, and Nikon NX Studio, and is standard in editing software, which creates frustrated expectations for new users of RawTherapee.

## Scope

- ✅ **Fully implemented:** Exposure, Detail, and Color tabs
- ⚠️ **Partial:** Advanced tab (most tools work, Wavelet requires additional work)
- ❌ **Not included:** Local Editing and Raw tabs (future work)

## Changes

### Technical Implementation

The core implementation strategy consists of creating the `tryEnableTool` method on the Adjuster object, which is the main user input across all the different tools. Every time an Adjuster is changed, it will check if the parent tool is disabled and enable if necessary. A method to ignore this behavior is implemented for special cases.

The same method is applied for the LabGrid and Curves objects, which operate similarly.

Per-tool implementation to deal with non-conventional input was also applied for all tools in the Exposure, Detail, and Color tabs. Most tools in the Advanced tab work correctly, but Wavelet will need additional work. Local Editing and Raw tabs were not tested.

In general, I avoided auto-enabling the tool if the input was just a setting that has no practical effect alone, such as the choice of a color space, but I believe this needs more testing.

**Core Infrastructure:**
- Implemented auto-enable logic in `Adjuster` widget (used extensively across tools)
- Added auto-enable support to `CurveEditorGroup` for all curve-based controls
- Implemented auto-enable in `LabGrid` for color/tone grid interactions
- Provided `setAutoEnableTool()` method to allow disabling the behavior per-widget
- Special case handling for many tools

**Tool-Specific Implementations:**
- **FilmSimulation:** Enables when selecting a CLUT profile
- **FilmNegative:** Enables when clicking to pick reference spots
- **Gradient:** Enables when activating edit mode
- **Spot:** Enables when entering edit mode
- **ColorToning:** Enables when activating "Show Mask" mode
- **Dehaze:** Enables when activating "Show Depth Map"
- **DirPyrEqualizer:** Enables when using contrast adjustment buttons
- **ToneEqualizer:** Enables when toggling colormap visualization

**Special Cases:**
- Some widgets explicitly disable auto-enable where the behavior would be undesirable (e.g., `rstprotection` in LCurve)

**Files Modified:**
- `rtgui/toolpanel.h` / `rtgui/toolpanel.cc` - Added enableTool() method
- `rtgui/widgets/basic/adjuster.h` / `rtgui/widgets/basic/adjuster.cc` - Implemented auto-enable logic
- `rtgui/widgets/curves/curveeditorgroup.h` / `rtgui/widgets/curves/curveeditorgroup.cc` - Added curve auto-enable
- `rtgui/labgrid.h` / `rtgui/labgrid.cc` - Implemented grid auto-enable with parent tool reference
- `rtgui/tools/colortoning.cc` - Integrated with LabGrid and show mask button
- `rtgui/tools/dehaze.cc` - Auto-enable on show depth map
- `rtgui/tools/dirpyrequalizer.cc` - Auto-enable on contrast buttons
- `rtgui/tools/filmnegative.cc` - Auto-enable on spot picking
- `rtgui/tools/filmsimulation.h` / `rtgui/tools/filmsimulation.cc` - Auto-enable on CLUT selection
- `rtgui/tools/gradient.cc` - Auto-enable on edit mode activation
- `rtgui/tools/labcurve.cc` - Disabled auto-enable for rstprotection adjuster
- `rtgui/tools/spot.cc` - Auto-enable on edit mode activation
- `rtgui/tools/toneequalizer.cc` - Auto-enable on colormap toggle

## Testing Performed

- Verified tools auto-enable when adjusting sliders/curves/grids while disabled
- Confirmed no auto-enable occurs when explicitly disabled via `setAutoEnableTool(false)`
- Tested all modified tools to ensure proper enabling behavior
- Verified no interference with normal enabled tool operation
- Confirmed edit mode activation properly enables respective tools
- Tested special visualization modes (show mask, show depth map, colormap) trigger enabling

## User Experience

**Before:**
- User must click to enable tool before adjusting any parameters
- Two-step process: enable, then adjust

**After:**
- User can directly interact with any tool control
- Tool automatically enables on first interaction

## Compatibility

Should be backward compatible, extent of tool affected demands testing.