### PR TITLE
Enable Denoise and refine for all levels decomposition issue 7686

### DIFF
--- a/rtgui/tools/wavelet.cc
+++ b/rtgui/tools/wavelet.cc
@@ -3746,6 +3746,8 @@ void Wavelet::adjusterChanged(Adjuster* a, double newval)
             } else {
                 sup->hide();
             }
+/* 
+// Issue 7686 - May 2026
             if(z >= 8 ) {
                 expnoise->setEnabled(false);
                 expnoise->set_sensitive(false);
@@ -3753,7 +3755,7 @@ void Wavelet::adjusterChanged(Adjuster* a, double newval)
               //  expnoise->setEnabled(pp->wavelet.expnoise);
                 expnoise->set_sensitive(true);
             }
-
+*/
             listener->panelChanged(EvWavthres, thres->getTextValue());
              updateGUImaxlev();
              updateGUI();
@@ -3874,14 +3876,15 @@ void Wavelet::enabledUpdateUI()
         } else {
             sup->hide();
         }
-
+/*
+// Issue 7686 - May 2026
             if(z >= 8) {
                 expnoise->setEnabled(false);
                 expnoise->set_sensitive(false);
             } else {
                 expnoise->set_sensitive(true);
             }
-
+*/
 //      adjusterUpdateUI(tmrs);
     }
 }


### PR DESCRIPTION
#7686

After disabling the GUI restrictions – expander "expnoise" for levels 8 and 9 – I tested several files with levels 5 through 9 for "Wavelets levels", and of course "Denoise and Refine"

It seems to work correctly in both the Preview and TIF outputs, in both "Standard" and "Advanced" modes.