### PR TITLE
Prints the partial profile name only if verbosity is set to true.

### DIFF
--- a/rtgui/profilepanel.cc
+++ b/rtgui/profilepanel.cc
@@ -501,7 +501,9 @@ void ProfilePanel::load_clicked (GdkEventButton* event)
 
     if (result == Gtk::RESPONSE_OK) {
         Glib::ustring fname = dialog.get_filename();
-		printf("fname=%s\n", fname.c_str());
+        if (settings->verbose) {
+		    printf("fname=%s\n", fname.c_str());
+        }
 
         bool customCreated = false;
 


### PR DESCRIPTION
When applying partial profiles, the profile name was printed out unconditionally.

I'm not sure if this printf is something that was intended to stay in the source or was it intended as a temporary.