### PR TITLE
rtengine/libraw: add explicit OOB guards for two ASan-confirmed heap-buffer-overflow bugs (refs #7694)

### DIFF
--- a/rtengine/libraw/src/decoders/decoders_libraw.cpp
+++ b/rtengine/libraw/src/decoders/decoders_libraw.cpp
@@ -317,6 +317,8 @@ void LibRaw::nikon_load_padded_packed_raw() // 12 bit per pixel, padded to 16
 
     for (int icol = 0; icol < S.raw_width / 2; icol++)
     {
+      if (((unsigned)icol * 3u + 2u) >= bytesperrow)
+        break; // explicit guard: buf is sized to bytesperrow
       imgdata.rawdata.raw_image[(row)*S.raw_width + (icol * 2)] =
           ((buf[icol * 3 + 1] & 0xf) << 8) | buf[icol * 3];
       imgdata.rawdata.raw_image[(row)*S.raw_width + (icol * 2 + 1)] =

--- a/rtengine/libraw/src/decompressors/losslessjpeg.cpp
+++ b/rtengine/libraw/src/decompressors/losslessjpeg.cpp
@@ -364,6 +364,15 @@ void HuffTable::initval(uint32_t _bits[17], uint32_t _huffval[256], bool _dng_bu
 	uint32_t tsize = 1 << nbits;
 	for (unsigned i = 0; i < hufftable.size(); i++) hufftable[i] = 0;
 
+	// Validate total code count upfront to catch malformed tables early
+	{
+		uint32_t total = 0;
+		for (int i = 1; i <= 16 && i <= nbits; i++)
+			total += (uint32_t)bits[i] * (1u << (nbits - i));
+		if (total > tsize)
+			throw LIBRAW_EXCEPTION_IO_CORRUPT;
+	}
+
 	int h = 0;
     int pos = 0;
     for (uint8_t len = 0; len < nbits; len++)


### PR DESCRIPTION
## Related Issue

Closes / references #7694 — two heap-buffer-overflow vulnerabilities in the bundled LibRaw 0.22.0.

## Changes

### losslessjpeg.cpp — HuffTable::initval()

**Added upfront total-count validation** before the Huffman table fill loop:

```c
// Validate total code count upfront to catch malformed tables early
{
    uint32_t total = 0;
    for (int i = 1; i <= 16 && i <= nbits; i++)
        total += (uint32_t)bits[i] * (1u << (nbits - i));
    if (total > tsize)
        throw LIBRAW_EXCEPTION_IO_CORRUPT;
}
```

The existing per-iteration  guard is preserved. The new check provides early rejection of malformed Huffman tables before any memory fills, reducing the attack surface window.

**CVE / ASan evidence:** LibRaw 0.22.0 crashes with  at  on a crafted 283-byte TIFF (Sony YCbCr with malformed Huffman table).

---

### decoders_libraw.cpp — nikon_load_padded_packed_raw()

**Added explicit inner-loop bounds guard:**

```c
if (((unsigned)icol * 3u + 2u) >= bytesperrow)
    break; // explicit guard: buf is sized to bytesperrow
```

The root-cause fix (computing  from  rather than the attacker-controlled ) is already in place. This guard makes the memory-safety invariant visible at the access site and protects against future refactors that might reintroduce the mismatch.

**CVE / ASan evidence:** LibRaw 0.22.0 crashes with  (1 byte) at  on a crafted Nikon padded-packed-raw TIFF.

---

## Testing

Both vulnerabilities were confirmed with AddressSanitizer against LibRaw 0.22.0. The patched code eliminates both crash paths.