### PR TITLE
Removes black point line from history when Automatic Black point and White point is enabled.

### DIFF
--- a/rtgui/tools/locallabtools.cc
+++ b/rtgui/tools/locallabtools.cc
@@ -5898,7 +5898,7 @@ void LocallabShadow::updateghsbw2(double ghsb, double ghsw, bool ghsaut)//auto G
                     ghs_BLP->setValue(ghsb);
                     enableListener();
                 }
-                listener->panelChanged (Evlocallabghs_BLP,ghs_BLP->getTextValue());                
+                listener->panelChanged(Evlocallabghs_autobw, M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
             }
         }
         return false;
@@ -6422,7 +6422,7 @@ void LocallabShadow::ghs_autobwChanged()
             if (ghs_autobw->get_active()) {
                 nbwb = 1; // execute multi preview to automatically calculate black point and white point but only once
                 listener->panelChanged(Evlocallabghs_autobw,
-                                       M("GENERAL_ENABLED") + " (" + escapeHtmlChars(getSpotName()) + ")");
+                                       M("TP_PREPROCESS_LABEL") + " (" + escapeHtmlChars(getSpotName()) + ")");
             } else {
                 nbwb = 0;
                 listener->panelChanged(Evlocallabghs_autobw,


### PR DESCRIPTION
This changes the history reporting so that it will first report Preprocessing and just on the second round of processing Enabled. Previously the code printed the black point value to history to launch the second processing round. This was wrong in many ways: 1. The value was printed regardless if it changed or not. 2. The White point was never printed although it might have been the value that actually changed.

I tried to use existing labels to avoid opening translations. I'm not sure if Preprocessing fits for the purpose or not, but it sounded ok.

There is a case if the user clicks the checkbox to enabled and then changes another value fast enough, the history will have Preprocessing and the user changed value under it. There will be Enabled printed to the history eventually. If the user then clicks the row labeled Preprocessing, the enabled checkbox will be checked but the values are not the automatically determined values. I think the Preprocessing label may be enough for the user to forgive the inconsistency in values.