### PR TITLE
Backport gtkmm 4 event controllers

### DIFF
--- a/rtgui/CMakeLists.txt
+++ b/rtgui/CMakeLists.txt
@@ -149,6 +149,7 @@ set(NONCLISOURCEFILES
     filepanel.cc
     filethumbnailbuttonset.cc
     filterpanel.cc
+    gtk4.cc
     guiutils.cc
     hidpi.cc
     histogrampanel.cc

--- a/rtgui/gtk4.cc
+++ b/rtgui/gtk4.cc
@@ -1,0 +1,288 @@
+/*
+ *  This file is part of RawTherapee.
+ *
+ *  Copyright (c) 2026 Daniel Gao <daniel.gao.work@gmail.com>
+ *
+ *  RawTherapee is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RawTherapee is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gtk4.h"
+
+#include <gtkmm/widget.h>
+
+namespace rt {
+namespace gtk4 {
+
+Glib::RefPtr<GestureClick> GestureClick::create(Gtk::Widget* widget)
+{
+    return Glib::RefPtr<GestureClick>(new GestureClick(widget));
+}
+
+GestureClick::GestureClick(Gtk::Widget* widget)
+    : Glib::ObjectBase("RtGestureClick"),
+      m_controller(gtk_gesture_multi_press_new(GTK_WIDGET(widget->gobj())))
+{
+    g_signal_connect(GTK_GESTURE_MULTI_PRESS(m_controller), "pressed",
+                     G_CALLBACK(&GestureClick::hook_pressed), this);
+    g_signal_connect(GTK_GESTURE_MULTI_PRESS(m_controller), "released",
+                     G_CALLBACK(&GestureClick::hook_released), this);
+    g_signal_connect(GTK_GESTURE_MULTI_PRESS(m_controller), "stopped",
+                     G_CALLBACK(&GestureClick::hook_stopped), this);
+}
+
+GestureClick::~GestureClick()
+{
+    g_object_unref(m_controller);
+    m_controller = nullptr;
+}
+
+GtkGestureMultiPress* GestureClick::gobj()
+{
+    return GTK_GESTURE_MULTI_PRESS(m_controller);
+}
+
+GtkPropagationPhase GestureClick::get_propagation_phase() const
+{
+    return gtk_event_controller_get_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller));
+}
+
+void GestureClick::set_propagation_phase(GtkPropagationPhase phase)
+{
+    gtk_event_controller_set_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller), phase);
+}
+
+unsigned int GestureClick::get_current_button() const
+{
+    return gtk_gesture_single_get_current_button(GTK_GESTURE_SINGLE(m_controller));
+}
+
+unsigned int GestureClick::get_button() const
+{
+    return gtk_gesture_single_get_button(GTK_GESTURE_SINGLE(m_controller));
+}
+
+void GestureClick::set_button(unsigned int button)
+{
+    return gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(m_controller), button);
+}
+
+void GestureClick::hook_pressed(GtkGestureMultiPress*, gint n_press, gdouble x,
+                                gdouble y, gpointer user_data)
+{
+    static_cast<GestureClick*>(user_data)->m_pressed.emit(n_press, x, y);
+}
+
+void GestureClick::hook_released(GtkGestureMultiPress*, gint n_press, gdouble x,
+                                 gdouble y, gpointer user_data)
+{
+    static_cast<GestureClick*>(user_data)->m_released.emit(n_press, x, y);
+}
+
+void GestureClick::hook_stopped(GtkGestureMultiPress*, gpointer user_data)
+{
+    static_cast<GestureClick*>(user_data)->m_stopped.emit();
+}
+
+Glib::RefPtr<EventControllerKey> EventControllerKey::create(Gtk::Widget* widget)
+{
+    return Glib::RefPtr<EventControllerKey>(new EventControllerKey(widget));
+}
+
+EventControllerKey::EventControllerKey(Gtk::Widget* widget)
+    : Glib::ObjectBase("RtEventControllerKey"),
+      m_controller(gtk_event_controller_key_new(GTK_WIDGET(widget->gobj())))
+{
+    g_signal_connect(GTK_EVENT_CONTROLLER_KEY(m_controller), "key-pressed",
+                     G_CALLBACK(&EventControllerKey::hook_pressed), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_KEY(m_controller), "key-released",
+                     G_CALLBACK(&EventControllerKey::hook_released), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_KEY(m_controller), "modifiers",
+                     G_CALLBACK(&EventControllerKey::hook_modifiers), this);
+}
+
+EventControllerKey::~EventControllerKey()
+{
+    g_object_unref(m_controller);
+    m_controller = nullptr;
+}
+
+GtkEventControllerKey* EventControllerKey::gobj()
+{
+    return GTK_EVENT_CONTROLLER_KEY(m_controller);
+}
+
+GtkPropagationPhase EventControllerKey::get_propagation_phase() const
+{
+    return gtk_event_controller_get_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller));
+}
+
+void EventControllerKey::set_propagation_phase(GtkPropagationPhase phase)
+{
+    gtk_event_controller_set_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller), phase);
+}
+
+bool EventControllerKey::hook_pressed(
+    GtkEventControllerKey*, guint keyval, guint keycode, GdkModifierType state,
+    gpointer user_data)
+{
+    return static_cast<EventControllerKey*>(user_data)
+        ->m_pressed.emit(keyval, keycode, state);
+}
+
+void EventControllerKey::hook_released(
+    GtkEventControllerKey*, guint keyval, guint keycode, GdkModifierType state,
+    gpointer user_data)
+{
+    static_cast<EventControllerKey*>(user_data)->m_released.emit(keyval, keycode, state);
+}
+
+bool EventControllerKey::hook_modifiers(GtkEventControllerKey*, GdkModifierType state,
+                                        gpointer user_data)
+{
+    return static_cast<EventControllerKey*>(user_data)->m_modifiers.emit(state);
+}
+
+Glib::RefPtr<EventControllerMotion> EventControllerMotion::create(Gtk::Widget* widget)
+{
+    return Glib::RefPtr<EventControllerMotion>(new EventControllerMotion(widget));
+}
+
+EventControllerMotion::EventControllerMotion(Gtk::Widget* widget)
+    : Glib::ObjectBase("RtEventControllerMotion"),
+      m_controller(gtk_event_controller_motion_new(GTK_WIDGET(widget->gobj())))
+{
+    g_signal_connect(GTK_EVENT_CONTROLLER_MOTION(m_controller), "enter",
+                     G_CALLBACK(&EventControllerMotion::hook_enter), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_MOTION(m_controller), "motion",
+                     G_CALLBACK(&EventControllerMotion::hook_motion), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_MOTION(m_controller), "leave",
+                     G_CALLBACK(&EventControllerMotion::hook_leave), this);
+}
+
+EventControllerMotion::~EventControllerMotion()
+{
+    g_object_unref(m_controller);
+    m_controller = nullptr;
+}
+
+GtkEventControllerMotion* EventControllerMotion::gobj()
+{
+    return GTK_EVENT_CONTROLLER_MOTION(m_controller);
+}
+
+GtkPropagationPhase EventControllerMotion::get_propagation_phase() const
+{
+    return gtk_event_controller_get_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller));
+}
+
+void EventControllerMotion::set_propagation_phase(GtkPropagationPhase phase)
+{
+    gtk_event_controller_set_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller), phase);
+}
+
+void EventControllerMotion::hook_enter(GtkEventControllerMotion*, gdouble x, gdouble y,
+                                       gpointer user_data)
+{
+    static_cast<EventControllerMotion*>(user_data)->m_enter.emit(x, y);
+}
+
+void EventControllerMotion::hook_motion(GtkEventControllerMotion*, gdouble x, gdouble y,
+                                        gpointer user_data)
+{
+    static_cast<EventControllerMotion*>(user_data)->m_motion.emit(x, y);
+}
+
+void EventControllerMotion::hook_leave(GtkEventControllerMotion*, gpointer user_data)
+{
+    static_cast<EventControllerMotion*>(user_data)->m_leave.emit();
+}
+
+Glib::RefPtr<EventControllerScroll> EventControllerScroll::create(
+    Gtk::Widget* widget, GtkEventControllerScrollFlags flags)
+{
+    return Glib::RefPtr<EventControllerScroll>(new EventControllerScroll(widget, flags));
+}
+
+EventControllerScroll::EventControllerScroll(Gtk::Widget* widget,
+                                             GtkEventControllerScrollFlags flags)
+    : Glib::ObjectBase("RtEventControllerScroll"),
+      m_controller(gtk_event_controller_scroll_new(GTK_WIDGET(widget->gobj()), flags))
+{
+    g_signal_connect(GTK_EVENT_CONTROLLER_SCROLL(m_controller), "scroll-begin",
+                     G_CALLBACK(&EventControllerScroll::hook_begin), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_SCROLL(m_controller), "scroll",
+                     G_CALLBACK(&EventControllerScroll::hook_scroll), this);
+    g_signal_connect(GTK_EVENT_CONTROLLER_SCROLL(m_controller), "scroll-end",
+                     G_CALLBACK(&EventControllerScroll::hook_end), this);
+}
+
+EventControllerScroll::~EventControllerScroll()
+{
+    g_object_unref(m_controller);
+    m_controller = nullptr;
+}
+
+GtkEventControllerScroll* EventControllerScroll::gobj()
+{
+    return GTK_EVENT_CONTROLLER_SCROLL(m_controller);
+}
+
+GtkPropagationPhase EventControllerScroll::get_propagation_phase() const
+{
+    return gtk_event_controller_get_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller));
+}
+
+void EventControllerScroll::set_propagation_phase(GtkPropagationPhase phase)
+{
+    gtk_event_controller_set_propagation_phase(
+        GTK_EVENT_CONTROLLER(m_controller), phase);
+}
+
+GtkEventControllerScrollFlags EventControllerScroll::get_flags() const
+{
+    return gtk_event_controller_scroll_get_flags(
+        GTK_EVENT_CONTROLLER_SCROLL(m_controller));
+}
+
+void EventControllerScroll::set_flags(GtkEventControllerScrollFlags flags)
+{
+    return gtk_event_controller_scroll_set_flags(
+        GTK_EVENT_CONTROLLER_SCROLL(m_controller), flags);
+}
+
+void EventControllerScroll::hook_scroll(GtkEventControllerScroll*, gdouble dx,
+                                        gdouble dy, gpointer user_data)
+{
+    static_cast<EventControllerScroll*>(user_data)->m_scroll.emit(dx, dy);
+}
+
+void EventControllerScroll::hook_begin(GtkEventControllerScroll*, gpointer user_data)
+{
+    static_cast<EventControllerScroll*>(user_data)->m_begin.emit();
+}
+
+void EventControllerScroll::hook_end(GtkEventControllerScroll*, gpointer user_data)
+{
+    static_cast<EventControllerScroll*>(user_data)->m_end.emit();
+}
+
+}  // namespace gtk4
+}  // namespace rt

--- a/rtgui/gtk4.h
+++ b/rtgui/gtk4.h
@@ -1,0 +1,175 @@
+/*
+ *  This file is part of RawTherapee.
+ *
+ *  Copyright (c) 2026 Daniel Gao <daniel.gao.work@gmail.com>
+ *
+ *  RawTherapee is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  RawTherapee is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glibmm/object.h>
+#include <glibmm/refptr.h>
+#include <glibmm/signalproxy.h>
+#include <gtk/gtk.h>
+#include <sigc++/sigc++.h>
+
+namespace Gtk {
+class Widget;
+}
+
+namespace rt {
+namespace gtk4 {
+
+// TODO(GTK4): Replace with proper Gtk::Gesture*/EventController* gtkmm wrappers.
+//
+// WARNING: You must store the RefPtr of the event controllers as adding the
+//          controller to the widget does not increase the ref count of the
+//          controller in GTK 3.
+
+class GestureClick : public Glib::Object
+{
+public:
+    static Glib::RefPtr<GestureClick> create(Gtk::Widget* widget);
+
+    ~GestureClick();
+
+    GtkGestureMultiPress* gobj();
+
+    GtkPropagationPhase get_propagation_phase() const;
+    void set_propagation_phase(GtkPropagationPhase phase);
+
+    unsigned int get_current_button() const;
+    unsigned int get_button() const;
+    void set_button(unsigned int button = 0);
+
+    sigc::signal<void(int, double, double)>& signal_pressed() { return m_pressed; }
+    sigc::signal<void(int, double, double)>& signal_released() { return m_released; }
+    sigc::signal<void()>& signal_stopped() { return m_stopped; }
+private:
+    static void hook_pressed(GtkGestureMultiPress*, gint n_press, gdouble x, gdouble y,
+                             gpointer user_data);
+    static void hook_released(GtkGestureMultiPress*, gint n_press, gdouble x, gdouble y,
+                              gpointer user_data);
+    static void hook_stopped(GtkGestureMultiPress*, gpointer user_data);
+
+    GestureClick(Gtk::Widget* widget);
+
+    sigc::signal<void(int, double, double)> m_pressed;
+    sigc::signal<void(int, double, double)> m_released;
+    sigc::signal<void()> m_stopped;
+    GtkGesture* m_controller;
+};
+
+class EventControllerKey : public Glib::Object
+{
+public:
+    static Glib::RefPtr<EventControllerKey> create(Gtk::Widget* widget);
+
+    ~EventControllerKey();
+
+    GtkEventControllerKey* gobj();
+
+    GtkPropagationPhase get_propagation_phase() const;
+    void set_propagation_phase(GtkPropagationPhase phase);
+
+    sigc::signal<bool(guint, guint, GdkModifierType)>&
+    signal_key_pressed() { return m_pressed; }
+    sigc::signal<void(guint, guint, GdkModifierType)>&
+    signal_key_released() { return m_released; }
+    sigc::signal<bool(GdkModifierType)>& signal_modifiers() { return m_modifiers; }
+
+private:
+    static bool hook_pressed(GtkEventControllerKey*, guint keyval, guint keycode,
+                             GdkModifierType state, gpointer user_data);
+    static void hook_released(GtkEventControllerKey*, guint keyval, guint keycode,
+                              GdkModifierType state, gpointer user_data);
+    static bool hook_modifiers(GtkEventControllerKey*, GdkModifierType state,
+                               gpointer user_data);
+
+    EventControllerKey(Gtk::Widget* widget);
+
+    sigc::signal<bool(guint, guint, GdkModifierType)> m_pressed;
+    sigc::signal<void(guint, guint, GdkModifierType)> m_released;
+    sigc::signal<bool(GdkModifierType)> m_modifiers;
+    GtkEventController* m_controller;
+};
+
+class EventControllerMotion : public Glib::Object
+{
+public:
+    static Glib::RefPtr<EventControllerMotion> create(Gtk::Widget* widget);
+
+    ~EventControllerMotion();
+
+    GtkEventControllerMotion* gobj();
+
+    GtkPropagationPhase get_propagation_phase() const;
+    void set_propagation_phase(GtkPropagationPhase phase);
+
+    sigc::signal<void(double, double)>& signal_enter() { return m_enter; }
+    sigc::signal<void(double, double)>& signal_motion() { return m_motion; }
+    sigc::signal<void()>& signal_leave() { return m_leave; }
+
+private:
+    static void hook_enter(GtkEventControllerMotion*, gdouble x, gdouble y,
+                           gpointer user_data);
+    static void hook_motion(GtkEventControllerMotion*, gdouble x, gdouble y,
+                            gpointer user_data);
+    static void hook_leave(GtkEventControllerMotion*, gpointer user_data);
+
+    EventControllerMotion(Gtk::Widget* widget);
+
+    sigc::signal<void(double, double)> m_enter;
+    sigc::signal<void(double, double)> m_motion;
+    sigc::signal<void()> m_leave;
+    GtkEventController* m_controller;
+};
+
+class EventControllerScroll : public Glib::Object
+{
+public:
+    static Glib::RefPtr<EventControllerScroll> create(
+        Gtk::Widget* widget, GtkEventControllerScrollFlags flags);
+
+    ~EventControllerScroll();
+
+    GtkEventControllerScroll* gobj();
+
+    GtkPropagationPhase get_propagation_phase() const;
+    void set_propagation_phase(GtkPropagationPhase phase);
+
+    GtkEventControllerScrollFlags get_flags() const;
+    void set_flags(GtkEventControllerScrollFlags flags);
+
+    sigc::signal<void()>& signal_scroll_begin() { return m_begin; }
+    sigc::signal<void(double, double)>& signal_scroll() { return m_scroll; }
+    sigc::signal<void()>& signal_scroll_end() { return m_end; }
+
+private:
+    static void hook_scroll(GtkEventControllerScroll*, gdouble dx, gdouble dy,
+                            gpointer user_data);
+    static void hook_begin(GtkEventControllerScroll*, gpointer user_data);
+    static void hook_end(GtkEventControllerScroll*, gpointer user_data);
+
+    EventControllerScroll(Gtk::Widget* widget, GtkEventControllerScrollFlags flags);
+
+    sigc::signal<void(double, double)> m_scroll;
+    sigc::signal<void()> m_begin;
+    sigc::signal<void()> m_end;
+    GtkEventController* m_controller;
+};
+
+}  // namespace gtk4
+}  // namespace rt


### PR DESCRIPTION
Adds the following minimal wrappers for GTK 4 event controllers:

- GestureClick (actually GestureMultiPress in GTK 3 backports)
- EventControllerKey
- EventControllerMotion
- EventControllerScroll

gtkmm already has backports for Gtk::EventControllerZoom and Gtk::GestureDrag. The others aren't backported due to a low number of maintainers for gtkmm.

This is to help facilitate incremental GTK 4 migrations.