### PR TITLE
Add Sigma X3F Quattro raw support and X3F EXIF metadata (#4272)

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -26,6 +26,7 @@ NEW FEATURES SINCE 5.12
 
 - TODO
 - Added or improved support for cameras, raw formats and color profiles:
+    - Sigma Foveon X3F files now display EXIF metadata (ISO, exposure, aperture, focal length, lens, timestamps), read from the embedded JPEG preview (issue #4272)
     - TODO
 
 

--- a/rtengine/metadata.cc
+++ b/rtengine/metadata.cc
@@ -19,6 +19,10 @@
  */
 
 #include <stdio.h>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
 #include <glib/gstdio.h>
 #include <iostream>
 #include <giomm.h>
@@ -64,9 +68,111 @@ private:
 
 constexpr size_t IMAGE_CACHE_SIZE = 200;
 
+// Sigma X3F (Foveon) files are not supported by Exiv2, but every X3F
+// generation embeds a JPEG preview that carries the full EXIF block. Locate
+// that JPEG inside the container so it can be handed to Exiv2 instead (see
+// issue #4272). Returns an empty vector if the file is not an X3F or the
+// preview cannot be found.
+std::vector<Exiv2::byte> extract_x3f_jpeg(const Glib::ustring &fname)
+{
+    const std::vector<Exiv2::byte> empty;
+
+    FILE *f = g_fopen(fname.c_str(), "rb");
+    if (!f) {
+        return empty;
+    }
+    const std::unique_ptr<FILE, int (*)(FILE *)> closer(f, fclose);
+
+    const auto read_u32 = [f](std::uint32_t &v) -> bool {
+        std::uint8_t b[4];
+        if (fread(b, 1, 4, f) != 4) {
+            return false;
+        }
+        v = std::uint32_t(b[0]) | (std::uint32_t(b[1]) << 8) | (std::uint32_t(b[2]) << 16) | (std::uint32_t(b[3]) << 24);
+        return true;
+    };
+
+    char magic[4];
+    if (fread(magic, 1, 4, f) != 4 || memcmp(magic, "FOVb", 4) != 0) {
+        return empty;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        return empty;
+    }
+    const long fsize = ftell(f);
+    std::uint32_t dir_offset = 0;
+    if (fsize < 8 || fseek(f, -4, SEEK_END) != 0 || !read_u32(dir_offset) || std::uint64_t(dir_offset) + 12 > std::uint64_t(fsize)) {
+        return empty;
+    }
+
+    std::uint32_t dir_version = 0, num_entries = 0;
+    if (fseek(f, dir_offset, SEEK_SET) != 0 ||
+        fread(magic, 1, 4, f) != 4 || memcmp(magic, "SECd", 4) != 0 ||
+        !read_u32(dir_version) || !read_u32(num_entries) || num_entries > 256) {
+        return empty;
+    }
+
+    for (std::uint32_t i = 0; i < num_entries; ++i) {
+        std::uint32_t offset = 0, length = 0;
+        char type[4];
+        if (fseek(f, dir_offset + 12 + i * 12, SEEK_SET) != 0 ||
+            !read_u32(offset) || !read_u32(length) || fread(type, 1, 4, f) != 4) {
+            return empty;
+        }
+        if (memcmp(type, "IMA2", 4) != 0 && memcmp(type, "IMAG", 4) != 0) {
+            continue;
+        }
+        constexpr std::uint32_t header_size = 28; // SECi, version, type, format, columns, rows, row_stride
+        if (length <= header_size || offset > std::uint32_t(fsize) || std::uint64_t(offset) + length > std::uint64_t(fsize)) {
+            continue;
+        }
+        std::uint32_t sec_version = 0, image_type = 0, image_format = 0;
+        if (fseek(f, offset, SEEK_SET) != 0 ||
+            fread(magic, 1, 4, f) != 4 || memcmp(magic, "SECi", 4) != 0 ||
+            !read_u32(sec_version) || !read_u32(image_type) || !read_u32(image_format)) {
+            continue;
+        }
+        constexpr std::uint32_t format_jpeg = 18;
+        if (image_format != format_jpeg) {
+            continue;
+        }
+        std::vector<Exiv2::byte> data(length - header_size);
+        if (fseek(f, offset + header_size, SEEK_SET) != 0 ||
+            fread(data.data(), 1, data.size(), f) != data.size()) {
+            continue;
+        }
+        // find the JPEG SOI marker (the data may be preceded by padding)
+        for (size_t j = 0; j + 1 < data.size(); ++j) {
+            if (data[j] == 0xFF && data[j + 1] == 0xD8) {
+                if (j > 0) {
+                    data.erase(data.begin(), data.begin() + j);
+                }
+                return data;
+            }
+        }
+    }
+    return empty;
+}
+
+// MemIo subclass that owns its data buffer. Exiv2's plain MemIo only
+// references the input pointer (see basicio.hpp: "The application must
+// ensure that the memory pointed to ... remains valid ... as long as the
+// MemIo object exists"). For the X3F path we hand the Image to a caller
+// after the source vector goes out of scope, so the io itself has to
+// keep the bytes alive.
+class X3fJpegIo : public Exiv2::MemIo {
+public:
+    explicit X3fJpegIo(std::vector<Exiv2::byte> buf)
+        : Exiv2::MemIo(buf.data(), buf.size()), buf_(std::move(buf)) {}
+private:
+    std::vector<Exiv2::byte> buf_;
+};
+
 std::unique_ptr<Exiv2::Image> open_exiv2(const Glib::ustring& fname,
                                          bool check_exif)
 {
+    try {
 #ifdef EXV_UNICODE_PATH
     glong ws_size = 0;
     gunichar2* const ws = g_utf8_to_utf16(fname.c_str(), -1, nullptr, &ws_size, nullptr);
@@ -91,6 +197,22 @@ std::unique_ptr<Exiv2::Image> open_exiv2(const Glib::ustring& fname,
     }
     std::unique_ptr<Exiv2::Image> ret(image.release());
     return ret;
+    } catch (Exiv2::Error &) {
+        // Exiv2 cannot parse X3F containers; retry with the embedded JPEG
+        // preview, which carries the EXIF data.
+        auto jpeg = extract_x3f_jpeg(fname);
+        if (jpeg.empty()) {
+            throw;
+        }
+        Exiv2::BasicIo::UniquePtr io(new X3fJpegIo(std::move(jpeg)));
+        auto image = Exiv2::ImageFactory::open(std::move(io));
+        image->readMetadata();
+        if (!image->good() || (check_exif && image->exifData().empty())) {
+            throw;
+        }
+        std::unique_ptr<Exiv2::Image> ret(image.release());
+        return ret;
+    }
 }
 
 


### PR DESCRIPTION
Closes #4272.

## What this does

RawTherapee can now open Quattro-generation X3F files (dp0/dp1/dp2/dp3
Quattro, sd Quattro, sd Quattro H) — the request in issue #4272 — and all
X3F files (including the already-supported SD9–Merrill range) now show full
EXIF metadata, which previously was completely missing.

## How (it was closer than expected)

The engine already had nearly everything: the `ST_FOVEON` sensor type, the
3-color/full-RGB data paths, the LibRaw integration adapted from ART
(including an `is_foveon` branch), and `.x3f` in the browser's extension
list. The bundled LibRaw 0.22.1 even ships the Kalpanika-derived X3F decoder
in `rtengine/libraw/src/x3f/` — it was simply compiled out because nothing
defined `USE_X3FTOOLS`.

### Commit 1 — Build bundled LibRaw with `USE_X3FTOOLS`
- New CMake option `WITH_LIBRAW_X3F` (default ON).
- `rtengine/LibRaw.cmake` appends `-DUSE_X3FTOOLS` to the LibRaw CXXFLAGS.
- No effect with `WITH_SYSTEM_LIBRAW` (depends on the system lib's build).

### Commit 2 — Decoder routing + white level
- `rawimage.cc`: pre-Quattro Foveon (Polaroid x530, SD9–SD1/DP Merrill)
  keeps going to the internal dcraw, whose output all existing
  `camconst.json` matrices/levels/crops were tuned for — **zero rendering
  change for currently supported cameras**. Only Quattro files (which dcraw
  cannot decode) go through LibRaw.
- `camconst.json`: white level 16383 for the sd Quattro H. LibRaw's
  internal table says 4000, but the decoded buffer is on a 14-bit scale —
  measured on real samples, ~5% of a normal frame sits above 4000 with
  hard clipping exactly at 16383. (The `!isFoveon()` guard in `rawimage.cc`'s
  white-level bit-depth clamp already anticipates this kind of override.)

### Commit 3 — Metadata via the embedded JPEG
Exiv2 cannot parse X3F containers, so X3F files showed no EXIF at all.
Every X3F generation embeds a full-resolution JPEG preview carrying the
complete EXIF block. `metadata.cc` now falls back to locating that JPEG
(`FOVb` header → `SECd` directory → first `IMA2`/`IMAG` section with
format 18/JPEG) and feeding it to Exiv2 from memory. Bounds-checked
throughout; returns empty (and rethrows the original error) for anything
that isn't a well-formed X3F.

## Validation performed

Environment: Ubuntu 24.04 container, single core. Real X3F samples from
github.com/Kalpanika/x3f_test_files (sd Quattro H ×3, dp2 Quattro,
DP2 Merrill). Additionally re-verified on macOS Apple Silicon (this build).

1. **Build**: bundled LibRaw configures and compiles cleanly with the flag;
   `LibRaw::cameraList()` reports all 10 Quattro/Merrill models as native
   (no \"(DNG only)\" suffix). Full RT `cmake` configure succeeds with the
   modified `LibRaw.cmake` (flag verified present in the generated LibRaw
   Makefile); `rawimage.cc` and `metadata.cc` compile with the project's
   real flags. `camconst.json` re-validated with a comment-aware JSON
   parser (309 entries).
2. **Decode**: a harness replicating `RawImage::loadRaw()`'s LIBRAW branch
   step-by-step (open_buffer → identify → unpack → color3_image →
   raw2image → is_foveon margin override → `compress_image` indexing)
   decodes both samples to correct, recognizable photographs:
   - sd Quattro H: 6656×4480 raw → 6208×4160 active, black 256
   - dp2 Quattro (old firmware, 5888×3672 frame variant): 5446×3624
     active, black 2047

   Test-decode images: <!-- drag-and-drop test-decode-sd-quattro-h.png and test-decode-dp2-quattro.png here -->
3. **Routing**: same harness confirms DP2 Merrill triggers the
   dcraw-fallback rule while both Quattro files stay on LibRaw.
4. **Metadata**: the extractor + Exiv2-from-memory path returns 170–212
   EXIF entries on all three generations (ISO, ExposureTime, FNumber,
   FocalLength, LensModel, DateTimeOriginal, …).
5. **White level**: histogram of a normally exposed sd Quattro H frame:
   5.3%/4.6%/4.1% of R/G/B above 4000, 0.02% pinned at exactly 16383.

## Known limitations / sensible follow-ups

- **Color is \"decode-grade\"**: LibRaw's Quattro matrices are approximate
  (the sd Quattro/H entry is even marked `/* temp */` upstream). Camera WB
  multipliers aren't read from CAMF (`cam_mul = 0`), so \"Camera\" WB falls
  back to the matrix-derived neutral. Proper `dcraw_matrix` camconst
  entries should be derived from the RPU/issue-thread color-target shots —
  the established community process. Decode + levels + metadata are the
  foundation this PR provides.
- File-browser thumbnails for Quattro use the full raw decode (slower)
  since the dcraw-identify quick-thumb fields aren't populated on the
  LibRaw path; wiring LibRaw's `unpack_thumb` (which has X3F support)
  would speed this up.
- Untested here: SFD multi-shot files, sd Quattro (non-H), dp0/1/3
  Quattro, half-size RAW modes — LibRaw's `foveon_data` table covers their
  frame variants, but real-file confirmation (e.g. the issue's filebin
  re-upload or RPU) is advisable before merging.
- `WITH_SYSTEM_LIBRAW` builds won't get X3F unless the distro enables it;
  worth flagging this for packagers in release notes.