### PR TITLE
Add Hald CLUT LUT export button to the editor

### DIFF
--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1880,7 +1880,6 @@ MAIN_BUTTON_NAVSYNC_TOOLTIP;Synchronize the File Browser or Filmstrip with the E
 MAIN_BUTTON_PREFERENCES;Preferences
 MAIN_BUTTON_PUTTOQUEUE_TOOLTIP;Put current image to processing queue.\nShortcut: <b>Ctrl+b</b>
 MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE;Export Hald CLUT LUT
-MAIN_BUTTON_SAVE_LUT_FILENAME;Filename
 MAIN_BUTTON_SAVE_LUT_TOOLTIP;Export a Hald CLUT PNG LUT.\nApplies colorimetric adjustments (white balance, curves, color grading)\nto a Hald 12 identity image and saves the result as PNG.
 MAIN_BUTTON_SAVE_TOOLTIP;Save current image.\nShortcut: <b>Ctrl+s</b>\nSave current profile (.pp3).\nShortcut: <b>Ctrl+Shift+s</b>
 MAIN_BUTTON_SENDTOEDITOR;Edit image in external editor

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1879,6 +1879,9 @@ MAIN_BUTTON_NAVPREV_TOOLTIP;Navigate to the previous image relative to image ope
 MAIN_BUTTON_NAVSYNC_TOOLTIP;Synchronize the File Browser or Filmstrip with the Editor to reveal the thumbnail of the currently opened image, and clear any active filters.\nShortcut: <b>x</b>\n\nAs above, but without clearing active filters:\nShortcut: <b>y</b>\n(Note that the thumbnail of the opened image will not be shown if filtered out).
 MAIN_BUTTON_PREFERENCES;Preferences
 MAIN_BUTTON_PUTTOQUEUE_TOOLTIP;Put current image to processing queue.\nShortcut: <b>Ctrl+b</b>
+MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE;Export Hald CLUT LUT
+MAIN_BUTTON_SAVE_LUT_FILENAME;Filename
+MAIN_BUTTON_SAVE_LUT_TOOLTIP;Export a Hald CLUT PNG LUT.\nApplies colorimetric adjustments (white balance, curves, color grading)\nto a Hald 12 identity image and saves the result as PNG.
 MAIN_BUTTON_SAVE_TOOLTIP;Save current image.\nShortcut: <b>Ctrl+s</b>\nSave current profile (.pp3).\nShortcut: <b>Ctrl+Shift+s</b>
 MAIN_BUTTON_SENDTOEDITOR;Edit image in external editor
 MAIN_BUTTON_SENDTOEDITOR_TOOLTIP;Edit current image in external editor.\nShortcut: <b>Ctrl+e</b>\nCurrent editor:

--- a/rtdata/languages/default
+++ b/rtdata/languages/default
@@ -1880,6 +1880,7 @@ MAIN_BUTTON_NAVSYNC_TOOLTIP;Synchronize the File Browser or Filmstrip with the E
 MAIN_BUTTON_PREFERENCES;Preferences
 MAIN_BUTTON_PUTTOQUEUE_TOOLTIP;Put current image to processing queue.\nShortcut: <b>Ctrl+b</b>
 MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE;Export Hald CLUT LUT
+MAIN_BUTTON_SAVE_LUT_INCLUDE_TONECURVE;Include tone curve
 MAIN_BUTTON_SAVE_LUT_TOOLTIP;Export a Hald CLUT PNG LUT.\nApplies colorimetric adjustments (white balance, curves, color grading)\nto a Hald 12 identity image and saves the result as PNG.
 MAIN_BUTTON_SAVE_TOOLTIP;Save current image.\nShortcut: <b>Ctrl+s</b>\nSave current profile (.pp3).\nShortcut: <b>Ctrl+Shift+s</b>
 MAIN_BUTTON_SENDTOEDITOR;Edit image in external editor

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -270,6 +270,38 @@ void rtengine::HaldCLUT::getRGB(
     }
 }
 
