### PR TITLE
Disables updates to the batch editor when the "Batch Edit" right hand panel tab is not selected.

### DIFF
--- a/rtgui/batchtoolpanelcoord.cc
+++ b/rtgui/batchtoolpanelcoord.cc
@@ -30,7 +30,7 @@
 
 using namespace rtengine::procparams;
 
-BatchToolPanelCoordinator::BatchToolPanelCoordinator (FilePanel* parent) : ToolPanelCoordinator(true), somethingChanged(false), parent(parent)
+BatchToolPanelCoordinator::BatchToolPanelCoordinator (FilePanel* parent) : active(false), ToolPanelCoordinator(true), somethingChanged(false), parent(parent)
 {
 
     blockedUpdate = false;
@@ -643,13 +643,22 @@ void BatchToolPanelCoordinator::getCamWB (double& temp, double& green, rtengine:
 
 void BatchToolPanelCoordinator::optionsChanged ()
 {
+    if (!active) return;
 
     closeSession ();
     initSession ();
 }
 
+void BatchToolPanelCoordinator::enableAutoUpdate ()
+{
+    active = true;
+    closeSession (false);
+    initSession ();
+}
+
 void BatchToolPanelCoordinator::procParamsChanged (Thumbnail* thm, int whoChangedIt, bool upgradeHint)
 {
+    if (!active) return;
 
     if (whoChangedIt != BATCHEDITOR && !blockedUpdate) {
         closeSession (false);
@@ -659,6 +668,7 @@ void BatchToolPanelCoordinator::procParamsChanged (Thumbnail* thm, int whoChange
 
 void BatchToolPanelCoordinator::beginBatchPParamsChange (int numberOfEntries)
 {
+    if (!active) return;
 
     blockedUpdate = true;
 
@@ -670,6 +680,8 @@ void BatchToolPanelCoordinator::beginBatchPParamsChange (int numberOfEntries)
 // The end of a batch pparams change triggers a close/initsession
 void BatchToolPanelCoordinator::endBatchPParamsChange()
 {
+    if (!active) return;
+
     //printf("BatchToolPanelCoordinator::endBatchPParamsChange  /  Nouvelle session!\n");
     closeSession (false);
     initSession ();
@@ -690,6 +702,8 @@ void BatchToolPanelCoordinator::profileChange(
     bool fromLastSave
 )
 {
+    if (!active) return;
+
     if (event == rtengine::EvProfileChanged) {
         // a profile has been selected in a hypothetical Profile panel
         // -> ACTUALLY NOT SUPPORTED

--- a/rtgui/batchtoolpanelcoord.cc
+++ b/rtgui/batchtoolpanelcoord.cc
@@ -668,8 +668,6 @@ void BatchToolPanelCoordinator::procParamsChanged (Thumbnail* thm, int whoChange
 
 void BatchToolPanelCoordinator::beginBatchPParamsChange (int numberOfEntries)
 {
-    if (!active) return;
-
     blockedUpdate = true;
 
     if (numberOfEntries > 50) { // Arbitrary amount
@@ -680,11 +678,11 @@ void BatchToolPanelCoordinator::beginBatchPParamsChange (int numberOfEntries)
 // The end of a batch pparams change triggers a close/initsession
 void BatchToolPanelCoordinator::endBatchPParamsChange()
 {
-    if (!active) return;
-
-    //printf("BatchToolPanelCoordinator::endBatchPParamsChange  /  Nouvelle session!\n");
-    closeSession (false);
-    initSession ();
+    if (active) {
+        //printf("BatchToolPanelCoordinator::endBatchPParamsChange  /  Nouvelle session!\n");
+        closeSession (false);
+        initSession ();
+    }
     blockedUpdate = false;
     parent->set_sensitive (true);
 }

--- a/rtgui/batchtoolpanelcoord.cc
+++ b/rtgui/batchtoolpanelcoord.cc
@@ -30,10 +30,10 @@
 
 using namespace rtengine::procparams;
 
-BatchToolPanelCoordinator::BatchToolPanelCoordinator (FilePanel* parent) : active(false), ToolPanelCoordinator(true), somethingChanged(false), parent(parent)
+BatchToolPanelCoordinator::BatchToolPanelCoordinator (FilePanel* parent) : ToolPanelCoordinator(true), active(false), somethingChanged(false), parent(parent)
 {
-
     blockedUpdate = false;
+
     if (toolBar) {
         toolBar->setBatchMode ();
     }

--- a/rtgui/batchtoolpanelcoord.h
+++ b/rtgui/batchtoolpanelcoord.h
@@ -34,6 +34,8 @@ class BatchToolPanelCoordinator final :
     public BatchPParamsChangeListener,
     public ThumbnailListener
 {
+private:
+    bool active;
 protected:
     rtengine::procparams::ProcParams pparams;
     ParamsEdited pparamsEdited;
@@ -86,4 +88,10 @@ public:
     CropGUIListener* startCropEditing (Thumbnail* thm = nullptr) override;
 
     void optionsChanged ();
+
+    void enableAutoUpdate ();
+    void disableAutoUpdate ()
+    {
+        active = false;
+    }
 };

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -240,6 +240,12 @@ void FilePanel::on_NB_switch_page(Gtk::Widget* page, guint page_num)
         // switching the inspector "off"
         fileCatalog->disableInspector();
     }
+    if (page_num == 2) {
+        // Batch Edit
+        tpc->enableAutoUpdate();
+    } else {
+        tpc->disableAutoUpdate();
+    }
 }
 
 bool FilePanel::fileSelected (Thumbnail* thm)

--- a/rtgui/filepanel.cc
+++ b/rtgui/filepanel.cc
@@ -240,7 +240,7 @@ void FilePanel::on_NB_switch_page(Gtk::Widget* page, guint page_num)
         // switching the inspector "off"
         fileCatalog->disableInspector();
     }
-    if (page_num == 2) {
+    if (page == tpcPaned) {
         // Batch Edit
         tpc->enableAutoUpdate();
     } else {


### PR DESCRIPTION
This PR disables the updates to the Batch editor, when the user is not using it.

Fixes #7526

Steps to reproduce:
1. Select enough images. This depends on the processing power in your system.
2. Clear processing profiles from those images.
3. Apply processing profile. Bundled profiles are good for this.
4. Observe the UI is unresponsive until all thumbnails have been updated.

Usually subsequent calls to apply processing profiles are fast.

### The issue
The call that updates the Batch editor tools does extensive calls to the thumbnails that are being processed. These thumbnails are mutexed and sometimes those mutexes cause performance issues and can even lock the UI to wait until all thumbnails the Batch editor is tracking get their updates finished.

Originally I started to implement optimization to the `void BatchToolPanelCoordinator::endBatchPParamsChange()`. However, I noticed that all updates that are done to the Batch editor tools are implemented with a pair of
```
closeSession (false);
initSession ();
```
calls.

They should all be optimized for the purpose and the safest way to do this work is to do them all in one go as it will be easier to debug and understand the entire Batch editor concept with user patterns.

However, it is not desirable that users who are not using the Batch editor, need to suffer performance penalties and UI locks caused by it. Therefore, I'm proposing this PR to disable the update functionality while the Batch editor is presumably not used by the user.

### Important note
It is important to note, that until the `Thumbnail`s memory management is made safer (with a std::shared_ptr or otherwise), it is important to allow the `BatchToolPanelCoordinator` to register references to the `Thumbnail`s. There are cases, when that can be the only reference keeping the Thumbnail safe from getting deleted while the program is moving the `Thumbnail` pointers around.

### Related
In the issue #7565, while this will not fix the possible problems with OMP threads,  you can see in the provided Youtube video, the UI gets locked up. I believe, that could have been caused by this exact issue as the image processing is all done in the worker threads.