### PR TITLE
Fixes issues related to thumbnail generation firstpass

### DIFF
--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -141,15 +141,16 @@ public:
         if (--nConcurrentThreads == 0) {
             std::lock_guard<std::mutex> lock(mutex_);
 
-            if (!jobs_removed_ && jobs_.empty()) {
+            if (!jobs_removed_ && !nConcurrentThreads && jobs_.empty()) {
+                // re-check nConcurrentThreads under mutex because it is possible for another
+                // thread to race to take the last job from jobs_ and to avoid double call to
+                // previewsFinished when that happens
                 notifyListener = true;    
             }
             inactive_.notify_all();
         }
 
-        if (notifyListener && !nConcurrentThreads) {
-            // As long as the upper if (--nConcurrentThreads == 0) { is executed outside of mutex,
-            // it will always be a rare possibility that the previewsFinished is called twice
+        if (notifyListener) {
             DEBUG("Previews Finished\n");
             j.listener_->previewsFinished(j.dir_id_);
         }

--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -92,7 +92,7 @@ public:
     std::atomic<int> nConcurrentThreads;
 
     // Need to be a std::mutex because used in a std::condition_variable object...
-    // This is the only exception along with ThumbImageUpdater and GThreadMutex (guiutils.cc), MyMutex is used everywhere else
+    // This is the only exception besides ThumbImageUpdater and GThreadMutex (guiutils.cc). MyMutex is used everywhere else
     std::mutex mutex_;
     bool jobs_removed_;
 
@@ -115,7 +115,7 @@ public:
             j = *jobs_.begin();
             jobs_.erase(jobs_.begin());
             DEBUG("processing %s", j.dir_entry_.c_str());
-            DEBUG("%d job(s) remaining", jobs_.size());
+            DEBUG("%ld job(s) remaining", jobs_.size());
 
             nConcurrentThreads++; // to detect when last thread in pool has run out
         }
@@ -147,7 +147,10 @@ public:
             inactive_.notify_all();
         }
 
-        if (notifyListener) {
+        if (notifyListener && !nConcurrentThreads) {
+            // As long as the upper if (--nConcurrentThreads == 0) { is executed outside of mutex,
+            // it will always be a rare possibility that the previewsFinished is called twice
+            DEBUG("Previews Finished\n");
             j.listener_->previewsFinished(j.dir_id_);
         }
     }
