### PR TITLE
CLANG64 for Windows x86_64 workflows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,8 +30,8 @@ jobs:
         build_type: [release, debug]
         arch: [x86_64, arm64]
     env:
-      MSYS2_ENV_NAME: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'MINGW64' }}
-      MSYS2_ENV_PREFIX: ${{ matrix.arch == 'arm64' && 'clangarm64' || 'mingw64' }}
+      MSYS2_ENV_NAME: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'CLANG64' }}
+      MSYS2_ENV_PREFIX: ${{ matrix.arch == 'arm64' && 'clangarm64' || 'clang64' }}
     outputs:
       ARTIFACT_NAME_PREFIX: ${{ steps.prepare-artifact-name.outputs.ARTIFACT_NAME_PREFIX }}
       REF_NAME_FILTERED: ${{ steps.prepare-artifact-name.outputs.REF_NAME_FILTERED }}


### PR DESCRIPTION
MINGW64 is deprecated: https://www.msys2.org/news/#2026-03-15-soft-deprecating-the-mingw64-environment
This replaces MINGW64 with CLANG64.