### PR TITLE
Full process inspector images with embedded profiles

### DIFF
--- a/rtengine/previewimage.cc
+++ b/rtengine/previewimage.cc
@@ -20,14 +20,10 @@
 #include "previewimage.h"
 
 #include "color.h"
-#include "iccstore.h"
-#include "iimage.h"
 #include "iimage.h"
 #include "procparams.h"
 #include "rawimagesource.h"
-#include "rtapp.h"
 #include "rtthumbnail.h"
-#include "settings.h"
 #include "utils.h"
 
 using namespace rtengine;
@@ -114,16 +110,7 @@ PreviewImage::PreviewImage (const Glib::ustring &fname, const Glib::ustring &ext
             ColorTemp wb = rawImage.getWB ();
             rawImage.getFullSize (fw, fh, TR_NONE);
             PreviewProps pp (0, 0, fw, fh, 1);
-            params.icm.inputProfile = "(embedded)";
-            {
-                Glib::ustring workingProfile =
-                    ICCStore::getInstance()->getDefaultMonitorProfileName();
-                if (workingProfile.size() > 0) {
-                    params.icm.workingProfile = workingProfile;
-                } else {
-                    params.icm.workingProfile = App::get().settings().srgb;
-                }
-            }
+            params.icm.inputProfile = Glib::ustring("(embedded)");
             params.raw.bayersensor.method = RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::FAST);
             params.raw.deadPixelFilter = false;
             params.raw.ca_autocorrect = false;

--- a/rtengine/previewimage.cc
+++ b/rtengine/previewimage.cc
@@ -20,11 +20,14 @@
 #include "previewimage.h"
 
 #include "color.h"
+#include "iccstore.h"
 #include "iimage.h"
 #include "iimage.h"
 #include "procparams.h"
 #include "rawimagesource.h"
+#include "rtapp.h"
 #include "rtthumbnail.h"
+#include "settings.h"
 #include "utils.h"
 
 using namespace rtengine;
@@ -111,7 +114,16 @@ PreviewImage::PreviewImage (const Glib::ustring &fname, const Glib::ustring &ext
             ColorTemp wb = rawImage.getWB ();
             rawImage.getFullSize (fw, fh, TR_NONE);
             PreviewProps pp (0, 0, fw, fh, 1);
-            params.icm.inputProfile = Glib::ustring("(embedded)");
+            params.icm.inputProfile = "(embedded)";
+            {
+                Glib::ustring workingProfile =
+                    ICCStore::getInstance()->getDefaultMonitorProfileName();
+                if (workingProfile.size() > 0) {
+                    params.icm.workingProfile = workingProfile;
+                } else {
+                    params.icm.workingProfile = App::get().settings().srgb;
+                }
+            }
             params.raw.bayersensor.method = RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::FAST);
             params.raw.deadPixelFilter = false;
             params.raw.ca_autocorrect = false;

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -44,7 +44,6 @@
 #include "rawimage.h"
 #include "rawimagesource.h"
 #include "rtengine.h"
-#include "rtapp.h"
 #include "rtthumbnail.h"
 #include "settings.h"
 #include "stdimagesource.h"
@@ -385,14 +384,6 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
             params.wb.observer = wbObserver;
             params.icm.inputProfile = "(embedded)";
 
-            Glib::ustring workingProfile =
-                ICCStore::getInstance()->getDefaultMonitorProfileName();
-            if (workingProfile.size() > 0) {
-                params.icm.workingProfile = workingProfile;
-            } else {
-                params.icm.workingProfile = App::get().settings().srgb;
-            }
-
             std::unique_ptr<const rtengine::FramesMetaData> metadata(
                 rtengine::FramesMetaData::fromFile(fname));
 
@@ -442,9 +433,6 @@ Image8 *load_inspector_mode(const Glib::ustring &fname, eSensorType &sensorType,
     neutral.raw.bayersensor.method = RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::FAST);
     neutral.raw.xtranssensor.method = RAWParams::XTransSensor::getMethodString(RAWParams::XTransSensor::Method::FAST);
     neutral.icm.inputProfile = "(camera)";
-    // Force sRGB because the final processing step at end of function uses
-    // gamma_srgbclipped() which probably doesn't work for any other colorspace
-    neutral.icm.workingProfile = App::get().settings().srgb;
     float reddeha = 0.f;
     float greendeha = 0.f;
     float bluedeha = 0.f;

