### PR TITLE
Fixes Capture sharpening history spam

### DIFF
--- a/rtgui/tools/pdsharpening.cc
+++ b/rtgui/tools/pdsharpening.cc
@@ -238,9 +238,13 @@ void PdSharpening::setDefaults(const ProcParams* defParams, const ParamsEdited* 
 void PdSharpening::checkBoxToggled (CheckBox* c, CheckValue newval)
 {
     if (listener) {
-        listener->panelChanged (EvPdShrCheckIter, itercheck->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
-        listener->panelChanged (EvPdShrshowcap, showcap->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
-        listener->panelChanged (EvPdShrnoisecaptype, noisecaptype->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        if (c == itercheck) {
+            listener->panelChanged (EvPdShrCheckIter, itercheck->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        } else if (c == showcap) {
+            listener->panelChanged (EvPdShrshowcap, showcap->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        } else if (c == noisecaptype) {
+            listener->panelChanged (EvPdShrnoisecaptype, noisecaptype->getLastActive() ? M("GENERAL_ENABLED") : M("GENERAL_DISABLED"));
+        }
     }
 }
 


### PR DESCRIPTION
Checking/unchecking check boxes in Capture sharpening spams history with settings that were not changed.

@Desmis This is a change to your recent code. Can you verify if this is correct?

Fixes #7680