### PR TITLE
Fix for random AppImage build failures on libjxl installation step

### DIFF
--- a/tools/makedeb/PKGBUILD.libjxl
+++ b/tools/makedeb/PKGBUILD.libjxl
@@ -34,7 +34,7 @@ build() {
   )
 
   cmake "${_cmake_options[@]}"
-  cmake --build build --parallel
+  cmake --build build --parallel $(nproc)
 }
 
 package() {


### PR DESCRIPTION
I ran the libjxl installation in Ubuntu 22.04 and saw that the build process spawned many subprocesses resulting in up to 7 or 8 gigabytes of RAM being used. It could be the cause of the libjxl installation failures. I tried setting the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable, but that didn't seem to have an effect. I settled on passing `--parallel $(nproc)` to CMake in the PKGBUILD file.

Hopefully fixes #7632.