--- a/rtengine/rtthumbnail.cc
+++ b/rtengine/rtthumbnail.cc
@@ -16,17 +16,17 @@
  *  You should have received a copy of the GNU General Public License
  *  along with RawTherapee.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 #include <algorithm>
 #include <array>
 #include <clocale>
-
-#include <lcms2.h>
+#include <memory>
 
 #include <glib/gstdio.h>
-
-#include <glibmm/ustring.h>
 #include <glibmm/fileutils.h>
 #include <glibmm/keyfile.h>
+#include <glibmm/ustring.h>
+#include <lcms2.h>
 
 #include "cieimage.h"
 #include "color.h"
@@ -44,6 +44,7 @@
 #include "rawimage.h"
 #include "rawimagesource.h"
 #include "rtengine.h"
+#include "rtapp.h"
 #include "rtthumbnail.h"
 #include "settings.h"
 #include "stdimagesource.h"
@@ -284,12 +285,15 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
     if (data && tpp->embProfileLength) {
         tpp->embProfileData = new unsigned char [tpp->embProfileLength];
         memcpy (tpp->embProfileData, data, tpp->embProfileLength);
+
+        tpp->embProfile =
+            cmsOpenProfileFromMem (tpp->embProfileData, tpp->embProfileLength);
     }
 
     tpp->scaleForSave = 8192;
     tpp->defGain = 1.0;
     tpp->gammaCorrected = false;
-    tpp->isRaw = 0;
+    tpp->isRaw = false;
     memset (tpp->colorMatrix, 0, sizeof (tpp->colorMatrix));
     tpp->colorMatrix[0][0] = 1.0;
     tpp->colorMatrix[1][1] = 1.0;
@@ -330,22 +334,7 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
         tpp->thumbImg = nullptr;
     }
 
-    if (inspectorMode) {
-        // we want an Image8
-        if (img->getType() == rtengine::sImage8) {
-            // copy the image
-            Image8 *srcImg = static_cast<Image8*> (img);
-            Image8 *thImg = new Image8 (w, h);
-            srcImg->copyData (thImg);
-            tpp->thumbImg = thImg;
-        } else {
-            // copy the image with a conversion
-            tpp->thumbImg = resizeTo<Image8> (w, h, TI_Bilinear, img);
-        }
-    } else {
-        // we want the same image type than the source file
-        tpp->thumbImg = resizeToSameType (w, h, TI_Bilinear, img);
-
+    auto computeAutoExp = [&](ProcParams& params) {
         // histogram computation
         tpp->aeHistCompression = 3;
         tpp->aeHistogram (65536 >> tpp->aeHistCompression);
@@ -368,8 +357,7 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
             printf ("loadFromImage: Unsupported image type \"%s\"!\n", img->getType());
         }
 
-        ProcParams paramsForAutoExp; // Dummy for constructor
-        ImProcFunctions ipf (&paramsForAutoExp, false);
+        ImProcFunctions ipf (&params, false);
         ipf.getAutoExp (tpp->aeHistogram, tpp->aeHistCompression, 0.02, tpp->aeExposureCompensation, tpp->aeLightness, tpp->aeContrast, tpp->aeBlack, tpp->aeHighlightCompression, tpp->aeHighlightCompressionThreshold);
         tpp->aeValid = true;
 
@@ -387,6 +375,48 @@ Thumbnail* Thumbnail::loadFromImage (const Glib::ustring& fname, int &w, int &h,
         }
 
         tpp->init ();
+    };
+
+    if (inspectorMode) {
+        // Generate Image8 thumbnail
+        if (tpp->embProfile) {
+            procparams::ProcParams params;
+            params.wb.equal = wbEq;
+            params.wb.observer = wbObserver;
+            params.icm.inputProfile = "(embedded)";
+
+            Glib::ustring workingProfile =
+                ICCStore::getInstance()->getDefaultMonitorProfileName();
+            if (workingProfile.size() > 0) {
+                params.icm.workingProfile = workingProfile;
+            } else {
+                params.icm.workingProfile = App::get().settings().srgb;
+            }
+
+            std::unique_ptr<const rtengine::FramesMetaData> metadata(
+                rtengine::FramesMetaData::fromFile(fname));
+
+            // thumbImg needs to be set before calling processImage()
+            tpp->thumbImg = img;
+
+            double scale = 1.0;
+            computeAutoExp(params);
+            tpp->thumbImg = tpp->processImage(params, rtengine::ST_NONE, h,
+                                              TI_Nearest, metadata.get(), scale);
+        } else if (img->getType() == rtengine::sImage8) {
+            Image8 *srcImg = static_cast<Image8*> (img);
+            Image8 *thImg = new Image8 (w, h);
+            srcImg->copyData (thImg);
+            tpp->thumbImg = thImg;
+        } else {
+            tpp->thumbImg = resizeTo<Image8> (w, h, TI_Nearest, img);
+        }
+    } else {
+        // we want the same image type than the source file
+        tpp->thumbImg = resizeToSameType (w, h, TI_Bilinear, img);
+
+        ProcParams paramsForAutoExp; // Dummy for constructor
+        computeAutoExp(paramsForAutoExp);
     }
 
     return tpp;