@@ -189,7 +192,7 @@ void PreviewLoader::add(int dir_id, const Glib::ustring& dir_entry, PreviewLoade
 
 void PreviewLoader::removeAllJobs()
 {
-    DEBUG("stop %d", impl_->nConcurrentThreads);
+    DEBUG("stop %d", impl_->nConcurrentThreads.load());
 
     std::unique_lock<std::mutex> lock(impl_->mutex_);
     impl_->jobs_.clear();

--- a/rtgui/previewloader.cc
+++ b/rtgui/previewloader.cc
@@ -17,13 +17,15 @@
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
 #include <memory>
 #include <set>
 #include "cachemanager.h"
 #include "filebrowserentry.h"
 #include "previewloader.h"
 #include "guiutils.h"
-#include "threadutils.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -52,15 +54,7 @@ public:
         Glib::ustring dir_entry_;
         PreviewLoaderListener* listener_;
     };
-    /* Issue 2406
-        struct OutputJob
-        {
-            bool complete;
-            int dir_id;
-            PreviewLoaderListener* listener;
-            FileBrowserEntry* fdn;
-        };
-    */
+
     struct JobCompare {
         bool operator()(const Job& lhs, const Job& rhs) const
         {
@@ -74,7 +68,9 @@ public:
 
     typedef std::set<Job, JobCompare> JobSet;
 
-    Impl(): nConcurrentThreads(0)
+    Impl(): 
+        nConcurrentThreads(0),
+        jobs_removed_(false)
     {
 #ifdef _OPENMP
         int threadCount = omp_get_num_procs();
@@ -83,20 +79,31 @@ public:
 #endif
 
         threadPool_.reset(new Glib::ThreadPool(threadCount, 0));
+
+        if (App::get().options().rtSettings.verbose) {
+            printf("PreviewLoader::Impl pool thread count is %d\n", threadCount);
+            printf("PreviewLoader::Impl nConcurrentThreads is ");
+            printf(nConcurrentThreads.is_lock_free() ? "lock free\n" : "not lock free\n");
+        }
     }
 
     std::unique_ptr<Glib::ThreadPool> threadPool_;
-    MyMutex mutex_;
     JobSet jobs_;
-    gint nConcurrentThreads;
-// Issue 2406   std::vector<OutputJob *> output_;
+    std::atomic<int> nConcurrentThreads;
+
+    // Need to be a std::mutex because used in a std::condition_variable object...
+    // This is the only exception along with ThumbImageUpdater and GThreadMutex (guiutils.cc), MyMutex is used everywhere else
+    std::mutex mutex_;
+    bool jobs_removed_;
+
+    std::condition_variable inactive_;
 
     void processNextJob()
     {
         Job j;
-// Issue 2406       OutputJob *oj;
+    
         {
-            MyMutex::MyLock lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
 
             // nothing to do; could be jobs have been removed
             if ( jobs_.empty() ) {
@@ -109,21 +116,11 @@ public:
             jobs_.erase(jobs_.begin());
             DEBUG("processing %s", j.dir_entry_.c_str());
             DEBUG("%d job(s) remaining", jobs_.size());
-            /* Issue 2406
-                        oj = new OutputJob();
-                        oj->complete = false;
-                        oj->dir_id = j.dir_id_;
-                        oj->listener = j.listener_;
-                        oj->fdn = 0;
-                        output_.push_back(oj);
-            */
+
+            nConcurrentThreads++; // to detect when last thread in pool has run out
         }
 
-        g_atomic_int_inc (&nConcurrentThreads);  // to detect when last thread in pool has run out
-
-        // unlock and do processing; will relock on block exit, then call listener
-        // if something got
-// Issue 2406       FileBrowserEntry* fdn = 0;
+        // do processing unlocked
         try {
             Thumbnail* tmb = nullptr;
             {
@@ -135,32 +132,22 @@ public:
             if ( tmb ) {
                 DEBUG("Preview Ready\n");
                 j.listener_->previewReady(j.dir_id_, new FileBrowserEntry(tmb, j.dir_entry_));
-// Issue 2406               fdn = new FileBrowserEntry(tmb,j.dir_entry_);
             }
 
         } catch (Glib::Error &e) {} catch(...) {}
 
-        /* Issue 2406
-                {
-                    // the purpose of the output_ vector is to deliver the previewReady() calls in the same
-                    // order as we got the jobs from the jobs_ queue.
-                    MyMutex::MyLock lock(mutex_);
-                    oj->fdn = fdn;
-                    oj->complete = true;
-                    while (output_.size() > 0 && output_.front()->complete) {
-                        oj = output_.front();
-                        if (oj->fdn) {
-                            oj->listener->previewReady(oj->dir_id,oj->fdn);
-                        }
-                        output_.erase(output_.begin());
-                        delete oj;
-                    }
-                }
-        */
-        bool last = g_atomic_int_dec_and_test (&nConcurrentThreads);
+        bool notifyListener = false;
 
-        // signal at end
-        if (last && jobs_.empty()) {
+        if (--nConcurrentThreads == 0) {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            if (!jobs_removed_ && jobs_.empty()) {
+                notifyListener = true;    
+            }
+            inactive_.notify_all();
+        }
+
+        if (notifyListener) {
             j.listener_->previewsFinished(j.dir_id_);
         }
     }
@@ -171,7 +158,8 @@ PreviewLoader::PreviewLoader():
 {
 }
 
-PreviewLoader::~PreviewLoader() {
+PreviewLoader::~PreviewLoader()
+{
     delete impl_;
 }
 
@@ -186,7 +174,7 @@ void PreviewLoader::add(int dir_id, const Glib::ustring& dir_entry, PreviewLoade
     // somebody listening?
     if ( l != nullptr ) {
         {
-            MyMutex::MyLock lock(impl_->mutex_);
+            std::lock_guard<std::mutex> lock(impl_->mutex_);
 
             // create a new job and append to queue
             DEBUG("saving job %s", dir_entry.c_str());
@@ -202,8 +190,17 @@ void PreviewLoader::add(int dir_id, const Glib::ustring& dir_entry, PreviewLoade
 void PreviewLoader::removeAllJobs()
 {
     DEBUG("stop %d", impl_->nConcurrentThreads);
-    MyMutex::MyLock lock(impl_->mutex_);
+
+    std::unique_lock<std::mutex> lock(impl_->mutex_);
     impl_->jobs_.clear();
+
+    if (impl_->nConcurrentThreads.load() != 0) {
+        DEBUG("waiting for running jobs2");
+
+        impl_->jobs_removed_ = true;
+        impl_->inactive_.wait(lock, [this] { return impl_->nConcurrentThreads.load() == 0; });
+        impl_->jobs_removed_ = false;
+    }
 }
 
 

--- a/rtgui/thumbimageupdater.cc
+++ b/rtgui/thumbimageupdater.cc
@@ -90,7 +90,7 @@ public:
     std::unique_ptr<Glib::ThreadPool> threadPool_;
 
     // Need to be a std::mutex because used in a std::condition_variable object...
-    // This is the only exceptions along with GThreadMutex (guiutils.cc), MyMutex is used everywhere else
+    // This is the only exception along with PreviewLoader and GThreadMutex (guiutils.cc), MyMutex is used everywhere else
     std::mutex mutex_;
 
     JobList jobs_;

--- a/rtgui/thumbimageupdater.cc
+++ b/rtgui/thumbimageupdater.cc
@@ -90,7 +90,7 @@ public:
     std::unique_ptr<Glib::ThreadPool> threadPool_;
 
     // Need to be a std::mutex because used in a std::condition_variable object...
-    // This is the only exception along with PreviewLoader and GThreadMutex (guiutils.cc), MyMutex is used everywhere else
+    // This is the only exception besides PreviewLoader and GThreadMutex (guiutils.cc). MyMutex is used everywhere else
     std::mutex mutex_;
 
     JobList jobs_;


### PR DESCRIPTION
### The issues
The thumbnail firstpass generation has two issues:
1. The previewsFinished is not always called
2. Rare condition when the program  segmentation faults when closed while the first pass is still working
3. There is a race condition reading the jobs_empty() in PreviewLoader::processNextJob()

### Steps to reproduce 1
1. Open directory with sufficient amount of files
2. While the File Browser is populating, switch to a directory with small amount of files
4. Observe the status bar does not update correctly.

The small directory needs to be small enough. If there is sufficient amount of files, the bug doesn't trigger. I have made a screen capturing of the bug: https://www.youtube.com/watch?v=b1gy6C6yhZY

### Steps to reproduce 2
1. Delete files from _~/.cache/RawTherapee/images/_ but leave the _data_ directory alone. This will trick the first pass into generating fully processed thumbnails.
2. Open directory with sufficient amount of previously cached images with processing profiles (pp3)
3. Close RawTherapee before the File Browser populates to full

I haven't been able to trigger the segfault when the program creates quick thumbnails. It can be, that there is segfault only when the first pass generates fully processed thumbnails. I don't know the exact segfault mechanism.

### Bug description
Both issues are happening because the `void PreviewLoader::removeAllJobs()` is not waiting for the already started jobs to finish before returning.

### Solution
I copied the logic that waits for the background jobs to finish from the `ThumbImageUpdater::removeAllJobs`.

### Potential adverse effects
The solution shouldn't give much adverse effects. The adverse effects means users waiting for the program. The solution does add wait times when the current directory is closed while the File Browser is populating. This can happen when the user chooses another directory or toggles recursive directories. However, normally the first pass is creating quick thumbnails and the added delay should be minimal. When the delay becomes significant is, when the first pass is generating fully processed thumbnails. As far as I know, that is abnormal behavior from the program.

Also, currently I have not been able to trigger segfaults outside of the sequence to close the program. On the other hand, not waiting the first pass to finish before continuing while the first pass has the potential to segfault may become problematic in the future because of some unrelated changes to thumbnails or otherwise.