+Glib::ustring rtengine::HaldCLUT::createIdentityTempFile(int level)
+{
+    const int cube  = level * level;          // samples per axis
+    const int size  = level * level * level;  // image side length
+    const float den = static_cast<float>(cube - 1);
+
+    Imagefloat img(size, size);
+
+    for (int y = 0; y < size; ++y) {
+        for (int x = 0; x < size; ++x) {
+            const int idx   = y * size + x;
+            const int b_idx = idx / (cube * cube);
+            const int rem   = idx % (cube * cube);
+            const int g_idx = rem / cube;
+            const int r_idx = rem % cube;
+
+            img.r(y, x) = r_idx * 65535.0f / den;
+            img.g(y, x) = g_idx * 65535.0f / den;
+            img.b(y, x) = b_idx * 65535.0f / den;
+        }
+    }
+
+    const Glib::ustring tmpPath =
+        Glib::build_filename(Glib::get_tmp_dir(), "rt_hald_identity.png");
+
+    if (img.saveAsPNG(tmpPath, 16) != 0) {
+        return {};
+    }
+
+    return tmpPath;
+}
+
 void rtengine::HaldCLUT::splitClutFilename(
     const Glib::ustring& filename,
     Glib::ustring& name,

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -41,6 +41,11 @@ public:
         bool checkProfile = true
     );
 
+    // Generate a Hald CLUT identity image at the given level, save it to a
+    // temporary PNG file (16-bit), and return the path.  Returns an empty
+    // string on failure.  The caller is responsible for deleting the file.
+    static Glib::ustring createIdentityTempFile(int level);
+
 private:
     AlignedBuffer<std::uint16_t> clut_image;
     unsigned int clut_level;

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -24,6 +24,7 @@
 #include "rtengine/array2D.h"
 #include "rtengine/clutstore.h"
 #include "rtengine/imagesource.h"
+#include "rtengine/utils.h"
 #include "rtengine/iccstore.h"
 #include "batchqueue.h"
 #include "batchqueueentry.h"
@@ -3002,46 +3003,54 @@ void EditorPanel::saveLUTPressed ()
 
     auto* toplevel = static_cast<Gtk::Window*>(get_toplevel());
 
-    // Ask the user where to save the LUT PNG.
-    // Use SELECT_FOLDER so the native portal never hides the filename entry.
-    Gtk::FileChooserDialog dialog(*toplevel,
-        M("MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE"),
-        Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER);
-    dialog.add_button(M("GENERAL_CANCEL"), Gtk::RESPONSE_CANCEL);
-    dialog.add_button(M("GENERAL_OK"),     Gtk::RESPONSE_OK);
+    // Build the dialog using the same pattern as SaveAsDialog.
+    Gtk::Dialog dialog(M("MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE"), *toplevel);
+
+    Gtk::FileChooserWidget* fchooser = Gtk::manage(
+        new Gtk::FileChooserWidget(Gtk::FILE_CHOOSER_ACTION_SAVE));
 
     auto& opts = App::get().mut_options();
     if (Glib::file_test(opts.lastSaveAsPath, Glib::FILE_TEST_IS_DIR)) {
-        dialog.set_current_folder(opts.lastSaveAsPath);
+        fchooser->set_current_folder(opts.lastSaveAsPath);
     }
+    fchooser->set_current_name("lut.png");
 
-    // Filename entry embedded in the dialog as an extra widget.
-    Gtk::Box* extraBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 6));
-    Gtk::Label* fnLabel = Gtk::manage(new Gtk::Label(M("MAIN_BUTTON_SAVE_LUT_FILENAME") + ":"));
-    Gtk::Entry* fnEntry = Gtk::manage(new Gtk::Entry());
-    fnEntry->set_text("lut");
-    fnEntry->set_width_chars(32);
-    extraBox->pack_start(*fnLabel, false, false, 0);
-    extraBox->pack_start(*fnEntry, true, true, 0);
-    extraBox->show_all();
-    dialog.set_extra_widget(*extraBox);
+    auto filter_png = Gtk::FileFilter::create();
+    filter_png->set_name("PNG");
+    filter_png->add_pattern("*.png");
+    filter_png->add_pattern("*.PNG");
+    fchooser->set_filter(filter_png);
+
+    fchooser->signal_file_activated().connect([&dialog]() {
+        dialog.response(Gtk::RESPONSE_OK);
+    });
+
+    Gtk::Button* ok     = Gtk::manage(new Gtk::Button(M("GENERAL_OK")));
+    Gtk::Button* cancel = Gtk::manage(new Gtk::Button(M("GENERAL_CANCEL")));
+    ok->signal_clicked().connect([&dialog]()     { dialog.response(Gtk::RESPONSE_OK); });
+    cancel->signal_clicked().connect([&dialog]() { dialog.response(Gtk::RESPONSE_CANCEL); });
+
+    dialog.get_content_area()->pack_start(*fchooser);
+    dialog.get_action_area()->pack_end(*ok,     Gtk::PACK_SHRINK, 4);
+    dialog.get_action_area()->pack_end(*cancel, Gtk::PACK_SHRINK, 4);
+    dialog.show_all_children();
 
     if (dialog.run() != Gtk::RESPONSE_OK) {
         return;
     }
 
