### PR TITLE
Add colors to crop guide presets

### DIFF
--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -330,12 +330,38 @@ void loadCropGuideParams(
 
     assignFromKeyfile(keyFile, group, TOOL_ENABLED, params.enabled, edited.enabled);
 
+    auto parse_color = [&](const cJSON* obj, const char* key, double& out) {
+        const cJSON* entry = cJSON_GetObjectItemCaseSensitive(obj, key);
+        if (cJSON_IsNumber(entry)) {
+            out = entry->valuedouble;
+        } else {
+            out = 1.0;
+        }
+    };
+
     auto load = [&](PresetIndex index, const char* key) {
-        bool is_enabled = false;
-        bool is_edited = edited.presets[index];
-        assignFromKeyfile(keyFile, group, key, is_enabled, is_edited);
-        params.presets[index] = is_enabled;
-        edited.presets[index] = is_edited;
+        if (!keyFile.has_key(group, key)) return;
+
+        Glib::ustring data = keyFile.get_string(group, key);
+        cJSON* json = cJSON_Parse(data.c_str());
+        if (!json) return;
+        if (!cJSON_IsObject(json)) {
+            cJSON_Delete(json);
+            return;
+        }
+
+        CropGuideParams::PresetParams& preset = params.presets[index];
+        edited.presets[index] = true;
+
+        const cJSON* enabled =
+            cJSON_GetObjectItemCaseSensitive(json, TOOL_ENABLED);
+        preset.enabled = cJSON_IsTrue(enabled);
+
+        parse_color(json, RED, preset.red);
+        parse_color(json, GREEN, preset.green);
+        parse_color(json, BLUE, preset.blue);
+
+        cJSON_Delete(json);
     };
 
     load(PresetIndex::RULE_OF_THIRDS, RULE_OF_THIRDS);
@@ -396,15 +422,6 @@ void loadCropGuideParams(
             return false;
         };
 
-        auto parse_color = [&](const cJSON* obj, const char* key, double& out) {
-            const cJSON* entry = cJSON_GetObjectItemCaseSensitive(obj, key);
-            if (cJSON_IsNumber(entry)) {
-                out = entry->valuedouble;
-            } else {
-                out = 1.0;
-            }
-        };
-
         const cJSON* obj = nullptr;
         cJSON_ArrayForEach(obj, json) {
             const cJSON* name = cJSON_GetObjectItemCaseSensitive(obj, NAME);
@@ -412,21 +429,15 @@ void loadCropGuideParams(
                 size_t preset_index = 0;
                 if (find_index(name->valuestring, preset_index)) {
                     CropGuideParams::AspectRatioParams entry(preset_index);
+                    edited.aspect_ratios = true;
 
                     const cJSON* enabled =
                         cJSON_GetObjectItemCaseSensitive(obj, TOOL_ENABLED);
-                    if (cJSON_IsTrue(enabled)) {
-                        entry.enabled = true;
-                    } else {
-                        entry.enabled = false;
-                    }
+                    entry.enabled = cJSON_IsTrue(enabled);
+
                     const cJSON* is_portrait =
                         cJSON_GetObjectItemCaseSensitive(obj, IS_PORTRAIT);
-                    if (cJSON_IsTrue(is_portrait)) {
-                        entry.is_portrait = true;
-                    } else {
-                        entry.is_portrait = false;
-                    }
+                    entry.is_portrait = cJSON_IsTrue(is_portrait);
 
                     parse_color(obj, RED, entry.red);
                     parse_color(obj, GREEN, entry.green);
@@ -463,8 +474,28 @@ void saveCropGuideParams(
                   params.enabled, keyFile);
 
     auto save = [&](PresetIndex index, const char* key) {
-        saveToKeyfile(!pedited || pedited->cropGuide.presets[index], group, key,
-                      static_cast<bool>(params.presets[index]), keyFile);
+        if (pedited && !pedited->cropGuide.presets[index]) return;
+
+        cJSON* json = cJSON_CreateObject();
+        if (!json) return;
+
+        const CropGuideParams::PresetParams& preset = params.presets[index];
+        if (preset.enabled) {
+            cJSON_AddTrueToObject(json, TOOL_ENABLED);
+        } else {
+            cJSON_AddFalseToObject(json, TOOL_ENABLED);
+        }
+        cJSON_AddNumberToObject(json, RED, preset.red);
+        cJSON_AddNumberToObject(json, GREEN, preset.green);
+        cJSON_AddNumberToObject(json, BLUE, preset.blue);
+
+        char* serialized_json = cJSON_PrintUnformatted(json);
+        if (serialized_json) {
+            keyFile.set_string(group, key, serialized_json);
+            free(serialized_json);
+        }
+
+        cJSON_Delete(json);
     };
 
     save(PresetIndex::RULE_OF_THIRDS, RULE_OF_THIRDS);
@@ -2137,6 +2168,19 @@ void CropParams::mapToResized(int resizedWidth, int resizedHeight, int scale, in
         x2 = min(resizedWidth, max(0, (x + w) / scale));
         y2 = min(resizedHeight, max(0, (y + h) / scale));
     }
+}
+
+CropGuideParams::PresetParams::PresetParams()
+    : enabled(false), red(1.0), green(1.0), blue(1.0)
+{
+}
+
+bool CropGuideParams::PresetParams::operator==(const PresetParams& other) const
+{
+    return enabled == other.enabled
+        && red == other.red
+        && green == other.green
+        && blue == other.blue;
 }
 
 CropGuideParams::AspectRatioParams::AspectRatioParams(size_t preset_index)

--- a/rtengine/procparams.cc
+++ b/rtengine/procparams.cc
@@ -142,6 +142,7 @@ namespace CropGuide {
     DEFINE_KEY(RED, "Red");
     DEFINE_KEY(GREEN, "Green");
     DEFINE_KEY(BLUE, "Blue");
+    DEFINE_KEY(ALPHA, "Alpha");
 }  // namespace CropGuide
 
 namespace Framing
@@ -360,6 +361,7 @@ void loadCropGuideParams(
         parse_color(json, RED, preset.red);
         parse_color(json, GREEN, preset.green);
         parse_color(json, BLUE, preset.blue);
+        parse_color(json, ALPHA, preset.alpha);
 
         cJSON_Delete(json);
     };
@@ -442,6 +444,7 @@ void loadCropGuideParams(
                     parse_color(obj, RED, entry.red);
                     parse_color(obj, GREEN, entry.green);
                     parse_color(obj, BLUE, entry.blue);
+                    parse_color(obj, ALPHA, entry.alpha);
                     params.aspect_ratios.push_back(std::move(entry));
                 }
             }
@@ -488,6 +491,7 @@ void saveCropGuideParams(
         cJSON_AddNumberToObject(json, RED, preset.red);
         cJSON_AddNumberToObject(json, GREEN, preset.green);
         cJSON_AddNumberToObject(json, BLUE, preset.blue);
+        cJSON_AddNumberToObject(json, ALPHA, preset.alpha);
 
         char* serialized_json = cJSON_PrintUnformatted(json);
         if (serialized_json) {
@@ -552,6 +556,7 @@ void saveCropGuideParams(
             cJSON_AddNumberToObject(obj, RED, entry.red);
             cJSON_AddNumberToObject(obj, GREEN, entry.green);
             cJSON_AddNumberToObject(obj, BLUE, entry.blue);
+            cJSON_AddNumberToObject(obj, ALPHA, entry.alpha);
 
             cJSON_AddItemToArray(serialized_aspect_ratios, obj);
         }
@@ -2171,7 +2176,7 @@ void CropParams::mapToResized(int resizedWidth, int resizedHeight, int scale, in
 }
 
 CropGuideParams::PresetParams::PresetParams()
-    : enabled(false), red(1.0), green(1.0), blue(1.0)
+    : enabled(false), red(1.0), green(1.0), blue(1.0), alpha(0.618)
 {
 }
 
@@ -2180,7 +2185,8 @@ bool CropGuideParams::PresetParams::operator==(const PresetParams& other) const
     return enabled == other.enabled
         && red == other.red
         && green == other.green
-        && blue == other.blue;
+        && blue == other.blue
+        && alpha == other.alpha;
 }
 
 CropGuideParams::AspectRatioParams::AspectRatioParams(size_t preset_index)
@@ -2189,7 +2195,8 @@ CropGuideParams::AspectRatioParams::AspectRatioParams(size_t preset_index)
       preset_index(preset_index),
       red(1.0),
       green(1.0),
-      blue(1.0)
+      blue(1.0),
+      alpha(0.618)
 {
 }
 
@@ -2200,7 +2207,8 @@ bool CropGuideParams::AspectRatioParams::operator==(const AspectRatioParams& oth
         && preset_index == other.preset_index
         && red == other.red
         && green == other.green
-        && blue == other.blue;
+        && blue == other.blue
+        && alpha == other.alpha;
 }
 
 CropGuideParams::CropGuideParams()

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -763,6 +763,7 @@ struct CropGuideParams {
         double red;
         double green;
         double blue;
+        double alpha;
 
         PresetParams();
 
@@ -779,6 +780,7 @@ struct CropGuideParams {
         double red;
         double green;
         double blue;
+        double alpha;
 
         AspectRatioParams(size_t preset_index);
 

--- a/rtengine/procparams.h
+++ b/rtengine/procparams.h
@@ -758,6 +758,20 @@ struct CropGuideParams {
 
     enum class Basis { SCALE, WIDTH, HEIGHT, LONG, SHORT };
 
+    struct PresetParams {
+        bool enabled;
+        double red;
+        double green;
+        double blue;
+
+        PresetParams();
+
+        bool operator==(const PresetParams& other) const;
+        bool operator!=(const PresetParams& other) const {
+            return !(*this == other);
+        }
+    };
+
     struct AspectRatioParams {
         bool enabled;
         bool is_portrait;
@@ -775,7 +789,7 @@ struct CropGuideParams {
     };
 
     std::vector<AspectRatioParams> aspect_ratios;
-    std::bitset<NUM_PRESETS> presets;
+    std::array<PresetParams, NUM_PRESETS> presets;
     bool enabled;
     bool mirror_golden_triangle;
     bool rotate_golden_ratio;

--- a/rtgui/drawcropguide.cc
+++ b/rtgui/drawcropguide.cc
@@ -138,21 +138,19 @@ void drawCropGuides(const Cairo::RefPtr<Cairo::Context>& cr,
 
     GuideDrawer util{cr, bleed_rect, params};
 
-    if (params.presets.any()) {
-        // Horizontal/vertical lines only
-        util.drawRuleOfThirds();
-        util.drawHarmonicMeans();
-        util.drawCrosshair();
-        util.drawGrid();
-        util.drawEpassport();
-        util.drawCenteredSquare();
+    // Horizontal/vertical lines only
+    util.drawRuleOfThirds();
+    util.drawHarmonicMeans();
+    util.drawCrosshair();
+    util.drawGrid();
+    util.drawEpassport();
+    util.drawCenteredSquare();
 
-        // Diagonals
-        util.drawDiagonals();
-        util.drawGoldenTriangle();
+    // Diagonals
+    util.drawDiagonals();
+    util.drawGoldenTriangle();
 
-        util.drawGoldenRatio(device_scale);
-    }
+    util.drawGoldenRatio(device_scale);
 
     util.drawAspectRatios();
 }
@@ -235,7 +233,7 @@ CropRect calculateBleedRect(const CropRect& crop_rect, const CropGuideParams& pa
 
 void GuideDrawer::drawRuleOfThirds()
 {
-    if (!params.presets[PresetIndex::RULE_OF_THIRDS]) return;
+    if (!params.presets[PresetIndex::RULE_OF_THIRDS].enabled) return;
 
     drawHorizontal(1.0 / 3.0);
     drawHorizontal(2.0 / 3.0);
@@ -245,7 +243,7 @@ void GuideDrawer::drawRuleOfThirds()
 
 void GuideDrawer::drawHarmonicMeans()
 {
-    if (!params.presets[PresetIndex::HARMONIC_MEANS]) return;
+    if (!params.presets[PresetIndex::HARMONIC_MEANS].enabled) return;
 
     drawHorizontal(GOLDEN_RATIO_RECIPROCAL);
     drawHorizontal(1.0 - GOLDEN_RATIO_RECIPROCAL);
@@ -255,7 +253,7 @@ void GuideDrawer::drawHarmonicMeans()
 
 void GuideDrawer::drawCrosshair()
 {
-    if (!params.presets[PresetIndex::CROSSHAIR]) return;
+    if (!params.presets[PresetIndex::CROSSHAIR].enabled) return;
 
     drawHorizontal(0.5);
     drawVertical(0.5);
@@ -263,7 +261,7 @@ void GuideDrawer::drawCrosshair()
 
 void GuideDrawer::drawGrid()
 {
-    if (!params.presets[PresetIndex::GRID]) return;
+    if (!params.presets[PresetIndex::GRID].enabled) return;
 
     // To have even distribution, normalize it a bit
     const int longSideNumLines = 10;
@@ -308,7 +306,7 @@ void GuideDrawer::drawGrid()
  */
 void GuideDrawer::drawEpassport()
 {
-    if (!params.presets[PresetIndex::EPASSPORT]) return;
+    if (!params.presets[PresetIndex::EPASSPORT].enabled) return;
 
     drawHorizontal(7.0 / 45.0);
     drawHorizontal(26.0 / 45.0);
@@ -318,7 +316,7 @@ void GuideDrawer::drawEpassport()
 
 void GuideDrawer::drawCenteredSquare()
 {
-    if (!params.presets[PresetIndex::CENTERED_SQUARE]) return;
+    if (!params.presets[PresetIndex::CENTERED_SQUARE].enabled) return;
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;
@@ -338,7 +336,7 @@ void GuideDrawer::drawCenteredSquare()
 
 void GuideDrawer::drawDiagonals()
 {
-    if (!params.presets[PresetIndex::RULE_OF_DIAGONALS]) return;
+    if (!params.presets[PresetIndex::RULE_OF_DIAGONALS].enabled) return;
 
     double corners_from[4][2];
     double corners_to[4][2];
@@ -372,7 +370,7 @@ void GuideDrawer::drawDiagonals()
 
 void GuideDrawer::drawGoldenTriangle()
 {
-    if (!params.presets[PresetIndex::GOLDEN_TRIANGLE]) return;
+    if (!params.presets[PresetIndex::GOLDEN_TRIANGLE].enabled) return;
 
     double x0 = rect.x0;
     double x1 = rect.x1;
@@ -404,7 +402,7 @@ void GuideDrawer::drawGoldenTriangle()
 
 void GuideDrawer::drawGoldenRatio(double device_scale)
 {
-    if (!params.presets[PresetIndex::GOLDEN_RATIO]) return;
+    if (!params.presets[PresetIndex::GOLDEN_RATIO].enabled) return;
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;

--- a/rtgui/drawcropguide.cc
+++ b/rtgui/drawcropguide.cc
@@ -25,6 +25,8 @@
 #include "rtengine/procparams.h"
 #include "rtengine/rt_math.h"
 
+#include <gdkmm/rgba.h>
+
 using namespace rtengine;
 using namespace rtengine::procparams;
 
@@ -33,6 +35,7 @@ namespace
 
 using PresetIndex = CropGuideParams::PresetIndex;
 
+constexpr double GUIDE_DASH = 4;
 constexpr double GUIDE_ALPHA = 0.618;
 constexpr double GOLDEN_RATIO = 1.618033988749895;
 constexpr double GOLDEN_RATIO_RECIPROCAL = 0.618033988749895;
@@ -50,10 +53,6 @@ struct GuideDrawer {
     const Cairo::RefPtr<Cairo::Context>& cr;
     const CropRect& rect;
     const CropGuideParams& params;
-
-    double red = 1.0;
-    double green = 1.0;
-    double blue = 1.0;
 
     GuideDrawer(const Cairo::RefPtr<Cairo::Context>& context,
                 const CropRect& bounds,
@@ -73,15 +72,17 @@ struct GuideDrawer {
     void drawGoldenRatio(double device_scale);
     void drawAspectRatios();
 
-    void drawHorizontal(double ratio);
-    void drawVertical(double ratio);
+    void drawHorizontal(double ratio, const Gdk::RGBA& color);
+    void drawVertical(double ratio, const Gdk::RGBA& color);
 
-    void drawDashedLine(double x0, double y0, double x1, double y1);
-    void drawDashedArc(double xc, double yc, double r, double rad0, double rad1);
+    void drawDashedLine(double x0, double y0, double x1, double y1,
+                        const Gdk::RGBA& color);
+    void drawDashedArc(double xc, double yc, double r, double rad0, double rad1,
+                       const Gdk::RGBA& color);
 
 private:
     void drawGoldenRatioRecursive(double x, double y, double length, Dir dir,
-                                  double limit, bool clockwise);
+                                  double limit, bool clockwise, const Gdk::RGBA& color);
 };
 
 void drawFrame(const Cairo::RefPtr<Cairo::Context>& cr,
@@ -97,14 +98,14 @@ void drawFrame(const Cairo::RefPtr<Cairo::Context>& cr,
     cr->stroke();
 
     cr->set_source_rgba(0.0, 0.0, 0.0, GUIDE_ALPHA);
-    cr->set_dash(std::valarray<double>({4}), 0);
+    cr->set_dash(std::vector<double>{GUIDE_DASH}, 0);
     cr->move_to(rect.x0, rect.y0);
     cr->line_to(rect.x1, rect.y0);
     cr->line_to(rect.x1, rect.y1);
     cr->line_to(rect.x0, rect.y1);
     cr->line_to(rect.x0, rect.y0);
     cr->stroke();
-    cr->set_dash(std::valarray<double>(), 0);
+    cr->set_dash(std::vector<double>{}, 0);
 }
 
 void drawCropGuides(const Cairo::RefPtr<Cairo::Context>& cr,
@@ -229,39 +230,58 @@ CropRect calculateBleedRect(const CropRect& crop_rect, const CropGuideParams& pa
     }
 }
 
+Gdk::RGBA buildColor(double red, double green, double blue)
+{
+    Gdk::RGBA color;
+    color.set_rgba(red, green, blue, GUIDE_ALPHA);
+    return color;
+}
+
 }  // namespace
 
 void GuideDrawer::drawRuleOfThirds()
 {
-    if (!params.presets[PresetIndex::RULE_OF_THIRDS].enabled) return;
+    const auto& preset = params.presets[PresetIndex::RULE_OF_THIRDS];
+    if (!preset.enabled) return;
 
-    drawHorizontal(1.0 / 3.0);
-    drawHorizontal(2.0 / 3.0);
-    drawVertical(1.0 / 3.0);
-    drawVertical(2.0 / 3.0);
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+
+    drawHorizontal(1.0 / 3.0, color);
+    drawHorizontal(2.0 / 3.0, color);
+    drawVertical(1.0 / 3.0, color);
+    drawVertical(2.0 / 3.0, color);
 }
 
 void GuideDrawer::drawHarmonicMeans()
 {
-    if (!params.presets[PresetIndex::HARMONIC_MEANS].enabled) return;
+    const auto& preset = params.presets[PresetIndex::HARMONIC_MEANS];
+    if (!preset.enabled) return;
 
-    drawHorizontal(GOLDEN_RATIO_RECIPROCAL);
-    drawHorizontal(1.0 - GOLDEN_RATIO_RECIPROCAL);
-    drawVertical(GOLDEN_RATIO_RECIPROCAL);
-    drawVertical(1.0 - GOLDEN_RATIO_RECIPROCAL);
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+
+    drawHorizontal(GOLDEN_RATIO_RECIPROCAL, color);
+    drawHorizontal(1.0 - GOLDEN_RATIO_RECIPROCAL, color);
+    drawVertical(GOLDEN_RATIO_RECIPROCAL, color);
+    drawVertical(1.0 - GOLDEN_RATIO_RECIPROCAL, color);
 }
 
 void GuideDrawer::drawCrosshair()
 {
-    if (!params.presets[PresetIndex::CROSSHAIR].enabled) return;
+    const auto& preset = params.presets[PresetIndex::CROSSHAIR];
+    if (!preset.enabled) return;
 
-    drawHorizontal(0.5);
-    drawVertical(0.5);
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+
+    drawHorizontal(0.5, color);
+    drawVertical(0.5, color);
 }
 
 void GuideDrawer::drawGrid()
 {
-    if (!params.presets[PresetIndex::GRID].enabled) return;
+    const auto& preset = params.presets[PresetIndex::GRID];
+    if (!preset.enabled) return;
+
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
 
     // To have even distribution, normalize it a bit
     const int longSideNumLines = 10;
@@ -272,21 +292,21 @@ void GuideDrawer::drawGrid()
     if (w > longSideNumLines && h > longSideNumLines) {
         if (w > h) {
             for (int i = 1; i < longSideNumLines; i++) {
-                drawVertical(static_cast<double>(i) / longSideNumLines);
+                drawVertical(static_cast<double>(i) / longSideNumLines, color);
             }
 
             int shortSideNumLines = static_cast<int>(std::round(h * longSideNumLines / w));
             for (int i = 1; i < shortSideNumLines; i++) {
-                drawHorizontal(static_cast<double>(i) / shortSideNumLines);
+                drawHorizontal(static_cast<double>(i) / shortSideNumLines, color);
             }
         } else {
             for (int i = 1; i < longSideNumLines; i++) {
-                drawHorizontal(static_cast<double>(i) / longSideNumLines);
+                drawHorizontal(static_cast<double>(i) / longSideNumLines, color);
             }
 
             int shortSideNumLines = static_cast<int>(std::round(w * longSideNumLines / h));
             for (int i = 1; i < shortSideNumLines; i++) {
-                drawVertical(static_cast<double>(i) / shortSideNumLines);
+                drawVertical(static_cast<double>(i) / shortSideNumLines, color);
             }
         }
     }
@@ -306,17 +326,23 @@ void GuideDrawer::drawGrid()
  */
 void GuideDrawer::drawEpassport()
 {
-    if (!params.presets[PresetIndex::EPASSPORT].enabled) return;
+    const auto& preset = params.presets[PresetIndex::EPASSPORT];
+    if (!preset.enabled) return;
 
-    drawHorizontal(7.0 / 45.0);
-    drawHorizontal(26.0 / 45.0);
-    drawHorizontal(37.0 / 45.0);
-    drawVertical(0.5);
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+
+    drawHorizontal(7.0 / 45.0, color);
+    drawHorizontal(26.0 / 45.0, color);
+    drawHorizontal(37.0 / 45.0, color);
+    drawVertical(0.5, color);
 }
 
 void GuideDrawer::drawCenteredSquare()
 {
-    if (!params.presets[PresetIndex::CENTERED_SQUARE].enabled) return;
+    const auto& preset = params.presets[PresetIndex::CENTERED_SQUARE];
+    if (!preset.enabled) return;
+
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;
@@ -325,18 +351,21 @@ void GuideDrawer::drawCenteredSquare()
     if (ratio < 1.0) {
         ratio = 1.0 / ratio;
         const double pos = (ratio - 1.0) / (2.0 * ratio);
-        drawHorizontal(pos);
-        drawHorizontal(1.0 - pos);
+        drawHorizontal(pos, color);
+        drawHorizontal(1.0 - pos, color);
     } else {
         const double pos = (ratio - 1.0) / (2.0 * ratio);
-        drawVertical(pos);
-        drawVertical(1.0 - pos);
+        drawVertical(pos, color);
+        drawVertical(1.0 - pos, color);
     }
 }
 
 void GuideDrawer::drawDiagonals()
 {
-    if (!params.presets[PresetIndex::RULE_OF_DIAGONALS].enabled) return;
+    const auto& preset = params.presets[PresetIndex::RULE_OF_DIAGONALS];
+    if (!preset.enabled) return;
+
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
 
     double corners_from[4][2];
     double corners_to[4][2];
@@ -364,13 +393,16 @@ void GuideDrawer::drawDiagonals()
 
     for (int i = 0; i < 4; i++) {
         drawDashedLine(corners_from[i][0], corners_from[i][1],
-                       corners_to[i][0], corners_to[i][1]);
+                       corners_to[i][0], corners_to[i][1], color);
     }
 }
 
 void GuideDrawer::drawGoldenTriangle()
 {
-    if (!params.presets[PresetIndex::GOLDEN_TRIANGLE].enabled) return;
+    const auto& preset = params.presets[PresetIndex::GOLDEN_TRIANGLE];
+    if (!preset.enabled) return;
+
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
 
     double x0 = rect.x0;
     double x1 = rect.x1;
@@ -381,7 +413,7 @@ void GuideDrawer::drawGoldenTriangle()
         std::swap(x0, x1);
     }
 
-    drawDashedLine(x0, y0, x1, y1);
+    drawDashedLine(x0, y0, x1, y1, color);
 
     const double height = y1 - y0;
     const double width = x1 - x0;
@@ -393,16 +425,19 @@ void GuideDrawer::drawGoldenTriangle()
 
     double x = (a * b) / height;
     double y = height - (b * (d - a)) / width;
-    drawDashedLine(x0, y1, x0 + x, y0 + y);
+    drawDashedLine(x0, y1, x0 + x, y0 + y, color);
 
     x = width - (a * b) / height;
     y = (b * (d - a)) / width;
-    drawDashedLine(x1, y0, x0 + x, y0 + y);
+    drawDashedLine(x1, y0, x0 + x, y0 + y, color);
 }
 
 void GuideDrawer::drawGoldenRatio(double device_scale)
 {
-    if (!params.presets[PresetIndex::GOLDEN_RATIO].enabled) return;
+    const auto& preset = params.presets[PresetIndex::GOLDEN_RATIO];
+    if (!preset.enabled) return;
+
+    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;
@@ -442,12 +477,16 @@ void GuideDrawer::drawGoldenRatio(double device_scale)
 
     // Don't show new fitted rect bounds if close enough
     if (delta_w >= 4.0) {
-        drawDashedLine(fitted_rect.x0, fitted_rect.y0, fitted_rect.x0, fitted_rect.y1);
-        drawDashedLine(fitted_rect.x1, fitted_rect.y0, fitted_rect.x1, fitted_rect.y1);
+        drawDashedLine(fitted_rect.x0, fitted_rect.y0,
+                       fitted_rect.x0, fitted_rect.y1, color);
+        drawDashedLine(fitted_rect.x1, fitted_rect.y0,
+                       fitted_rect.x1, fitted_rect.y1, color);
     }
     if (delta_h >= 4.0) {
-        drawDashedLine(fitted_rect.x0, fitted_rect.y0, fitted_rect.x1, fitted_rect.y0);
-        drawDashedLine(fitted_rect.x0, fitted_rect.y1, fitted_rect.x1, fitted_rect.y1);
+        drawDashedLine(fitted_rect.x0, fitted_rect.y0,
+                       fitted_rect.x1, fitted_rect.y0, color);
+        drawDashedLine(fitted_rect.x0, fitted_rect.y1,
+                       fitted_rect.x1, fitted_rect.y1, color);
     }
 
     double start_x = fitted_rect.x0;
@@ -502,7 +541,7 @@ void GuideDrawer::drawGoldenRatio(double device_scale)
     limit = std::max(limit, 10.0 * device_scale);
 
     bool clockwise = !params.mirror_golden_ratio;
-    drawGoldenRatioRecursive(start_x, start_y, length, dir, limit, clockwise);
+    drawGoldenRatioRecursive(start_x, start_y, length, dir, limit, clockwise, color);
 }
 
 /**
@@ -514,7 +553,8 @@ void GuideDrawer::drawGoldenRatio(double device_scale)
  * @param clockwise Direction of spiral while travelling inwards
  */
 void GuideDrawer::drawGoldenRatioRecursive(double x, double y, double length,
-                                           Dir dir, double limit, bool clockwise)
+                                           Dir dir, double limit, bool clockwise,
+                                           const Gdk::RGBA& color)
 {
     if (length <= limit) return;
 
@@ -611,10 +651,10 @@ void GuideDrawer::drawGoldenRatioRecursive(double x, double y, double length,
         }
     }
 
-    drawDashedArc(arc_x, arc_y, offset, arc_start, arc_end);
-    drawDashedLine(arc_x, arc_y, next_x, next_y);
+    drawDashedArc(arc_x, arc_y, offset, arc_start, arc_end, color);
+    drawDashedLine(arc_x, arc_y, next_x, next_y, color);
 
-    drawGoldenRatioRecursive(next_x, next_y, offset, next_dir, limit, clockwise);
+    drawGoldenRatioRecursive(next_x, next_y, offset, next_dir, limit, clockwise, color);
 }
 
 void GuideDrawer::drawAspectRatios()
@@ -626,9 +666,7 @@ void GuideDrawer::drawAspectRatios()
     for (const auto& entry : params.aspect_ratios) {
         if (!entry.enabled) continue;
 
-        red = entry.red;
-        green = entry.green;
-        blue = entry.blue;
+        Gdk::RGBA color = buildColor(entry.red, entry.green, entry.blue);
 
         const double aspect_ratio = [&]() {
             double result = getAspectRatioValue(entry.preset_index);
@@ -664,63 +702,66 @@ void GuideDrawer::drawAspectRatios()
 
         // Don't show new fitted rect bounds if close enough
         if (delta_w >= 2.0) {
-            drawDashedLine(fitted_rect.x0, fitted_rect.y0, fitted_rect.x0, fitted_rect.y1);
-            drawDashedLine(fitted_rect.x1, fitted_rect.y0, fitted_rect.x1, fitted_rect.y1);
+            drawDashedLine(fitted_rect.x0, fitted_rect.y0,
+                           fitted_rect.x0, fitted_rect.y1, color);
+            drawDashedLine(fitted_rect.x1, fitted_rect.y0,
+                           fitted_rect.x1, fitted_rect.y1, color);
         }
         if (delta_h >= 2.0) {
-            drawDashedLine(fitted_rect.x0, fitted_rect.y0, fitted_rect.x1, fitted_rect.y0);
-            drawDashedLine(fitted_rect.x0, fitted_rect.y1, fitted_rect.x1, fitted_rect.y1);
+            drawDashedLine(fitted_rect.x0, fitted_rect.y0,
+                           fitted_rect.x1, fitted_rect.y0, color);
+            drawDashedLine(fitted_rect.x0, fitted_rect.y1,
+                           fitted_rect.x1, fitted_rect.y1, color);
         }
     }
-
-    // Restore default crop guide color
-    red = 1.0;
-    green = 1.0;
-    blue = 1.0;
 }
 
-void GuideDrawer::drawHorizontal(double ratio)
+void GuideDrawer::drawHorizontal(double ratio, const Gdk::RGBA& color)
 {
     double y = rect.y0 + std::round((rect.y1 - rect.y0) * ratio);
-    drawDashedLine(rect.x0, y, rect.x1, y);
+    drawDashedLine(rect.x0, y, rect.x1, y, color);
 }
 
-void GuideDrawer::drawVertical(double ratio)
+void GuideDrawer::drawVertical(double ratio, const Gdk::RGBA& color)
 {
     double x = rect.x0 + std::round((rect.x1 - rect.x0) * ratio);
-    drawDashedLine(x, rect.y0, x, rect.y1);
+    drawDashedLine(x, rect.y0, x, rect.y1, color);
 }
 
-void GuideDrawer::drawDashedLine(double x0, double y0, double x1, double y1)
+void GuideDrawer::drawDashedLine(double x0, double y0, double x1, double y1,
+                                 const Gdk::RGBA& color)
 {
-    cr->set_source_rgba(red, green, blue, GUIDE_ALPHA);
+    cr->set_source_rgba(color.get_red(), color.get_green(), color.get_blue(),
+                        color.get_alpha());
     cr->move_to(x0, y0);
     cr->line_to(x1, y1);
     cr->stroke();
 
     cr->set_source_rgba(0.0, 0.0, 0.0, GUIDE_ALPHA);
-    cr->set_dash(std::valarray<double>({4}), 0);
+    cr->set_dash(std::vector<double>{GUIDE_DASH}, 0);
     cr->move_to(x0, y0);
     cr->line_to(x1, y1);
     cr->stroke();
 
     // Reset state
-    cr->set_dash(std::valarray<double>(), 0);
+    cr->set_dash(std::vector<double>{}, 0);
 }
 
-void GuideDrawer::drawDashedArc(double xc, double yc, double r, double rad0, double rad1)
+void GuideDrawer::drawDashedArc(double xc, double yc, double r,
+                                double rad0, double rad1, const Gdk::RGBA& color)
 {
-    cr->set_source_rgba(1.0, 1.0, 1.0, GUIDE_ALPHA);
+    cr->set_source_rgba(color.get_red(), color.get_green(), color.get_blue(),
+                        color.get_alpha());
     cr->arc(xc, yc, r, rad0, rad1);
     cr->stroke();
 
     cr->set_source_rgba(0.0, 0.0, 0.0, GUIDE_ALPHA);
-    cr->set_dash(std::valarray<double>({4}), 0);
+    cr->set_dash(std::vector<double>{GUIDE_DASH}, 0);
     cr->arc(xc, yc, r, rad0, rad1);
     cr->stroke();
 
     // Reset state
-    cr->set_dash(std::valarray<double>(), 0);
+    cr->set_dash(std::vector<double>{}, 0);
 }
 
 void drawCrop(const Cairo::RefPtr<Cairo::Context>& cr,

--- a/rtgui/drawcropguide.cc
+++ b/rtgui/drawcropguide.cc
@@ -230,10 +230,17 @@ CropRect calculateBleedRect(const CropRect& crop_rect, const CropGuideParams& pa
     }
 }
 
-Gdk::RGBA buildColor(double red, double green, double blue)
+Gdk::RGBA buildColor(const CropGuideParams::PresetParams& preset)
 {
     Gdk::RGBA color;
-    color.set_rgba(red, green, blue, GUIDE_ALPHA);
+    color.set_rgba(preset.red, preset.green, preset.blue, preset.alpha);
+    return color;
+}
+
+Gdk::RGBA buildColor(const CropGuideParams::AspectRatioParams& params)
+{
+    Gdk::RGBA color;
+    color.set_rgba(params.red, params.green, params.blue, params.alpha);
     return color;
 }
 
@@ -244,7 +251,7 @@ void GuideDrawer::drawRuleOfThirds()
     const auto& preset = params.presets[PresetIndex::RULE_OF_THIRDS];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     drawHorizontal(1.0 / 3.0, color);
     drawHorizontal(2.0 / 3.0, color);
@@ -257,7 +264,7 @@ void GuideDrawer::drawHarmonicMeans()
     const auto& preset = params.presets[PresetIndex::HARMONIC_MEANS];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     drawHorizontal(GOLDEN_RATIO_RECIPROCAL, color);
     drawHorizontal(1.0 - GOLDEN_RATIO_RECIPROCAL, color);
@@ -270,7 +277,7 @@ void GuideDrawer::drawCrosshair()
     const auto& preset = params.presets[PresetIndex::CROSSHAIR];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     drawHorizontal(0.5, color);
     drawVertical(0.5, color);
@@ -281,7 +288,7 @@ void GuideDrawer::drawGrid()
     const auto& preset = params.presets[PresetIndex::GRID];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     // To have even distribution, normalize it a bit
     const int longSideNumLines = 10;
@@ -329,7 +336,7 @@ void GuideDrawer::drawEpassport()
     const auto& preset = params.presets[PresetIndex::EPASSPORT];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     drawHorizontal(7.0 / 45.0, color);
     drawHorizontal(26.0 / 45.0, color);
@@ -342,7 +349,7 @@ void GuideDrawer::drawCenteredSquare()
     const auto& preset = params.presets[PresetIndex::CENTERED_SQUARE];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;
@@ -365,7 +372,7 @@ void GuideDrawer::drawDiagonals()
     const auto& preset = params.presets[PresetIndex::RULE_OF_DIAGONALS];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     double corners_from[4][2];
     double corners_to[4][2];
@@ -402,7 +409,7 @@ void GuideDrawer::drawGoldenTriangle()
     const auto& preset = params.presets[PresetIndex::GOLDEN_TRIANGLE];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     double x0 = rect.x0;
     double x1 = rect.x1;
@@ -437,7 +444,7 @@ void GuideDrawer::drawGoldenRatio(double device_scale)
     const auto& preset = params.presets[PresetIndex::GOLDEN_RATIO];
     if (!preset.enabled) return;
 
-    Gdk::RGBA color = buildColor(preset.red, preset.green, preset.blue);
+    Gdk::RGBA color = buildColor(preset);
 
     const double w = rect.x1 - rect.x0;
     const double h = rect.y1 - rect.y0;
@@ -666,7 +673,7 @@ void GuideDrawer::drawAspectRatios()
     for (const auto& entry : params.aspect_ratios) {
         if (!entry.enabled) continue;
 
-        Gdk::RGBA color = buildColor(entry.red, entry.green, entry.blue);
+        Gdk::RGBA color = buildColor(entry);
 
         const double aspect_ratio = [&]() {
             double result = getAspectRatioValue(entry.preset_index);

--- a/rtgui/tools/cropguide.cc
+++ b/rtgui/tools/cropguide.cc
@@ -433,9 +433,7 @@ void CropGuide::read(const rtengine::procparams::ProcParams* pp,
         }
 
         Gdk::RGBA color;
-        color.set_rgba(static_cast<float>(pp_preset.red),
-                       static_cast<float>(pp_preset.green),
-                       static_cast<float>(pp_preset.blue));
+        color.set_rgba(pp_preset.red, pp_preset.green, pp_preset.blue, pp_preset.alpha);
         preset.color = color;
         preset.preview->setRgb(color.get_red(), color.get_green(), color.get_blue());
 
@@ -463,8 +461,7 @@ void CropGuide::read(const rtengine::procparams::ProcParams* pp,
         preset->visible = param.enabled;
 
         Gdk::RGBA color;
-        color.set_rgba(static_cast<float>(param.red), static_cast<float>(param.green),
-                       static_cast<float>(param.blue));
+        color.set_rgba(param.red, param.green, param.blue, param.alpha);
         preset->color = color;
 
         m_aspect_ratio_store->insert_sorted(
@@ -502,12 +499,14 @@ void CropGuide::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedite
     }
 
     for (size_t i = 0; i < m_presets.size(); i++) {
-        auto& preset = m_presets[i];
+        const auto& preset = m_presets[i];
+        auto& pp_preset = pp->cropGuide.presets[i];
 
-        pp->cropGuide.presets[i].enabled = preset.visibility_button->get_active();
-        pp->cropGuide.presets[i].red = preset.color.get_red();
-        pp->cropGuide.presets[i].green = preset.color.get_green();
-        pp->cropGuide.presets[i].blue = preset.color.get_blue();
+        pp_preset.enabled = preset.visibility_button->get_active();
+        pp_preset.red = preset.color.get_red();
+        pp_preset.green = preset.color.get_green();
+        pp_preset.blue = preset.color.get_blue();
+        pp_preset.alpha = preset.color.get_alpha();
 
         if (pedited) {
             pedited->cropGuide.presets[i] = preset.is_dirty;
@@ -528,6 +527,7 @@ void CropGuide::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedite
         params.red = model->color.get_red();
         params.green = model->color.get_green();
         params.blue = model->color.get_blue();
+        params.alpha = model->color.get_alpha();
 
         pp->cropGuide.aspect_ratios.push_back(std::move(params));
     }
@@ -680,7 +680,7 @@ void CropGuide::onPresetPickColor(size_t index)
     auto& preset = m_presets.at(index);
 
     Gtk::ColorChooserDialog dialog;
-    dialog.set_use_alpha(false);
+    dialog.set_use_alpha(true);
     dialog.set_rgba(preset.color);
 
     int result = dialog.run();
@@ -751,7 +751,7 @@ void CropGuide::onAspectRatioPresetPickColor(size_t index, ColorPreview* preview
     auto& preset = m_aspect_ratio_presets.at(index);
 
     Gtk::ColorChooserDialog dialog;
-    dialog.set_use_alpha(false);
+    dialog.set_use_alpha(true);
     dialog.set_rgba(preset->color);
 
     int result = dialog.run();

--- a/rtgui/tools/cropguide.cc
+++ b/rtgui/tools/cropguide.cc
@@ -176,9 +176,9 @@ void CropGuide::setupEvents()
 
 void CropGuide::setupPresets()
 {
-    // N by 5 grid with columns:
+    // N by 7 grid with columns:
     //
-    // | Toggle | Label | [Rotate] | [Mirror] | [Undo] |
+    // | Toggle | Label | [Rotate] | [Mirror] | [Undo] | Color Preview | Color Picker |
     //
     // where Label may span multiple columns to fill space
     auto grid = Gtk::manage(new Gtk::Grid());
@@ -218,6 +218,29 @@ void CropGuide::setupPresets()
             return button;
         };
 
+        auto color_event_box = Gtk::manage(new Gtk::EventBox());
+        preset.preview = Gtk::manage(new ColorPreview());
+        preset.preview->set_hexpand(false);
+        preset.preview->set_halign(Gtk::ALIGN_CENTER);
+        preset.preview->set_vexpand(false);
+        preset.preview->set_valign(Gtk::ALIGN_CENTER);
+        preset.preview->set_margin_start(4);
+        preset.preview->set_margin_end(4);
+        preset.preview->setRgb(preset.color.get_red(), preset.color.get_green(),
+                               preset.color.get_blue());
+        color_event_box->add(*(preset.preview));
+        grid->attach(*color_event_box, 5, i);
+
+        auto color_button = add_button("color-picker-small", 6);
+
+        color_event_box->signal_button_release_event().connect(
+            [this, i](GdkEventButton* ev) -> bool {
+                this->onPresetPickColor(i);
+                return true;
+            });
+        color_button->signal_clicked().connect(sigc::bind(
+            sigc::mem_fun(this, &CropGuide::onPresetPickColor), i));
+
         if (type_index == CropGuideParams::PresetIndex::GOLDEN_TRIANGLE) {
             grid->attach(*label, 1, i, 2);
 
@@ -242,7 +265,7 @@ void CropGuide::setupPresets()
             undo_button->signal_clicked().connect(
                 sigc::mem_fun(this, &CropGuide::onGoldenRatioReset));
         } else {
-            grid->attach(*label, 1, i, 4);
+            grid->attach(*label, 1, i, 6);
         }
     }
 }
@@ -293,7 +316,7 @@ Gtk::Widget* CropGuide::createAspectRatioModelControls(
 {
     // N by 6 grid with columns:
     //
-    // | Toggle | Label | Color | Color Select | Rotate | Remove |
+    // | Toggle | Label | Rotate | Color | Color Select | Remove |
     //
     // where Label may span multiple columns to fill space
     auto grid = Gtk::manage(new Gtk::Grid());
@@ -318,23 +341,34 @@ Gtk::Widget* CropGuide::createAspectRatioModelControls(
     label->set_line_wrap(true);
     grid->attach(*label, 1, 0);
 
+    auto rotate_button = Gtk::manage(new Gtk::Button());
+    rotate_button->set_image(*Gtk::manage(
+        new RTImage("rotate-right-small", Gtk::ICON_SIZE_BUTTON)));
+    rotate_button->set_relief(Gtk::RELIEF_NONE);
+    grid->attach(*rotate_button, 2, 0);
+
+    rotate_button->signal_clicked().connect(sigc::bind(
+        sigc::mem_fun(this, &CropGuide::onAspectRatioPresetRotate),
+        item->index));
+
     auto color_event_box = Gtk::manage(new Gtk::EventBox());
     auto color_preview = Gtk::manage(new ColorPreview());
     color_preview->set_hexpand(false);
     color_preview->set_halign(Gtk::ALIGN_CENTER);
     color_preview->set_vexpand(false);
     color_preview->set_valign(Gtk::ALIGN_CENTER);
+    color_preview->set_margin_start(4);
     color_preview->set_margin_end(4);
     color_preview->setRgb(item->color.get_red(), item->color.get_green(),
                           item->color.get_blue());
     color_event_box->add(*color_preview);
-    grid->attach(*color_event_box, 2, 0);
+    grid->attach(*color_event_box, 3, 0);
 
     auto color_button = Gtk::manage(new Gtk::Button());
     color_button->set_image(*Gtk::manage(
         new RTImage("color-picker-small", Gtk::ICON_SIZE_BUTTON)));
     color_button->set_relief(Gtk::RELIEF_NONE);
-    grid->attach(*color_button, 3, 0);
+    grid->attach(*color_button, 4, 0);
 
     const size_t preset_index = item->index;
     color_event_box->signal_button_release_event().connect(
@@ -347,21 +381,11 @@ Gtk::Widget* CropGuide::createAspectRatioModelControls(
         item->index,
         color_preview));
 
-    auto rotate_button = Gtk::manage(new Gtk::Button());
-    rotate_button->set_image(*Gtk::manage(
-        new RTImage("rotate-right-small", Gtk::ICON_SIZE_BUTTON)));
-    rotate_button->set_relief(Gtk::RELIEF_NONE);
-    grid->attach(*rotate_button, 4, 0);
-
-    rotate_button->signal_clicked().connect(sigc::bind(
-        sigc::mem_fun(this, &CropGuide::onAspectRatioPresetRotate),
-        item->index));
-
     auto remove_button = Gtk::manage(new Gtk::Button());
     remove_button->set_image(*Gtk::manage(
         new RTImage("cancel-small", Gtk::ICON_SIZE_BUTTON)));
     remove_button->set_relief(Gtk::RELIEF_NONE);
-    grid->attach(*remove_button, 6, 0);
+    grid->attach(*remove_button, 5, 0);
 
     remove_button->signal_clicked().connect(sigc::bind(
         sigc::mem_fun(this, &CropGuide::onAspectRatioPresetRemoved),
@@ -398,14 +422,22 @@ void CropGuide::read(const rtengine::procparams::ProcParams* pp,
     }
 
     for (size_t i = 0; i < m_presets.size(); i++) {
+        const auto& pp_preset = pp->cropGuide.presets[i];
         auto& preset = m_presets[i];
-        bool is_enabled = pp->cropGuide.presets[i];
+        bool is_enabled = pp_preset.enabled;
 
         if (preset.visibility_button->get_active() != is_enabled) {
             ConnectionBlocker block(preset.visibility_conn);
             preset.visibility_button->set_active(is_enabled);
             updateImage(preset.visibility_button, is_enabled);
         }
+
+        Gdk::RGBA color;
+        color.set_rgba(static_cast<float>(pp_preset.red),
+                       static_cast<float>(pp_preset.green),
+                       static_cast<float>(pp_preset.blue));
+        preset.color = color;
+        preset.preview->setRgb(color.get_red(), color.get_green(), color.get_blue());
 
         if (pedited) {
             preset.is_dirty = pedited->cropGuide.presets[i];
@@ -472,7 +504,10 @@ void CropGuide::write(rtengine::procparams::ProcParams* pp, ParamsEdited* pedite
     for (size_t i = 0; i < m_presets.size(); i++) {
         auto& preset = m_presets[i];
 
-        pp->cropGuide.presets[i] = preset.visibility_button->get_active();
+        pp->cropGuide.presets[i].enabled = preset.visibility_button->get_active();
+        pp->cropGuide.presets[i].red = preset.color.get_red();
+        pp->cropGuide.presets[i].green = preset.color.get_green();
+        pp->cropGuide.presets[i].blue = preset.color.get_blue();
 
         if (pedited) {
             pedited->cropGuide.presets[i] = preset.is_dirty;
@@ -637,6 +672,29 @@ void CropGuide::onGoldenRatioReset()
     if (listener && getEnabled()) {
         listener->panelChanged(EvCropGuidePresetChanged, M(GUIDE_TYPE_OPTIONS.at(
             CropGuideParams::PresetIndex::GOLDEN_RATIO)));
+    }
+}
+
+void CropGuide::onPresetPickColor(size_t index)
+{
+    auto& preset = m_presets.at(index);
+
+    Gtk::ColorChooserDialog dialog;
+    dialog.set_use_alpha(false);
+    dialog.set_rgba(preset.color);
+
+    int result = dialog.run();
+    if (result != Gtk::RESPONSE_OK) return;
+
+    Gdk::RGBA color = dialog.get_rgba();
+    preset.color = color;
+    preset.is_dirty = true;
+
+    preset.preview->setRgb(color.get_red(), color.get_green(), color.get_blue());
+
+    if (listener && getEnabled()) {
+        listener->panelChanged(EvCropGuidePresetChanged,
+                               M(GUIDE_TYPE_OPTIONS.at(index)));
     }
 }
 

--- a/rtgui/tools/cropguide.h
+++ b/rtgui/tools/cropguide.h
@@ -90,8 +90,10 @@ private:
     };
 
     struct Preset {
+        ColorPreview* preview = nullptr;
         Gtk::ToggleButton* visibility_button = nullptr;
         sigc::connection visibility_conn;
+        Gdk::RGBA color;
         bool is_dirty = false;
     };
 
@@ -99,6 +101,7 @@ private:
     void setupPresets();
     void setupAspectRatioGuides();
 
+    void onPresetPickColor(size_t index);
     void onAspectRatioComboChanged();
     void onAspectRatioPresetToggled(Gtk::ToggleButton* button, size_t index);
     void onAspectRatioPresetPickColor(size_t index, ColorPreview* preview);


### PR DESCRIPTION
The previous change only added colors to aspect ratio crop guides. This adds it for presets as well to close #6338.

It also allows for changing the alpha of the crop guide color. The alpha is not displayed in the color preview.