### PR TITLE
Color matrix JSONs for Windows installer

### DIFF
--- a/tools/win/InnoSetup/WindowsInnoSetup.iss.in
+++ b/tools/win/InnoSetup/WindowsInnoSetup.iss.in
@@ -98,7 +98,7 @@ Name: regOpenFile; Description: "Add ""Open with RawTherapee"" option to context
 
 [Files]
 Source: "{#MyBuildBasePath}\rawtherapee*.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#MyBuildBasePath}\camconst.json"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#MyBuildBasePath}\*.json"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyBuildBasePath}\dcpprofiles\*"; DestDir: "{app}\dcpprofiles\"; Flags: ignoreversion recursesubdirs createallsubdirs
 ;Source: "{#MyBuildBasePath}\etc\*"; DestDir: "{app}\etc\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#MyBuildBasePath}\iccprofiles\*"; DestDir: "{app}\iccprofiles\"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
The Windows installer did not include some JSON files containing color matrices.

Fixes #7622.