-    Glib::ustring lutName = fnEntry->get_text();
-    if (lutName.empty()) {
-        lutName = "lut";
-    }
-    // Strip .png if the user typed it — we always append it ourselves.
-    if (lutName.size() > 4 && lutName.substr(lutName.size() - 4) == ".png") {
-        lutName = lutName.substr(0, lutName.size() - 4);
+    Glib::ustring destPath = fchooser->get_filename();
+    if (destPath.empty()) {
+        destPath = Glib::build_filename(
+            fchooser->get_current_folder(), fchooser->get_current_name());
     }
 
-    const Glib::ustring destDir = dialog.get_filename();
-    Glib::ustring destPath = Glib::build_filename(destDir, lutName + ".png");
-    opts.lastSaveAsPath = destDir;
+    // Append .png if the user omitted it.
+    if (rtengine::getFileExtension(destPath).lowercase() != "png") {
+        destPath += ".png";
+    }
+
+    opts.lastSaveAsPath = Glib::path_get_dirname(destPath);
 
     // Ask before overwriting an existing file.
     if (Glib::file_test(destPath, Glib::FILE_TEST_EXISTS)) {

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -707,19 +707,32 @@ public:
 namespace
 {
 
-// Returns a copy of src with all spatially-dependent and non-colorimetric
-// tools disabled, suitable for applying to a Hald CLUT identity image.
-// Kept: white balance, tone curves, exposure, Lab curves, RGB curves, HSV
-// equalizer, vibrance, colour toning, colour appearance, shadows/highlights,
-// tone equalizer, gamut compression, dehaze, soft-light, film simulation,
-// channel mixer, black & white, output colour management.
+// Returns a copy of src suitable for processing a Hald CLUT identity image.
+//
+// The generated LUT operates on display-referred (already tone-curved) values,
+// matching how RT applies its own film simulation CLUTs: gamma sRGB is applied
+// before the CLUT lookup, inverse gamma after.  This means the tone curve must
+// NOT be included — it is applied by the camera (or host application) before
+// the LUT, and including it here would double the effect.
+//
+// Kept: Lab curves, RGB curves, HSV equalizer, vibrance, colour toning,
+//       colour appearance, shadows/highlights, tone equalizer, gamut
+//       compression, dehaze, soft-light, film simulation, channel mixer,
+//       black & white, output colour management.
+// Reset to neutral: tone curve, exposure, white balance.
 // Disabled: sharpening, noise reduction, edge-preserving / Retinex tone
-// mapping, local contrast, all geometric transforms, lens/CA/vignette
-// corrections, gradient, spot removal, locallab, wavelet, dir-pyr, resize,
-// framing, film negative.
-ProcParams makeLUTProcParams(const ProcParams& src)
+//           mapping, local contrast, all geometric transforms, lens/CA/vignette
+//           corrections, gradient, spot removal, locallab, wavelet, dir-pyr,
+//           resize, framing, film negative.
+ProcParams makeLUTProcParams(const ProcParams& src, bool includeToneCurve)
 {
     ProcParams p = src;
+
+    // Tone curve and exposure — applied before the CLUT in RT's pipeline.
+    // Reset to neutral unless the user explicitly wants to bake it into the LUT.
+    if (!includeToneCurve) {
+        p.toneCurve = ToneCurveParams{};
+    }
 
     // Sharpening (spatial)
     p.sharpening.enabled   = false;
@@ -3025,12 +3038,17 @@ void EditorPanel::saveLUTPressed ()
         dialog.response(Gtk::RESPONSE_OK);
     });
 
+    Gtk::CheckButton* toneCurveCb = Gtk::manage(
+        new Gtk::CheckButton(M("MAIN_BUTTON_SAVE_LUT_INCLUDE_TONECURVE")));
+    toneCurveCb->set_active(false);
+
     Gtk::Button* ok     = Gtk::manage(new Gtk::Button(M("GENERAL_OK")));
     Gtk::Button* cancel = Gtk::manage(new Gtk::Button(M("GENERAL_CANCEL")));
     ok->signal_clicked().connect([&dialog]()     { dialog.response(Gtk::RESPONSE_OK); });
     cancel->signal_clicked().connect([&dialog]() { dialog.response(Gtk::RESPONSE_CANCEL); });
 
     dialog.get_content_area()->pack_start(*fchooser);
+    dialog.get_content_area()->pack_start(*toneCurveCb, Gtk::PACK_SHRINK, 4);
     dialog.get_action_area()->pack_end(*ok,     Gtk::PACK_SHRINK, 4);
     dialog.get_action_area()->pack_end(*cancel, Gtk::PACK_SHRINK, 4);
     dialog.show_all_children();
@@ -3072,12 +3090,12 @@ void EditorPanel::saveLUTPressed ()
         return;
     }
 
-    // Build a colorimetric-only set of processing parameters.
+    // Build the processing parameters, optionally including the tone curve.
     ProcParams pparams;
     ipc->getParams(&pparams);
-    const ProcParams lutParams = makeLUTProcParams(pparams);
+    const ProcParams lutParams = makeLUTProcParams(pparams, toneCurveCb->get_active());
 
-    // Process the identity image asynchronously.
+    // Process the identity image asynchronously; route progress to this panel.
     rtengine::ProcessingJob* job =
         rtengine::ProcessingJob::create(tmpPath, false, lutParams);
 
@@ -3085,7 +3103,7 @@ void EditorPanel::saveLUTPressed ()
         new ProgressConnector<rtengine::IImagefloat*>();
     ld->startFunc(
         sigc::bind(sigc::ptr_fun(&rtengine::processImage),
-                   job, err, parent->getProgressListener(), false),
+                   job, err, static_cast<rtengine::ProgressListener*>(this), false),
         sigc::bind(sigc::mem_fun(*this, &EditorPanel::idle_saveLUTImage),
                    ld, destPath, tmpPath));
 
