### PR TITLE
fix: invalid ThumbBrowserEntryBase comparators

### DIFF
--- a/rtgui/thumbbrowserbase.cc
+++ b/rtgui/thumbbrowserbase.cc
@@ -1121,8 +1121,11 @@ void ThumbBrowserBase::resort ()
             fd.end(),
             [&](const ThumbBrowserEntryBase* a, const ThumbBrowserEntryBase* b)
             {
-                bool lt = a->compare(*b, options.sortMethod);
-                return options.sortDescending ? !lt : lt;
+                if (!options.sortDescending) {
+                    return a->compare(*b, options.sortMethod);
+                } else {
+                    return b->compare(*a, options.sortMethod);
+                }
             }
         );
     }
@@ -1275,8 +1278,11 @@ void ThumbBrowserBase::insertEntry (ThumbBrowserEntryBase* entry)
                 entry,
                 [&](const ThumbBrowserEntryBase* a, const ThumbBrowserEntryBase* b)
                 {
-                    bool lt = a->compare(*b, options.sortMethod);
-                    return options.sortDescending ? !lt : lt;
+                    if (!options.sortDescending) {
+                        return a->compare(*b, options.sortMethod);
+                    } else {
+                        return b->compare(*a, options.sortMethod);
+                    }
                 }
             ),
             entry


### PR DESCRIPTION
Fix an issue in the `ThumbBrowserEntryBase` sorting comparator where the use of taking direct negation violated the requirements of a strict weak ordering when sorting in descending order. The comparison now explicitly changes the order of `a` and `b` instead to restore correct comparator behavior and prevent undefined behavior during sorting.

In terms of the algorithm's contract, the comparator used by `std::sort` must induce a strict weak ordering. In particular:

- For all `a`, `comp(a, a) == false`.
- If `comp(a, b) == true` then `comp(b, a) == false`.

Directly taking negation violated these rules when two elements were equal and sorting in descending order. Current fix ensures compliance with the standard and improves stability.

Even if equal `ThumbBrowserEntryBase` are unlikely or impossible to appear in `fd` array, switching to the new fix is still safe and makes the comparator correct by definition. If `ThumbBrowserEntryBase` can never be equal, then the original comparator and the new comparator behave the same anyway so it won't be a concern to break the existing behavior.

References:

- [C++ reference, C++ named requirements: Compare](https://en.cppreference.com/cpp/named_req/Compare)