### PR TITLE
Fixes an issue when adding empty directory to profiles directory messes up profile menus.

### DIFF
--- a/rtengine/profilestore.cc
+++ b/rtengine/profilestore.cc
@@ -218,7 +218,7 @@ bool ProfileStore::parseDir (Glib::ustring& realPath, Glib::ustring& virtualPath
             if (Glib::file_test (fname, Glib::FILE_TEST_IS_DIR)) {
                 Glib::ustring vp (Glib::build_filename (virtualPath, currDir));
                 Glib::ustring rp (Glib::build_filename (realPath,    currDir));
-                fileFound = parseDir (rp, vp, currDir, folder, level + 1, 0);
+                fileFound |= parseDir (rp, vp, currDir, folder, level + 1, 0);
             } else {
                 size_t lastdot = currDir.find_last_of ('.');
 


### PR DESCRIPTION
When the profiles directory is parsed in `bool ProfileStore::parseDir` and an empty directory is found, the `fileFound` boolean is set to false. If this was the last time `fileFound` is updated, the `bool ProfileStore::parseDir` function will accidentally delete the current directory entry even if the function had found files before the last assignment.

Fixes #4929
Maybe fixes #6453, I couldn't reproduce the crash.