@@ -3104,7 +3122,9 @@ bool EditorPanel::idle_saveLUTImage (ProgressConnector<rtengine::IImagefloat*>* 
     } catch (...) {}
 
     if (img) {
-        // Save the processed image as 8-bit PNG asynchronously.
+        setProgressStr(M("GENERAL_SAVE"));
+        setProgress(0.9f);
+
         ProgressConnector<int>* ld = new ProgressConnector<int>();
         img->setSaveProgressListener(parent->getProgressListener());
         ld->startFunc(
@@ -3118,6 +3138,7 @@ bool EditorPanel::idle_saveLUTImage (ProgressConnector<rtengine::IImagefloat*>* 
             "<b>Error processing Hald identity image.</b>",
             true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
         msgd.run();
+        setProgressState(false);
         saveLUTBtn->set_sensitive(true);
     }
 
@@ -3141,6 +3162,9 @@ bool EditorPanel::idle_saveLUTSaved (ProgressConnector<int>* pc,
         msgd.run();
     }
 
+    parent->setProgressStr("");
+    parent->setProgress(0.);
+    setProgressState(false);
     saveLUTBtn->set_sensitive(true);
     return false;
 }

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "rtengine/array2D.h"
+#include "rtengine/clutstore.h"
 #include "rtengine/imagesource.h"
 #include "rtengine/iccstore.h"
 #include "batchqueue.h"
@@ -704,54 +705,6 @@ public:
 
 namespace
 {
-
-// Generate a Hald CLUT identity PNG at the given level and write it to a temp
-// file.  For level 12 the image is 1728×1728 pixels with 144 samples per
-// colour axis.  Returns the path of the temp file, or an empty string on
-// failure.
-Glib::ustring generateHaldIdentityPNG(int level)
-{
-    const int cube = level * level;
-    const int size = level * level * level;
-    const double den = static_cast<double>(cube - 1);
-
-    auto pixbuf = Gdk::Pixbuf::create(Gdk::COLORSPACE_RGB, false, 8, size, size);
-
-    if (!pixbuf) {
-        return {};
-    }
-
-    const int rowstride = pixbuf->get_rowstride();
-    guchar* const pixels = pixbuf->get_pixels();
-
-    for (int y = 0; y < size; y++) {
-        guchar* row = pixels + y * rowstride;
-
-        for (int x = 0; x < size; x++) {
-            const int idx   = y * size + x;
-            const int b_idx = idx / (cube * cube);
-            const int rem   = idx % (cube * cube);
-            const int g_idx = rem / cube;
-            const int r_idx = rem % cube;
-
-            guchar* p = row + x * 3;
-            p[0] = static_cast<guchar>(r_idx * 255.0 / den + 0.5);
-            p[1] = static_cast<guchar>(g_idx * 255.0 / den + 0.5);
-            p[2] = static_cast<guchar>(b_idx * 255.0 / den + 0.5);
-        }
-    }
-
-    const Glib::ustring tmpPath =
-        Glib::build_filename(Glib::get_tmp_dir(), "rt_hald_identity.png");
-
-    try {
-        pixbuf->save(tmpPath, "png");
-    } catch (const Glib::Exception&) {
-        return {};
-    }
-
-    return tmpPath;
-}
 
 // Returns a copy of src with all spatially-dependent and non-colorimetric
 // tools disabled, suitable for applying to a Hald CLUT identity image.
@@ -3101,7 +3054,7 @@ void EditorPanel::saveLUTPressed ()
     }
 
     // Generate a Hald 12 identity PNG to a temp file.
-    const Glib::ustring tmpPath = generateHaldIdentityPNG(12);
+    const Glib::ustring tmpPath = rtengine::HaldCLUT::createIdentityTempFile(12);
     if (tmpPath.empty()) {
         Gtk::MessageDialog msgd(*toplevel,
             "<b>Could not generate Hald identity image.</b>",

--- a/rtgui/editorpanel.cc
+++ b/rtgui/editorpanel.cc
@@ -702,6 +702,129 @@ public:
 
 };
 
+namespace
+{
+
+// Generate a Hald CLUT identity PNG at the given level and write it to a temp
+// file.  For level 12 the image is 1728×1728 pixels with 144 samples per
+// colour axis.  Returns the path of the temp file, or an empty string on
+// failure.
+Glib::ustring generateHaldIdentityPNG(int level)
+{
+    const int cube = level * level;
+    const int size = level * level * level;
+    const double den = static_cast<double>(cube - 1);
+
+    auto pixbuf = Gdk::Pixbuf::create(Gdk::COLORSPACE_RGB, false, 8, size, size);
+
+    if (!pixbuf) {
+        return {};
+    }
+
+    const int rowstride = pixbuf->get_rowstride();
+    guchar* const pixels = pixbuf->get_pixels();
+
+    for (int y = 0; y < size; y++) {
+        guchar* row = pixels + y * rowstride;
+
+        for (int x = 0; x < size; x++) {
+            const int idx   = y * size + x;
+            const int b_idx = idx / (cube * cube);
+            const int rem   = idx % (cube * cube);
+            const int g_idx = rem / cube;
+            const int r_idx = rem % cube;
+
+            guchar* p = row + x * 3;
+            p[0] = static_cast<guchar>(r_idx * 255.0 / den + 0.5);
+            p[1] = static_cast<guchar>(g_idx * 255.0 / den + 0.5);
+            p[2] = static_cast<guchar>(b_idx * 255.0 / den + 0.5);
+        }
+    }
+
+    const Glib::ustring tmpPath =
+        Glib::build_filename(Glib::get_tmp_dir(), "rt_hald_identity.png");
+
+    try {
+        pixbuf->save(tmpPath, "png");
+    } catch (const Glib::Exception&) {
+        return {};
+    }
+
+    return tmpPath;
+}
+
+// Returns a copy of src with all spatially-dependent and non-colorimetric
+// tools disabled, suitable for applying to a Hald CLUT identity image.
+// Kept: white balance, tone curves, exposure, Lab curves, RGB curves, HSV
+// equalizer, vibrance, colour toning, colour appearance, shadows/highlights,
+// tone equalizer, gamut compression, dehaze, soft-light, film simulation,
+// channel mixer, black & white, output colour management.
+// Disabled: sharpening, noise reduction, edge-preserving / Retinex tone
+// mapping, local contrast, all geometric transforms, lens/CA/vignette
+// corrections, gradient, spot removal, locallab, wavelet, dir-pyr, resize,
+// framing, film negative.
+ProcParams makeLUTProcParams(const ProcParams& src)
+{
+    ProcParams p = src;
+
+    // Sharpening (spatial)
+    p.sharpening.enabled   = false;
+    p.prsharpening.enabled = false;
+    p.pdsharpening.enabled = false;
+    p.sharpenEdge.enabled  = false;
+    p.sharpenMicro.enabled = false;
+
+    // Noise reduction (spatial)
+    p.defringe.enabled       = false;
+    p.impulseDenoise.enabled = false;
+    p.dirpyrDenoise.enabled  = false;
+
+    // Tone mapping (edge-aware / spatial)
+    p.epd.enabled     = false;
+    p.fattal.enabled  = false;
+    p.retinex.enabled = false;
+
+    // Local contrast (radius-based)
+    p.localContrast.enabled = false;
+
+    // Geometric transforms
+    p.crop.enabled      = false;
+    p.coarse.rotate     = 0;
+    p.coarse.hflip      = false;
+    p.coarse.vflip      = false;
+    p.rotate.degree     = 0.0;
+    p.distortion.amount = 0.0;
+    p.distortion.defish = false;
+    p.lensProf.lcMode   = LensProfParams::LcMode::NONE;
+    p.perspective.horizontal = 0.0;
+    p.perspective.vertical   = 0.0;
+    p.perspective.render     = false;
+
+    // Optical corrections (position-dependent)
+    p.cacorrection.red   = 0.0;
+    p.cacorrection.blue  = 0.0;
+    p.vignetting.amount  = 0;
+    p.gradient.enabled   = false;
+    p.pcvignette.enabled = false;
+
+    // Spot removal and local adjustments (position-dependent)
+    p.spot.enabled     = false;
+    p.locallab.enabled = false;
+
+    // Wavelet / directional pyramid (spatial)
+    p.wavelet.enabled         = false;
+    p.dirpyrequalizer.enabled = false;
+
+    // Resize, framing, film negative
+    p.resize.enabled       = false;
+    p.framing.enabled      = false;
+    p.filmNegative.enabled = false;
+
+    return p;
+}
+
+} // namespace
+
 EditorPanel::EditorPanel (FilePanel* filePanel)
     : catalogPane (nullptr), realized (false), tbBeforeLock (nullptr), iHistoryShow (nullptr), iHistoryHide (nullptr),
       iTopPanel_1_Show (nullptr), iTopPanel_1_Hide (nullptr), iRightPanel_1_Show (nullptr), iRightPanel_1_Hide (nullptr),
@@ -900,6 +1023,12 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     saveimgas->set_tooltip_markup (M ("MAIN_BUTTON_SAVE_TOOLTIP"));
     setExpandAlignProperties (saveimgas, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_FILL);
 
+    saveLUTBtn = Gtk::manage (new Gtk::Button ());
+    saveLUTBtn->set_relief(Gtk::RELIEF_NONE);
+    saveLUTBtn->add (*Gtk::manage(new Gtk::Label("LUT")));
+    saveLUTBtn->set_tooltip_markup (M ("MAIN_BUTTON_SAVE_LUT_TOOLTIP"));
+    setExpandAlignProperties (saveLUTBtn, false, false, Gtk::ALIGN_CENTER, Gtk::ALIGN_FILL);
+
     Gtk::Image *queueButtonImage = Gtk::manage (new RTImage ("gears", Gtk::ICON_SIZE_LARGE_TOOLBAR));
     queueimg = Gtk::manage (new Gtk::Button ());
     queueimg->set_relief(Gtk::RELIEF_NONE);
@@ -988,9 +1117,12 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     }
 
     if (!App::get().isGimpPlugin()) {
-        iops->attach_next_to (*saveimgas, Gtk::POS_LEFT, 1, 1);
+        iops->attach_next_to (*saveLUTBtn, Gtk::POS_LEFT, 1, 1);
     }
 
+    if (!App::get().isGimpPlugin()) {
+        iops->attach_next_to (*saveimgas, Gtk::POS_LEFT, 1, 1);
+    }
 
     // Color management toolbar
     colorMgmtToolBar.reset (new ColorManagementToolbar (ipc));
@@ -1083,6 +1215,7 @@ EditorPanel::EditorPanel (FilePanel* filePanel)
     hidehp->signal_toggled().connect ( sigc::mem_fun (*this, &EditorPanel::hideHistoryActivated) );
     tbRightPanel_1->signal_toggled().connect ( sigc::mem_fun (*this, &EditorPanel::tbRightPanel_1_toggled) );
     saveimgas->signal_pressed().connect ( sigc::mem_fun (*this, &EditorPanel::saveAsPressed) );
+    saveLUTBtn->signal_pressed().connect ( sigc::mem_fun (*this, &EditorPanel::saveLUTPressed) );
     queueimg->signal_pressed().connect ( sigc::mem_fun (*this, &EditorPanel::queueImgPressed) );
     send_to_external->signal_changed().connect(sigc::mem_fun(*this, &EditorPanel::sendToExternalChanged));
     send_to_external->signal_pressed().connect(sigc::mem_fun(*this, &EditorPanel::sendToExternalPressed));
@@ -2908,3 +3041,144 @@ void EditorPanel::defaultMonitorProfileChanged (const Glib::ustring &profile_nam
     colorMgmtToolBar->defaultMonitorProfileChanged (profile_name, auto_monitor_profile);
 }
 
+void EditorPanel::saveLUTPressed ()
+{
+    if (!ipc || !openThm) {
+        return;
+    }
+
+    auto* toplevel = static_cast<Gtk::Window*>(get_toplevel());
+
+    // Ask the user where to save the LUT PNG.
+    // Use SELECT_FOLDER so the native portal never hides the filename entry.
+    Gtk::FileChooserDialog dialog(*toplevel,
+        M("MAIN_BUTTON_SAVE_LUT_DIALOG_TITLE"),
+        Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER);
+    dialog.add_button(M("GENERAL_CANCEL"), Gtk::RESPONSE_CANCEL);
+    dialog.add_button(M("GENERAL_OK"),     Gtk::RESPONSE_OK);
+
+    auto& opts = App::get().mut_options();
+    if (Glib::file_test(opts.lastSaveAsPath, Glib::FILE_TEST_IS_DIR)) {
+        dialog.set_current_folder(opts.lastSaveAsPath);
+    }
+
+    // Filename entry embedded in the dialog as an extra widget.
+    Gtk::Box* extraBox = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 6));
+    Gtk::Label* fnLabel = Gtk::manage(new Gtk::Label(M("MAIN_BUTTON_SAVE_LUT_FILENAME") + ":"));
+    Gtk::Entry* fnEntry = Gtk::manage(new Gtk::Entry());
+    fnEntry->set_text("lut");
+    fnEntry->set_width_chars(32);
+    extraBox->pack_start(*fnLabel, false, false, 0);
+    extraBox->pack_start(*fnEntry, true, true, 0);
+    extraBox->show_all();
+    dialog.set_extra_widget(*extraBox);
+
+    if (dialog.run() != Gtk::RESPONSE_OK) {
+        return;
+    }
+
+    Glib::ustring lutName = fnEntry->get_text();
+    if (lutName.empty()) {
+        lutName = "lut";
+    }
+    // Strip .png if the user typed it — we always append it ourselves.
+    if (lutName.size() > 4 && lutName.substr(lutName.size() - 4) == ".png") {
+        lutName = lutName.substr(0, lutName.size() - 4);
+    }
+
+    const Glib::ustring destDir = dialog.get_filename();
+    Glib::ustring destPath = Glib::build_filename(destDir, lutName + ".png");
+    opts.lastSaveAsPath = destDir;
+
+    // Ask before overwriting an existing file.
+    if (Glib::file_test(destPath, Glib::FILE_TEST_EXISTS)) {
+        Gtk::MessageDialog confirm(*toplevel,
+            escapeHtmlChars(destPath) + "\n" + M("MAIN_MSG_ALREADYEXISTS") + " " + M("MAIN_MSG_QOVERWRITE"),
+            true, Gtk::MESSAGE_QUESTION, Gtk::BUTTONS_YES_NO, true);
+        if (confirm.run() != Gtk::RESPONSE_YES) {
+            return;
+        }
+    }
+
+    // Generate a Hald 12 identity PNG to a temp file.
+    const Glib::ustring tmpPath = generateHaldIdentityPNG(12);
+    if (tmpPath.empty()) {
+        Gtk::MessageDialog msgd(*toplevel,
+            "<b>Could not generate Hald identity image.</b>",
+            true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+        msgd.run();
+        return;
+    }
+
+    // Build a colorimetric-only set of processing parameters.
+    ProcParams pparams;
+    ipc->getParams(&pparams);
+    const ProcParams lutParams = makeLUTProcParams(pparams);
+
+    // Process the identity image asynchronously.
+    rtengine::ProcessingJob* job =
+        rtengine::ProcessingJob::create(tmpPath, false, lutParams);
+
+    ProgressConnector<rtengine::IImagefloat*>* ld =
+        new ProgressConnector<rtengine::IImagefloat*>();
+    ld->startFunc(
+        sigc::bind(sigc::ptr_fun(&rtengine::processImage),
+                   job, err, parent->getProgressListener(), false),
+        sigc::bind(sigc::mem_fun(*this, &EditorPanel::idle_saveLUTImage),
+                   ld, destPath, tmpPath));
+
+    saveLUTBtn->set_sensitive(false);
+}
+
+bool EditorPanel::idle_saveLUTImage (ProgressConnector<rtengine::IImagefloat*>* pc,
+                                      Glib::ustring destPath, Glib::ustring tmpPath)
+{
+    rtengine::IImagefloat* img = pc->returnValue();
+    delete pc;
+
+    // Remove the temporary identity file regardless of outcome.
+    try {
+        Gio::File::create_for_path(tmpPath)->remove();
+    } catch (...) {}
+
+    if (img) {
+        // Save the processed image as 8-bit PNG asynchronously.
+        ProgressConnector<int>* ld = new ProgressConnector<int>();
+        img->setSaveProgressListener(parent->getProgressListener());
+        ld->startFunc(
+            sigc::bind(sigc::mem_fun(img, &rtengine::IImagefloat::saveAsPNG),
+                       destPath, 8),
+            sigc::bind(sigc::mem_fun(*this, &EditorPanel::idle_saveLUTSaved),
+                       ld, img, destPath));
+    } else {
+        auto* toplevel = static_cast<Gtk::Window*>(get_toplevel());
+        Gtk::MessageDialog msgd(*toplevel,
+            "<b>Error processing Hald identity image.</b>",
+            true, Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+        msgd.run();
+        saveLUTBtn->set_sensitive(true);
+    }
+
+    return false;
+}
+
+bool EditorPanel::idle_saveLUTSaved (ProgressConnector<int>* pc,
+                                      rtengine::IImagefloat* img, Glib::ustring destPath)
+{
+    const int result = pc->returnValue();
+    delete pc;
+    delete img;
+
+    if (result != 0) {
+        auto* toplevel = static_cast<Gtk::Window*>(get_toplevel());
+        Glib::ustring msg =
+            Glib::ustring("<b>") + M("MAIN_MSG_CANNOTSAVE") + ": "
+            + escapeHtmlChars(destPath) + "</b>";
+        Gtk::MessageDialog msgd(*toplevel, msg, true,
+            Gtk::MESSAGE_ERROR, Gtk::BUTTONS_OK, true);
+        msgd.run();
+    }
+
+    saveLUTBtn->set_sensitive(true);
+    return false;
+}

--- a/rtgui/editorpanel.h
+++ b/rtgui/editorpanel.h
@@ -167,6 +167,7 @@ public:
     void beforeAfterToggled ();
     void tbBeforeLock_toggled();
     void saveAsPressed ();
+    void saveLUTPressed ();
     void queueImgPressed ();
     void sendToExternal();
     void sendToExternalChanged(int);
@@ -213,6 +214,8 @@ private:
     BatchQueueEntry*    createBatchQueueEntry ();
     bool                idle_imageSaved (ProgressConnector<int> *pc, rtengine::IImagefloat* img, Glib::ustring fname, SaveFormat sf, rtengine::procparams::ProcParams &pparams);
     bool                idle_saveImage (ProgressConnector<rtengine::IImagefloat*> *pc, Glib::ustring fname, SaveFormat sf, rtengine::procparams::ProcParams &pparams);
+    bool                idle_saveLUTImage (ProgressConnector<rtengine::IImagefloat*> *pc, Glib::ustring destPath, Glib::ustring tmpPath);
+    bool                idle_saveLUTSaved (ProgressConnector<int> *pc, rtengine::IImagefloat* img, Glib::ustring destPath);
     bool                idle_sendToGimp ( ProgressConnector<rtengine::IImagefloat*> *pc, Glib::ustring fname);
     bool                idle_sentToGimp (ProgressConnector<int> *pc, rtengine::IImagefloat* img, Glib::ustring filename);
     void                histogramProfile_toggled ();
@@ -248,6 +251,7 @@ private:
 
     Gtk::Button* queueimg;
     Gtk::Button* saveimgas;
+    Gtk::Button* saveLUTBtn;
     PopUpButton* send_to_external;
     Gtk::RadioButtonGroup send_to_external_radio_group;
     Gtk::Button* navSync;


### PR DESCRIPTION
Adds a "LUT" button to the editor toolbar that exports the current colorimetric adjustments as a Hald 12 CLUT PNG file.                        
                                                                                                                                                 
A Hald identity image is generated in-engine using Imagefloat, processed through a colorimetric-only subset of the pipeline (white balance, tone curves, color grading, etc.), and saved as a 16-bit PNG. 
Spatially-dependent tools (sharpening, noise reduction, geometric transforms, local adjustments, etc.) are automatically disabled for the export.

The save dialog follows the same pattern as the existing Save As dialog (Gtk::Dialog + embedded Gtk::FileChooserWidget).

This feature is useful in two main scenarios:
- Film simulation presets: export a RawTherapee look (film curves, color grading, white balance) as a portable LUT that can be applied in other applications or shared with others.
- In-camera LUT support: some modern cameras (e.g. Panasonic Lumix S9) can load custom LUTs and apply them at capture time for JPEG output and live view. This allows photographers to develop a look in RawTherapee and carry it into their camera workflow.