### PR TITLE
Upgrades for workflows

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -28,7 +28,7 @@ jobs:
         build_type: [release, debug]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Restore AppImage tools from cache
         id: appimage-tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: appimage-tools-1
           path: |
@@ -204,7 +204,7 @@ jobs:
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_NAME}}.AppImage
           path: ${{github.workspace}}/build/${{env.ARTIFACT_NAME}}.AppImage
@@ -226,7 +226,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
 
       - name: Publish artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         with:
           tag_name: nightly-github-actions
@@ -256,7 +256,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
 
       - name: Publish pre-dev artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-publish-pre-dev.outcome == 'success'}}
         with:
           tag_name: pre-dev-github-actions
@@ -275,7 +275,7 @@ jobs:
         build_type: [release, debug]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -413,7 +413,7 @@ jobs:
 
       - name: Restore AppImage tools from cache
         id: appimage-tools-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: appimage-tools-1
           path: |
@@ -468,7 +468,7 @@ jobs:
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_NAME}}.AppImage
           path: ${{github.workspace}}/build/${{env.ARTIFACT_NAME}}.AppImage
@@ -490,7 +490,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
 
       - name: Publish artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         with:
           tag_name: nightly-github-actions
@@ -520,7 +520,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
 
       - name: Publish pre-dev artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-publish-pre-dev.outcome == 'success'}}
         with:
           tag_name: pre-dev-github-actions

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install Exiv2
         run: |
-          EXIV2_VERSION='v0.28.5'
+          EXIV2_VERSION='v0.28.8'
           echo "Cloning Exiv2 $EXIV2_VERSION."
           git clone --depth 1 --branch "$EXIV2_VERSION" https://github.com/Exiv2/exiv2.git ext/exiv2
 
@@ -288,7 +288,7 @@ jobs:
 
       - name: Install Exiv2
         run: |
-          EXIV2_VERSION='v0.28.5'
+          EXIV2_VERSION='v0.28.8'
           echo "Cloning Exiv2 $EXIV2_VERSION."
           git clone --depth 1 --branch "$EXIV2_VERSION" https://github.com/Exiv2/exiv2.git ext/exiv2
 
@@ -303,8 +303,8 @@ jobs:
       - name: Install libjxl
         working-directory: .
         run: |
-          echo "Building and installing libjxl v0.11.1..."
-          git clone --depth 1 --branch 'v0.11.1' 'https://github.com/libjxl/libjxl.git'
+          echo "Building and installing libjxl v0.11.2..."
+          git clone --depth 1 --branch 'v0.11.2' 'https://github.com/libjxl/libjxl.git'
           cd libjxl
           ./deps.sh
           mkdir build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
           echo "REF_NAME_FILTERED=$REF_NAME_FILTERED" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
@@ -105,6 +105,6 @@ jobs:
           mv AppDir/usr/bin/share AppDir/usr/
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: 
           fetch-tags: '0'
           fetch-depth: '0'
@@ -106,7 +106,7 @@ jobs:
             "ARTIFACT_FILE: ${ARTIFACT_FILE}" \
             "PUBLISH_NAME: ${PUBLISH_NAME}"
           exit
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_FILE}}
           path: ${{env.ARTIFACT_PATH}}
@@ -131,7 +131,7 @@ jobs:
           echo "$(RawTherapee*folder/rawtherapee-cli --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Publish artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         with:
           tag_name: nightly-github-actions
@@ -145,7 +145,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: 
           fetch-tags: '0'
           fetch-depth: '0'
@@ -230,7 +230,7 @@ jobs:
             "PUBLISH_NAME: ${PUBLISH_NAME}"
           exit
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_FILE}}
           path: ${{env.ARTIFACT_PATH}}
@@ -255,7 +255,7 @@ jobs:
           echo "$(RawTherapee*folder/rawtherapee-cli --version)" >> $GITHUB_STEP_SUMMARY
 
       - name: Publish artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{github.ref_type == 'tag' || github.ref_name == 'dev'}}
         with:
           tag_name: nightly-github-actions

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
       REF_NAME_FILTERED: ${{ steps.prepare-artifact-name.outputs.REF_NAME_FILTERED }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -215,14 +215,14 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_NAME}}
           path: build\${{env.ARTIFACT_NAME}}
 
       - name: Upload installer
         if: ${{matrix.build_type == 'release'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{env.ARTIFACT_NAME}}.exe
           path: build\${{env.ARTIFACT_NAME}}.exe
@@ -253,7 +253,7 @@ jobs:
       - name: Download build artifact
         id: download-build-artifact
         if: ${{steps.initialize.outcome == 'success'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{env.ARTIFACT_NAME}}
           path: build/${{env.ARTIFACT_NAME}}
@@ -261,7 +261,7 @@ jobs:
       - name: Download installer
         id: download-installer
         if: ${{steps.download-build-artifact.outcome == 'success' && matrix.build_type == 'release'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{env.ARTIFACT_NAME}}.exe
           path: build
@@ -296,7 +296,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> "$(cygpath -u $GITHUB_ENV)"
 
       - name: Publish artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-for-publishing.outcome == 'success'}}
         with:
           tag_name: nightly-github-actions
@@ -305,7 +305,7 @@ jobs:
             build/${{env.PUBLISH_NAME}}-AboutThisBuild.txt
 
       - name: Publish installer
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-for-publishing.outcome == 'success' && matrix.build_type == 'release'}}
         with:
           tag_name: nightly-github-actions
@@ -337,7 +337,7 @@ jobs:
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> "$(cygpath -u $GITHUB_ENV)"
 
       - name: Publish pre-dev artifacts
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-publish-pre-dev.outcome == 'success'}}
         with:
           tag_name: pre-dev-github-actions
@@ -347,7 +347,7 @@ jobs:
             build/${{env.PUBLISH_NAME}}-AboutThisBuild.txt
 
       - name: Publish pre-dev installer
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{steps.prepare-publish-pre-dev.outcome == 'success' && matrix.build_type == 'release'}}
         with:
           tag_name: pre-dev-github-actions
@@ -370,7 +370,7 @@ jobs:
     steps:
       - name: Download build artifact
         id: download-build-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{env.ARTIFACT_NAME}}
           path: build/${{env.ARTIFACT_NAME}}

--- a/tools/makedeb/PKGBUILD.libjxl
+++ b/tools/makedeb/PKGBUILD.libjxl
@@ -2,7 +2,7 @@
 
 _pkgname="libjxl"
 pkgname="$_pkgname"
-pkgver='0.11.1'
+pkgver='0.11.2'
 pkgrel='1'
 pkgdesc='JPEG XL image format reference implementation'
 url='https://github.com/libjxl/libjxl'


### PR DESCRIPTION
This is to make sure the GitHub workflows are in good condition and all dependencies are upgraded in preparation for the 5.13 release.

- Upgrades actions to use Node.js 24 because Node.js 20 is being deprecated.
- Upgrades CodeQL actions to v4 because of the v3 deprecation.
- Upgrades the AppImage Exiv2 to the latest version (v0.28.8).
- Upgrades the AppImage libjxl to the latest version (v0.11.2).