### PR TITLE
On Windows, Gio.FileInfo standard::type doesn't exist for some enumerable items.

### DIFF
--- a/rtgui/dirbrowser.cc
+++ b/rtgui/dirbrowser.cc
@@ -52,6 +52,11 @@ std::vector<Glib::ustring> listSubDirs (const Glib::RefPtr<Gio::File>& dir, bool
                 if (!file) {
                     break;
                 }
+#ifdef _WIN32
+                if (!file->has_attribute("standard::type")) {
+                    continue;
+                }
+#endif
                 if (file->get_file_type () != Gio::FILE_TYPE_DIRECTORY) {
                     continue;
                 }

--- a/rtgui/filecatalog.cc
+++ b/rtgui/filecatalog.cc
@@ -82,7 +82,11 @@ void getFilesRecursively(
                 if (!file) {
                     break;
                 }
-
+#ifdef _WIN32
+                if (!file->has_attribute("standard::type")) {
+                    continue;
+                }
+#endif
                 if (!options.fbShowHidden && file->is_hidden()) {
                     continue;
                 }


### PR DESCRIPTION
On Windows, there are some special system directories and other items such as `System Volume Information` and `Recovery` that do not have `Gio.FileInfo` `standard::type` information for some reason. This could be a Gtk bug. This results the console printing `GLib-GIO-CRITICAL **: 17:24:42.681: GFileInfo created without standard::type` type errors when such directories are enumerated and the type info is being queried.

I don't know any case where this has been harmful.

Closes #7647
