### PR TITLE
CAL RGB brightness curves threshold

### DIFF
--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -760,6 +760,7 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
         const float schrgreen = params->colorappearance.schromagreen;
         const float hueblue = params->colorappearance.colorhblue;
         const float schrblue = params->colorappearance.schromablue;
+        const float brighthres = 10.f;
 
         const float rstprotection = 100. - params->colorappearance.rstprotection;
 
@@ -1190,16 +1191,25 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                     //I haven't addressed the transitions or spillovers during other hue modifications, to keep things simple... The effects are marginal and minor.
                     //It's possible to set a Hue equalizer for each color range (Red, Green, Blue), which is more purist but complicates the interface and usage.
                     constexpr float attenuation_hue = 0.555f;//Hue attenuation factor of 100/180. I find the changes too significant. It's just a convention.
+
+                    // Creates a transition to mitigate the effects of "brightness" (red green blue) curves on artifacts
+                    constexpr float klimb = 0.5f;//ponderation
+                    const float limb = brighthres + klimb * (100.f - brighthres);//intermediate zone where the application of the curve is progressive
+                    constexpr float mink = 0.01f;//minimum curve factor
+                    const float kam = (1.f - mink) / (limb - brighthres);//linear interpolation
+                    const float kbm = mink - kam * brighthres;//linear interpolation
                     if((hpro > 340.f && hpro <= 360.f) || (hpro > 0.f && hpro <= 100.f)) {//Red CIECAM
                         if ((hasColCurvered)) {
                             jpred = true;
                             float Qq = Qpro * coefQ;
                             float Qold = Qpro;
                             const Brightcurve& userColCurveBred = static_cast<const Brightcurve&>(customColCurvered);
-                            userColCurveBred.Apply(Qq);
-
+                            const float kreduc = Cpro * kam + kbm;//calculates the reduction in the applied force of the curve as a function of Cpro
+                            if (Cpro  > brighthres) {
+                                userColCurveBred.Apply(Qq);
+                            }
                             Qq = Qq / coefQ;
-                            Qpro = 0.2f * (Qq - Qold) + Qold;
+                            Qpro = 0.2f * kreduc * (Qq - Qold) + Qold;
                         }
                         if (jpred) {
                             Jpro = SQR((10.f * Qpro) / wh);
@@ -1224,10 +1234,13 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                             float Qq = Qpro * coefQ;
                             float Qold = Qpro;
                             const Brightcurve& userColCurveBgreen = static_cast<const Brightcurve&>(customColCurvegreen);
-                            userColCurveBgreen.Apply(Qq);
+                            if (Cpro  > brighthres) {
+                                userColCurveBgreen.Apply(Qq);
+                            }
+                            const float kreduc = Cpro * kam + kbm;
 
                             Qq = Qq / coefQ;
-                            Qpro = 0.2f * (Qq - Qold) + Qold;
+                            Qpro = 0.2f * kreduc * (Qq - Qold) + Qold;
                         }
                         if (jpgreen) {
                             Jpro = SQR((10.f * Qpro) / wh);
@@ -1250,10 +1263,13 @@ void ImProcFunctions::ciecam_02float(CieImage* ncie, float adap, int pW, int pwb
                             float Qq = Qpro * coefQ;
                             float Qold = Qpro;
                             const Brightcurve& userColCurveBblue = static_cast<const Brightcurve&>(customColCurveblue);
-                            userColCurveBblue.Apply(Qq);
+                            if (Cpro  > brighthres) {
+                                userColCurveBblue.Apply(Qq);
+                            }
+                            const float kreduc = Cpro * kam + kbm;
 
                             Qq = Qq / coefQ;
-                            Qpro = 0.2f * (Qq - Qold) + Qold;
+                            Qpro = 0.2f * kreduc * (Qq - Qold) + Qold;
                         }
                         if (jpblue) {
                             Jpro = SQR((10.f * Qpro) / wh);


### PR DESCRIPTION
Eliminate hard transitions when using the Color Appearance & Lighting RGB brightness curves.

Addresses the behavior seen in https://discuss.pixls.us/t/rawtherapee-5-13-release-candidate-1/58782/6 and is meant to be compatible with #7629 