### PR TITLE
Fix for crash on small images

### DIFF
--- a/rtengine/image16.cc
+++ b/rtengine/image16.cc
@@ -218,20 +218,23 @@ void Image16::getStdImage(const ColorTemp &ctemp, int tran, Imagefloat* image, c
 
         // Iterating all the rows of the destination image
         for (int iy = 0; iy < imheight; iy++) {
+            int dst_x_lim = imwidth; // One less is the largest dst_x used.
+
             if (skip == 1) {
                 // special case (speedup for 1:1 scale)
                 // i: source image, first line of the current destination row
                 int src_y = sy1 + iy;
 
-                // overflow security check, not sure that it's necessary
+                // overflow security check
                 if (src_y >= maxy) {
                     continue;
                 }
 
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x++) {
-                    // overflow security check, not sure that it's necessary
+                    // overflow security check
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     lineR[dst_x] = CLIP(rm2 * r(src_y, src_x));
@@ -248,7 +251,8 @@ void Image16::getStdImage(const ColorTemp &ctemp, int tran, Imagefloat* image, c
 
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     int src_sub_width = MIN(maxx - src_x, skip);
@@ -281,22 +285,22 @@ void Image16::getStdImage(const ColorTemp &ctemp, int tran, Imagefloat* image, c
             }
 
             if (mtran == TR_NONE)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(iy, dst_x) = lineR[dst_x];
                     image->g(iy, dst_x) = lineG[dst_x];
                     image->b(iy, dst_x) = lineB[dst_x];
                 } else if (mtran == TR_R180)
-                for (int dst_x = 0; dst_x < imwidth; dst_x++) {
+                for (int dst_x = 0; dst_x < dst_x_lim; dst_x++) {
                     image->r(imheight - 1 - iy, imwidth - 1 - dst_x) = lineR[dst_x];
                     image->g(imheight - 1 - iy, imwidth - 1 - dst_x) = lineG[dst_x];
                     image->b(imheight - 1 - iy, imwidth - 1 - dst_x) = lineB[dst_x];
                 } else if (mtran == TR_R90)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(dst_x, imheight - 1 - iy) = lineR[dst_x];
                     image->g(dst_x, imheight - 1 - iy) = lineG[dst_x];
                     image->b(dst_x, imheight - 1 - iy) = lineB[dst_x];
                 } else if (mtran == TR_R270)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(imwidth - 1 - dst_x, iy) = lineR[dst_x];
                     image->g(imwidth - 1 - dst_x, iy) = lineG[dst_x];
                     image->b(imwidth - 1 - dst_x, iy) = lineB[dst_x];

--- a/rtengine/image8.cc
+++ b/rtengine/image8.cc
@@ -168,12 +168,14 @@ void Image8::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* image, c
 
         // Iterating all the rows of the destination image
         for (int iy = 0; iy < imheight; iy++) {
+            int dst_x_lim = imwidth; // One less is the largest dst_x used.
+
             if (skip == 1) {
                 // special case (speedup for 1:1 scale)
                 // i: source image, first line of the current destination row
                 int src_y = sy1 + iy;
 
-                // overflow security check, not sure that it's necessary
+                // overflow security check
                 if (src_y >= maxy) {
                     continue;
                 }
@@ -181,9 +183,10 @@ void Image8::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* image, c
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x++) {
                     float r_, g_, b_;
 
-                    // overflow security check, not sure that it's necessary
+                    // overflow security check
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     convertTo(r(src_y, src_x), r_);
@@ -203,7 +206,8 @@ void Image8::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* image, c
 
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     int src_sub_width = MIN(maxx - src_x, skip);
@@ -240,25 +244,25 @@ void Image8::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* image, c
             }
 
             if      (mtran == TR_NONE)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(iy, dst_x) = lineR[dst_x];
                     image->g(iy, dst_x) = lineG[dst_x];
                     image->b(iy, dst_x) = lineB[dst_x];
                 }
             else if (mtran == TR_R180)
-                for (int dst_x = 0; dst_x < imwidth; dst_x++) {
+                for (int dst_x = 0; dst_x < dst_x_lim; dst_x++) {
                     image->r(imheight - 1 - iy, imwidth - 1 - dst_x) = lineR[dst_x];
                     image->g(imheight - 1 - iy, imwidth - 1 - dst_x) = lineG[dst_x];
                     image->b(imheight - 1 - iy, imwidth - 1 - dst_x) = lineB[dst_x];
                 }
             else if (mtran == TR_R90)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(dst_x, imheight - 1 - iy) = lineR[dst_x];
                     image->g(dst_x, imheight - 1 - iy) = lineG[dst_x];
                     image->b(dst_x, imheight - 1 - iy) = lineB[dst_x];
                 }
             else if (mtran == TR_R270)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(imwidth - 1 - dst_x, iy) = lineR[dst_x];
                     image->g(imwidth - 1 - dst_x, iy) = lineG[dst_x];
                     image->b(imwidth - 1 - dst_x, iy) = lineB[dst_x];

--- a/rtengine/imagefloat.cc
+++ b/rtengine/imagefloat.cc
@@ -341,6 +341,23 @@ void Imagefloat::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* imag
 #endif
 }
 
+void Imagefloat::fill(const float value, const bool multithread)
+{
+    const int W = width;
+    const int H = height;
+
+#ifdef _OPENMP
+#   pragma omp parallel for firstprivate(W, H) schedule(dynamic, 5) if (multithread)
+#endif
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            r(y, x) = value;
+            g(y, x) = value;
+            b(y, x) = value;
+        }
+    }
+}
+
 // From ART.
 void Imagefloat::multiply(float factor, bool multithread)
 {

--- a/rtengine/imagefloat.cc
+++ b/rtengine/imagefloat.cc
@@ -248,20 +248,23 @@ void Imagefloat::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* imag
 #endif
 
         for (int iy = 0; iy < imheight; iy++) {
+            int dst_x_lim = imwidth; // One less is the largest dst_x used.
+
             if (skip == 1) {
                 // special case (speedup for 1:1 scale)
                 // i: source image, first line of the current destination row
                 int src_y = sy1 + iy;
 
-                // overflow security check, not sure that it's necessary
+                // overflow security check
                 if (src_y >= maxy) {
                     continue;
                 }
 
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x++) {
-                    // overflow security check, not sure that it's necessary
+                    // overflow security check
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     lineR[dst_x] = CLIP0(rm2 * r(src_y, src_x));
@@ -278,7 +281,8 @@ void Imagefloat::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* imag
 
                 for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
                     if (src_x >= maxx) {
-                        continue;
+                        dst_x_lim = dst_x;
+                        break;
                     }
 
                     int src_sub_width = MIN(maxx - src_x, skip);
@@ -311,25 +315,25 @@ void Imagefloat::getStdImage (const ColorTemp &ctemp, int tran, Imagefloat* imag
             }
 
             if      (mtran == TR_NONE)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(iy, dst_x) = lineR[dst_x];
                     image->g(iy, dst_x) = lineG[dst_x];
                     image->b(iy, dst_x) = lineB[dst_x];
                 }
             else if (mtran == TR_R180)
-                for (int dst_x = 0; dst_x < imwidth; dst_x++) {
+                for (int dst_x = 0; dst_x < dst_x_lim; dst_x++) {
                     image->r(imheight - 1 - iy, imwidth - 1 - dst_x) = lineR[dst_x];
                     image->g(imheight - 1 - iy, imwidth - 1 - dst_x) = lineG[dst_x];
                     image->b(imheight - 1 - iy, imwidth - 1 - dst_x) = lineB[dst_x];
                 }
             else if (mtran == TR_R90)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(dst_x, imheight - 1 - iy) = lineR[dst_x];
                     image->g(dst_x, imheight - 1 - iy) = lineG[dst_x];
                     image->b(dst_x, imheight - 1 - iy) = lineB[dst_x];
                 }
             else if (mtran == TR_R270)
-                for (int dst_x = 0, src_x = sx1; dst_x < imwidth; dst_x++, src_x += skip) {
+                for (int dst_x = 0, src_x = sx1; dst_x < dst_x_lim; dst_x++, src_x += skip) {
                     image->r(imwidth - 1 - dst_x, iy) = lineR[dst_x];
                     image->g(imwidth - 1 - dst_x, iy) = lineG[dst_x];
                     image->b(imwidth - 1 - dst_x, iy) = lineB[dst_x];

--- a/rtengine/imagefloat.h
+++ b/rtengine/imagefloat.h
@@ -213,6 +213,7 @@ public:
         return (uint32_t) ((lsign << 31) | (exponent << 23) | mantissa);
     }
 
+    void fill(const float value, const bool multithread = false);
     void multiply(float factor, bool multithread);
     void                 normalizeFloat(float srcMinVal, float srcMaxVal) override;
     void                 normalizeFloatTo1(bool multithread=true);

--- a/rtengine/simpleprocess.cc
+++ b/rtengine/simpleprocess.cc
@@ -661,6 +661,7 @@ private:
                 {
                     Imagefloat *origCropPart;//init auto noise
                     origCropPart = new Imagefloat(crW, crH); //allocate memory
+                    origCropPart->fill(0.f);
                     Imagefloat *provicalc = new Imagefloat((crW + 1) / 2, (crH + 1) / 2);  //for denoise curves
 
 #ifdef _OPENMP


### PR DESCRIPTION
Fixes use of uninitialized values. The uninitialized values can lead to crashes in some cases, like denoising a small image.

One place where uninitialized values are used is in a `simpleprocess` temporary image. The fix is to fill the image with 0.

Another place is when reading pixels from a source image. Only a subregion may be copied. The current code uses values in buffers corresponding to pixels outside the subregion. Those values may be uninitialized or are old values. The fix is to not copy those values over to the final destination. The problematic code is duplicated and appears in Image8, Image16, and Imagefloat. I applied the fix in all three.

Fixes #7639.