### PR TITLE
fix: respect explicit PROJECT_SOURCE_DIR in UpdateInfo.cmake on macOS

### DIFF
--- a/UpdateInfo.cmake
+++ b/UpdateInfo.cmake
@@ -1,7 +1,7 @@
 # cmakefile executed within a makefile target
 
-if(APPLE)
-    set(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+if(APPLE AND (NOT DEFINED PROJECT_SOURCE_DIR OR PROJECT_SOURCE_DIR STREQUAL ""))
+    set(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 endif()
 
 # If we find ReleaseInfo.cmake we use the info from there and don't need Git to be installed


### PR DESCRIPTION
This fixes a macOS source-build issue in `UpdateInfo.cmake` during out-of-source builds.

## Problem

On macOS, `UpdateInfo.cmake` resets `PROJECT_SOURCE_DIR` using `CMAKE_CURRENT_SOURCE_DIR` when run in script mode. In this build path, that can resolve relative to the build directory instead of the repository root, which breaks generation of versioned files.

Observed failure during an out-of-source build:

```text
CMake Error: File <build-root>/build/rtgui/version.h.in does not exist.
CMake Error at UpdateInfo.cmake:153 (configure_file):
  configure_file Problem configuring file
```

## Repro

1. Configure an out-of-source build in a nested build directory on macOS
2. Build `rawtherapee-cli`

Example:

```bash
cmake -S . -B build/codex-dev-llvm -G Ninja ...
cmake --build build/codex-dev-llvm --target rawtherapee-cli
```

## Root Cause

`UpdateInfo.cmake` uses `CMAKE_CURRENT_SOURCE_DIR` in script mode, which is not the right variable for locating the script itself here.

## Fix

Use `CMAKE_CURRENT_LIST_DIR` and only set `PROJECT_SOURCE_DIR` if it was not already provided by the caller.

This keeps the existing behavior intact while making the macOS out-of-source path reliable.