@@ -412,7 +442,9 @@ Image8 *load_inspector_mode(const Glib::ustring &fname, eSensorType &sensorType,
     neutral.raw.bayersensor.method = RAWParams::BayerSensor::getMethodString(RAWParams::BayerSensor::Method::FAST);
     neutral.raw.xtranssensor.method = RAWParams::XTransSensor::getMethodString(RAWParams::XTransSensor::Method::FAST);
     neutral.icm.inputProfile = "(camera)";
-    neutral.icm.workingProfile = settings->srgb;
+    // Force sRGB because the final processing step at end of function uses
+    // gamma_srgbclipped() which probably doesn't work for any other colorspace
+    neutral.icm.workingProfile = App::get().settings().srgb;
     float reddeha = 0.f;
     float greendeha = 0.f;
     float bluedeha = 0.f;
@@ -1127,7 +1159,7 @@ Thumbnail::~Thumbnail ()
 }
 
 // Simple processing of RAW internal JPGs
-IImage8* Thumbnail::quickProcessImage (const procparams::ProcParams& params, int rheight, rtengine::TypeInterpolation interp)
+Image8* Thumbnail::quickProcessImage (const procparams::ProcParams& params, int rheight, rtengine::TypeInterpolation interp)
 {
 
     int rwidth;
@@ -1157,7 +1189,7 @@ IImage8* Thumbnail::quickProcessImage (const procparams::ProcParams& params, int
 }
 
 // Full thumbnail processing, second stage if complete profile exists
-IImage8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorType sensorType, int rheight, TypeInterpolation interp, const FramesMetaData *metadata, double& myscale, bool forMonitor, bool forHistogramMatching)
+Image8* Thumbnail::processImage (const procparams::ProcParams& params, eSensorType sensorType, int rheight, TypeInterpolation interp, const FramesMetaData *metadata, double& myscale, bool forMonitor, bool forHistogramMatching)
 {
     const std::string camName = metadata->getCamera();
     const float shutter = metadata->getShutterSpeed();

--- a/rtengine/rtthumbnail.h
+++ b/rtengine/rtthumbnail.h
@@ -93,10 +93,10 @@ public:
 
     void init ();
 
-    IImage8* processImage   (const procparams::ProcParams& pparams, eSensorType sensorType, int rheight, TypeInterpolation interp, const FramesMetaData *metadata, double& scale, bool forMonitor=true, bool forHistogramMatching = false);
-    IImage8* quickProcessImage   (const procparams::ProcParams& pparams, int rheight, TypeInterpolation interp);
-    int      getImageWidth  (const procparams::ProcParams& pparams, int rheight, float &ratio);
-    void     getDimensions  (int& w, int& h, double& scaleFac);
+    Image8* processImage    (const procparams::ProcParams& pparams, eSensorType sensorType, int rheight, TypeInterpolation interp, const FramesMetaData *metadata, double& scale, bool forMonitor=true, bool forHistogramMatching = false);
+    Image8* quickProcessImage   (const procparams::ProcParams& pparams, int rheight, TypeInterpolation interp);
+    int     getImageWidth   (const procparams::ProcParams& pparams, int rheight, float &ratio);
+    void    getDimensions   (int& w, int& h, double& scaleFac);
 
     static Thumbnail* loadQuickFromRaw (const Glib::ustring& fname, eSensorType &sensorType, int &w, int &h, int fixwh, bool rotate, bool inspectorMode = false, bool forHistogramMatching = false);
     static Thumbnail* loadFromRaw (const Glib::ustring& fname, eSensorType &sensorType, int &w, int &h, int fixwh, double wbEq, StandardObserver wbObserver, bool rotate, const RAWParams *rawParams, bool forHistogramMatching=false);


### PR DESCRIPTION
Fix #3357 by running the normal thumbnail generation pipeline on non-RAW images with embedded profiles.

The fix was tested using the test image provided in the issue.