### PR TITLE
Improve clarity of power-*-small icons

### DIFF
--- a/rtdata/icons/rawtherapee/scalable/apps/power-inconsistent-small.svg
+++ b/rtdata/icons/rawtherapee/scalable/apps/power-inconsistent-small.svg
@@ -62,11 +62,11 @@
        d="M 11.503774,13.432989 A 5,5 0 0 1 13,17 v 0 A 5,5 0 0 1 8,22 5,5 0 0 1 3,17 5,5 0 0 1 4.499601,13.429677"
        id="path5608" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#cccccc;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal;opacity:0.7"
+       style="fill:none;fill-rule:evenodd;stroke:#f1f1f1;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
        d="m 7.9999994,10.437301 v 3.068104"
        id="path2553" />
     <circle
-       style="opacity:1;fill:#cccccc;fill-opacity:1.0;fill-rule:nonzero;stroke:#cccccc;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
+       style="opacity:1;fill:#f1f1f1;fill-opacity:1.0;fill-rule:nonzero;stroke:#f1f1f1;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
        id="path6217"
        cx="8"
        cy="17.5"

--- a/rtdata/icons/rawtherapee/scalable/apps/power-off-small.svg
+++ b/rtdata/icons/rawtherapee/scalable/apps/power-off-small.svg
@@ -56,11 +56,11 @@
      id="layer1"
      transform="translate(0,-8)">
     <path
-       style="display:inline;opacity:0.5;fill:none;fill-opacity:0.752941;fill-rule:nonzero;stroke:#cccccc;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
+       style="display:inline;opacity:0.5;fill:none;fill-opacity:0.752941;fill-rule:nonzero;stroke:#cccccc;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
        d="m 11.030908,13.501206 a 4.3252046,4.3407218 0 0 1 1.294297,3.096681 v 0 A 4.3252046,4.3407218 0 0 1 8,20.938608 4.3252046,4.3407218 0 0 1 3.6747954,16.597887 4.3252046,4.3407218 0 0 1 4.9720116,13.498331"
        id="path5608" />
     <path
-       style="opacity:0.5;fill:none;fill-rule:evenodd;stroke:#cccccc;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
+       style="opacity:0.5;fill:none;fill-rule:evenodd;stroke:#cccccc;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1.0;paint-order:normal"
        d="m 7.9999995,11.259782 v 3.39629"
        id="path2553" />
   </g>


### PR DESCRIPTION
- Decrease width of power-off icon
- Make power-inconsistent exclamation mark color consistent with power-on

<img width="422" height="115" alt="icons" src="https://github.com/user-attachments/assets/c3823ce6-8aca-49fb-8b8d-5eeb5cfde908" />

<img width="241" height="129" alt="batch_edit" src="https://github.com/user-attachments/assets/33ab24ab-8a6c-41a1-9387-941aea9322d9" />

Closes #7167