### PR TITLE
Add .cube LUT support to Film Simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 .idea
 .env
 .venv
+__pycache__/
+*.pyc
 
 CMakeUserPresets.json
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,8 @@ install(
     FILES RELEASE_NOTES.txt
     DESTINATION "${CREDITSDIR}"
     OPTIONAL)
+install(FILES tools/bake_cube_lut.py
+        DESTINATION "${DATADIR}/tools")
 
 # The standard location for man pages in Linux is /usr/share/man Use "manpath"
 # to see the search paths for man pages on your system.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,7 @@ install(
     DESTINATION "${CREDITSDIR}"
     OPTIONAL)
 install(FILES tools/bake_cube_lut.py
+              tools/bake_cube_lut-README.md
         DESTINATION "${DATADIR}/tools")
 
 # The standard location for man pages in Linux is /usr/share/man Use "manpath"

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <fstream>
 #include <sstream>
 #include <vector>
@@ -27,7 +28,7 @@ namespace
 // ---------------------------------------------------------------------------
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
-vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
+vfloat2 getHaldClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
 {
     const vint v_values = _mm_loadu_si128(reinterpret_cast<const vint*>(clut_image.data + index));
 #ifdef __SSE4_1__
@@ -54,14 +55,9 @@ vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t ind
 #endif
 }
 
-vfloat getClutValue(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
+vfloat getCubeClutValue(const AlignedBuffer<float>& clut_image, size_t index)
 {
-    const vint v_value = _mm_loadl_epi64(reinterpret_cast<const vint*>(clut_image.data + index));
-#ifdef __SSE4_1__
-    return _mm_cvtepi32_ps(_mm_cvtepu16_epi32(v_value));
-#else
-    return _mm_cvtepi32_ps(_mm_unpacklo_epi16(v_value, _mm_setzero_si128()));
-#endif
+    return LVF(clut_image.data[index]);
 }
 #endif
 
@@ -143,7 +139,7 @@ bool loadHaldFile(
 
 rtengine::CLUT3D::operator bool() const
 {
-    return !clut_image.isEmpty();
+    return clut_level > 0;
 }
 
 Glib::ustring rtengine::CLUT3D::getFilename() const
@@ -234,12 +230,12 @@ void rtengine::HaldCLUT::getRGB(
 
         const vfloat v_r = PERMUTEPS(v_rgb, _MM_SHUFFLE(0, 0, 0, 0));
 
-        vfloat2 v_clut_values = getClutValues(clut_image, index);
+        vfloat2 v_clut_values = getHaldClutValues(clut_image, index);
         vfloat v_tmp1 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         index = (color + level) * 4;
 
-        v_clut_values = getClutValues(clut_image, index);
+        v_clut_values = getHaldClutValues(clut_image, index);
         vfloat v_tmp2 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         const vfloat v_g = PERMUTEPS(v_rgb, _MM_SHUFFLE(1, 1, 1, 1));
@@ -248,12 +244,12 @@ void rtengine::HaldCLUT::getRGB(
 
         index = (color + level_square) * 4;
 
-        v_clut_values = getClutValues(clut_image, index);
+        v_clut_values = getHaldClutValues(clut_image, index);
         v_tmp1 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         index = (color + level + level_square) * 4;
 
-        v_clut_values = getClutValues(clut_image, index);
+        v_clut_values = getHaldClutValues(clut_image, index);
         v_tmp2 = vintpf(v_r, v_clut_values.y, v_clut_values.x);
 
         v_tmp1 = vintpf(v_g, v_tmp2, v_tmp1);
@@ -380,6 +376,10 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
             float r, g, b;
             std::istringstream ss(line);
             if (ss >> r >> g >> b) {
+                if (!std::isfinite(r) || !std::isfinite(g) || !std::isfinite(b)) {
+                    return false;
+                }
+
                 if (entry_limit == 0 || entries.size() >= entry_limit) {
                     return false;
                 }
@@ -390,7 +390,11 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     }
 
     for (int c = 0; c < 3; ++c) {
-        if (!(domain_min[c] < domain_max[c])) {
+        if (
+            !std::isfinite(domain_min[c])
+            || !std::isfinite(domain_max[c])
+            || !(domain_min[c] < domain_max[c])
+        ) {
             return false;
         }
     }
@@ -406,15 +410,19 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
 
     clut_level = size;
 
-    AlignedBuffer<std::uint16_t> image(total * 4 + 4); // +4: getRGB reads one pixel ahead
+    AlignedBuffer<float> image(total * 4);
+    if (image.isEmpty()) {
+        return false;
+    }
 
     for (std::size_t i = 0; i < total; ++i) {
         for (int c = 0; c < 3; ++c) {
             // DOMAIN_MIN and DOMAIN_MAX describe input coordinates, not LUT output values.
-            // Cube outputs remain limited to [0, 1] by the shared uint16 storage.
-            float v = entries[i][c];
-            v = std::max(0.f, std::min(1.f, v));
-            image.data[i * 4 + c] = static_cast<std::uint16_t>(v * 65535.f + 0.5f);
+            const float value = entries[i][c] * MAXVALF;
+            if (!std::isfinite(value)) {
+                return false;
+            }
+            image.data[i * 4 + c] = value;
         }
         image.data[i * 4 + 3] = 0;
     }
@@ -538,10 +546,10 @@ void rtengine::CubeLUT::getRGB(
             out_rgbx[channel] = intp<float>(strength, value, input[channel]);
         }
 #else
-        const vfloat v_first = getClutValue(clut_image, first_index);
-        const vfloat v_second = getClutValue(clut_image, second_index);
-        const vfloat v_third = getClutValue(clut_image, third_index);
-        const vfloat v_last = getClutValue(clut_image, last_index);
+        const vfloat v_first = getCubeClutValue(clut_image, first_index);
+        const vfloat v_second = getCubeClutValue(clut_image, second_index);
+        const vfloat v_third = getCubeClutValue(clut_image, third_index);
+        const vfloat v_last = getCubeClutValue(clut_image, last_index);
 
         vfloat v_value = v_first + F2V(first_fraction) * (v_second - v_first);
         v_value = v_value + F2V(second_fraction) * (v_third - v_second);

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -337,6 +337,10 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         if (!line.empty() && line.back() == '\r') {
             line.pop_back();
         }
+
+        // Keyword lines may have leading spaces or tabs.
+        line.erase(0, line.find_first_not_of(" \t"));
+
         // Skip empty lines and comments
         if (line.empty() || line[0] == '#') {
             continue;

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -410,8 +410,9 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
 
     for (std::size_t i = 0; i < total; ++i) {
         for (int c = 0; c < 3; ++c) {
-            const float range = domain_max[c] - domain_min[c];
-            float v = (range > 0.f) ? (entries[i][c] - domain_min[c]) / range : 0.f;
+            // DOMAIN_MIN and DOMAIN_MAX describe input coordinates, not LUT output values.
+            // Cube outputs remain limited to [0, 1] by the shared uint16 storage.
+            float v = entries[i][c];
             v = std::max(0.f, std::min(1.f, v));
             image.data[i * 4 + c] = static_cast<std::uint16_t>(v * 65535.f + 0.5f);
         }
@@ -428,6 +429,12 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;
     flevel_minus_two = static_cast<float>(clut_level - 2);
 
+    for (int c = 0; c < 3; ++c) {
+        const float range = domain_max[c] - domain_min[c];
+        domain_scale[c] = flevel_minus_one / range;
+        domain_offset[c] = -domain_min[c] * static_cast<float>(clut_level - 1) / range;
+    }
+
     return true;
 }
 
@@ -443,15 +450,16 @@ void rtengine::CubeLUT::getRGB(
     const unsigned int level = clut_level;
     const unsigned int level_square = level * level;
     const unsigned int last_offset = 1 + level + level_square;
+    const float level_minus_one = static_cast<float>(level - 1);
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
     const vfloat v_strength = F2V(strength);
 #endif
 
     for (std::size_t column = 0; column < line_size; ++column, ++r, ++g, ++b, out_rgbx += 4) {
-        const float scaled_red = *r * flevel_minus_one;
-        const float scaled_green = *g * flevel_minus_one;
-        const float scaled_blue = *b * flevel_minus_one;
+        const float scaled_red = std::max(0.f, std::min(level_minus_one, *r * domain_scale[0] + domain_offset[0]));
+        const float scaled_green = std::max(0.f, std::min(level_minus_one, *g * domain_scale[1] + domain_offset[1]));
+        const float scaled_blue = std::max(0.f, std::min(level_minus_one, *b * domain_scale[2] + domain_offset[2]));
 
         const unsigned int red = std::min(flevel_minus_two, scaled_red);
         const unsigned int green = std::min(flevel_minus_two, scaled_green);

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -153,7 +153,33 @@ Glib::ustring rtengine::CLUT3D::getFilename() const
 
 Glib::ustring rtengine::CLUT3D::getProfile() const
 {
-    return clut_profile;
+    return clut_input_profile;
+}
+
+Glib::ustring rtengine::CLUT3D::getInputProfile() const
+{
+    return clut_input_profile;
+}
+
+Glib::ustring rtengine::CLUT3D::getOutputProfile() const
+{
+    return clut_output_profile;
+}
+
+rtengine::CLUTTransferFunction rtengine::CLUT3D::getInputTransferFunction() const
+{
+    return clut_input_transfer_function;
+}
+
+rtengine::CLUTTransferFunction rtengine::CLUT3D::getOutputTransferFunction() const
+{
+    return clut_output_transfer_function;
+}
+
+bool rtengine::CLUT3D::hasDifferentInputAndOutputColorSpace() const
+{
+    return clut_input_profile != clut_output_profile
+        || clut_input_transfer_function != clut_output_transfer_function;
 }
 
 void rtengine::HaldCLUT::getRGB(
@@ -275,7 +301,10 @@ bool rtengine::HaldCLUT::load(const Glib::ustring& filename)
 {
     if (loadHaldFile(filename, "", clut_image, clut_level)) {
         Glib::ustring name, ext;
-        splitClutFilename(filename, name, ext, clut_profile);
+        splitClutFilename(filename, name, ext, clut_input_profile);
+        clut_output_profile = clut_input_profile;
+        clut_input_transfer_function = CLUTTransferFunction::SRGB;
+        clut_output_transfer_function = CLUTTransferFunction::SRGB;
 
         clut_filename = filename;
         clut_level *= clut_level;
@@ -340,6 +369,8 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     float domain_max[3] = {1.f, 1.f, 1.f};
     std::vector<std::array<float, 3>> entries;
     std::size_t entry_limit = 0;
+    std::string gamma_metadata;
+    std::string gamut_metadata;
 
     std::string line;
     while (std::getline(file, line)) {
@@ -351,8 +382,26 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         // Keyword lines may have leading spaces or tabs.
         line.erase(0, line.find_first_not_of(" \t"));
 
-        // Skip empty lines and comments
-        if (line.empty() || line[0] == '#') {
+        // Preserve vendor metadata from comment lines before skipping them.
+        if (!line.empty() && line[0] == '#') {
+            std::string comment = line.substr(1);
+            comment.erase(0, comment.find_first_not_of(" \t"));
+
+            if (comment.rfind("Gamma:", 0) == 0) {
+                gamma_metadata = comment.substr(6);
+                gamma_metadata.erase(0, gamma_metadata.find_first_not_of(" \t"));
+                gamma_metadata.erase(gamma_metadata.find_last_not_of(" \t") + 1);
+            } else if (comment.rfind("Gamut:", 0) == 0) {
+                gamut_metadata = comment.substr(6);
+                gamut_metadata.erase(0, gamut_metadata.find_first_not_of(" \t"));
+                gamut_metadata.erase(gamut_metadata.find_last_not_of(" \t") + 1);
+            }
+
+            continue;
+        }
+
+        // Skip empty lines
+        if (line.empty()) {
             continue;
         }
 
@@ -422,7 +471,28 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
 
     // Determine colour profile from filename suffix (same convention as HaldCLUT)
     Glib::ustring name, ext;
-    HaldCLUT::splitClutFilename(filename, name, ext, clut_profile);
+    HaldCLUT::splitClutFilename(filename, name, ext, clut_input_profile);
+    clut_output_profile = clut_input_profile;
+    clut_input_transfer_function = CLUTTransferFunction::SRGB;
+    clut_output_transfer_function = CLUTTransferFunction::SRGB;
+
+    if (
+        gamma_metadata.rfind("F-Log2 to ", 0) == 0
+        && gamut_metadata == "F-Gamut to ITU-R BT.709"
+    ) {
+        // F-Gamut has the same D65 white and primaries as Rec.2020, while
+        // BT.709 has the same D65 white and primaries as sRGB.
+        clut_input_profile = "Rec2020";
+        clut_output_profile = "sRGB";
+        clut_input_transfer_function = CLUTTransferFunction::FLOG2;
+
+        if (gamma_metadata == "F-Log2 to F-Log2") {
+            clut_output_transfer_function = CLUTTransferFunction::FLOG2;
+        }
+        // The creative and WDR variants retain Film Simulation's existing
+        // sRGB output wrapper, which preserves their LUT output code values
+        // when rendering to sRGB.
+    }
 
     clut_filename = filename;
     flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -153,33 +153,7 @@ Glib::ustring rtengine::CLUT3D::getFilename() const
 
 Glib::ustring rtengine::CLUT3D::getProfile() const
 {
-    return clut_input_profile;
-}
-
-Glib::ustring rtengine::CLUT3D::getInputProfile() const
-{
-    return clut_input_profile;
-}
-
-Glib::ustring rtengine::CLUT3D::getOutputProfile() const
-{
-    return clut_output_profile;
-}
-
-rtengine::CLUTTransferFunction rtengine::CLUT3D::getInputTransferFunction() const
-{
-    return clut_input_transfer_function;
-}
-
-rtengine::CLUTTransferFunction rtengine::CLUT3D::getOutputTransferFunction() const
-{
-    return clut_output_transfer_function;
-}
-
-bool rtengine::CLUT3D::hasDifferentInputAndOutputColorSpace() const
-{
-    return clut_input_profile != clut_output_profile
-        || clut_input_transfer_function != clut_output_transfer_function;
+    return clut_profile;
 }
 
 void rtengine::HaldCLUT::getRGB(
@@ -301,10 +275,7 @@ bool rtengine::HaldCLUT::load(const Glib::ustring& filename)
 {
     if (loadHaldFile(filename, "", clut_image, clut_level)) {
         Glib::ustring name, ext;
-        splitClutFilename(filename, name, ext, clut_input_profile);
-        clut_output_profile = clut_input_profile;
-        clut_input_transfer_function = CLUTTransferFunction::SRGB;
-        clut_output_transfer_function = CLUTTransferFunction::SRGB;
+        splitClutFilename(filename, name, ext, clut_profile);
 
         clut_filename = filename;
         clut_level *= clut_level;
@@ -369,8 +340,6 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     float domain_max[3] = {1.f, 1.f, 1.f};
     std::vector<std::array<float, 3>> entries;
     std::size_t entry_limit = 0;
-    std::string gamma_metadata;
-    std::string gamut_metadata;
 
     std::string line;
     while (std::getline(file, line)) {
@@ -382,26 +351,8 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         // Keyword lines may have leading spaces or tabs.
         line.erase(0, line.find_first_not_of(" \t"));
 
-        // Preserve vendor metadata from comment lines before skipping them.
-        if (!line.empty() && line[0] == '#') {
-            std::string comment = line.substr(1);
-            comment.erase(0, comment.find_first_not_of(" \t"));
-
-            if (comment.rfind("Gamma:", 0) == 0) {
-                gamma_metadata = comment.substr(6);
-                gamma_metadata.erase(0, gamma_metadata.find_first_not_of(" \t"));
-                gamma_metadata.erase(gamma_metadata.find_last_not_of(" \t") + 1);
-            } else if (comment.rfind("Gamut:", 0) == 0) {
-                gamut_metadata = comment.substr(6);
-                gamut_metadata.erase(0, gamut_metadata.find_first_not_of(" \t"));
-                gamut_metadata.erase(gamut_metadata.find_last_not_of(" \t") + 1);
-            }
-
-            continue;
-        }
-
-        // Skip empty lines
-        if (line.empty()) {
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == '#') {
             continue;
         }
 
@@ -471,28 +422,7 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
 
     // Determine colour profile from filename suffix (same convention as HaldCLUT)
     Glib::ustring name, ext;
-    HaldCLUT::splitClutFilename(filename, name, ext, clut_input_profile);
-    clut_output_profile = clut_input_profile;
-    clut_input_transfer_function = CLUTTransferFunction::SRGB;
-    clut_output_transfer_function = CLUTTransferFunction::SRGB;
-
-    if (
-        gamma_metadata.rfind("F-Log2 to ", 0) == 0
-        && gamut_metadata == "F-Gamut to ITU-R BT.709"
-    ) {
-        // F-Gamut has the same D65 white and primaries as Rec.2020, while
-        // BT.709 has the same D65 white and primaries as sRGB.
-        clut_input_profile = "Rec2020";
-        clut_output_profile = "sRGB";
-        clut_input_transfer_function = CLUTTransferFunction::FLOG2;
-
-        if (gamma_metadata == "F-Log2 to F-Log2") {
-            clut_output_transfer_function = CLUTTransferFunction::FLOG2;
-        }
-        // The creative and WDR variants retain Film Simulation's existing
-        // sRGB output wrapper, which preserves their LUT output code values
-        // when rendering to sRGB.
-    }
+    HaldCLUT::splitClutFilename(filename, name, ext, clut_profile);
 
     clut_filename = filename;
     flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -329,6 +329,7 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     float domain_min[3] = {0.f, 0.f, 0.f};
     float domain_max[3] = {1.f, 1.f, 1.f};
     std::vector<std::array<float, 3>> entries;
+    std::size_t entry_limit = 0;
 
     std::string line;
     while (std::getline(file, line)) {
@@ -343,7 +344,13 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
 
         if (line.rfind("LUT_3D_SIZE", 0) == 0) {
             std::istringstream ss(line.substr(11));
+            size = 0;
             ss >> size;
+            entry_limit = 0;
+            if (size >= 2 && size <= 256) {
+                const std::size_t cube_size = static_cast<std::size_t>(size);
+                entry_limit = cube_size * cube_size * cube_size;
+            }
         } else if (line.rfind("DOMAIN_MIN", 0) == 0) {
             std::istringstream ss(line.substr(10));
             ss >> domain_min[0] >> domain_min[1] >> domain_min[2];
@@ -359,6 +366,10 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
             float r, g, b;
             std::istringstream ss(line);
             if (ss >> r >> g >> b) {
+                if (entry_limit == 0 || entries.size() >= entry_limit) {
+                    return false;
+                }
+
                 entries.push_back({r, g, b});
             }
         }
@@ -374,8 +385,7 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         return false;
     }
 
-    const std::size_t cube_size = static_cast<std::size_t>(size);
-    const std::size_t total = cube_size * cube_size * cube_size;
+    const std::size_t total = entry_limit;
     if (entries.size() != total) {
         return false;
     }

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -23,7 +23,7 @@ namespace
 {
 
 // ---------------------------------------------------------------------------
-// Shared SSE helper used by CLUT3D::getRGB
+// SSE helper used by HaldCLUT::getRGB
 // ---------------------------------------------------------------------------
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
@@ -146,7 +146,7 @@ Glib::ustring rtengine::CLUT3D::getProfile() const
     return clut_profile;
 }
 
-void rtengine::CLUT3D::getRGB(
+void rtengine::HaldCLUT::getRGB(
     float strength,
     std::size_t line_size,
     const float* r,
@@ -419,6 +419,101 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
     flevel_minus_two = static_cast<float>(clut_level - 2);
 
     return true;
+}
+
+void rtengine::CubeLUT::getRGB(
+    float strength,
+    std::size_t line_size,
+    const float* r,
+    const float* g,
+    const float* b,
+    float* out_rgbx
+) const
+{
+    const unsigned int level = clut_level;
+    const unsigned int level_square = level * level;
+    const unsigned int last_offset = 1 + level + level_square;
+
+    for (std::size_t column = 0; column < line_size; ++column, ++r, ++g, ++b, out_rgbx += 4) {
+        const float scaled_red = *r * flevel_minus_one;
+        const float scaled_green = *g * flevel_minus_one;
+        const float scaled_blue = *b * flevel_minus_one;
+
+        const unsigned int red = std::min(flevel_minus_two, scaled_red);
+        const unsigned int green = std::min(flevel_minus_two, scaled_green);
+        const unsigned int blue = std::min(flevel_minus_two, scaled_blue);
+
+        const float re = scaled_red - red;
+        const float gr = scaled_green - green;
+        const float bl = scaled_blue - blue;
+
+        unsigned int first_offset;
+        unsigned int second_offset;
+        float first_fraction;
+        float second_fraction;
+        float third_fraction;
+
+        if (re >= gr) {
+            if (gr >= bl) { // r >= g >= b
+                first_offset = 1;
+                second_offset = 1 + level;
+                first_fraction = re;
+                second_fraction = gr;
+                third_fraction = bl;
+            } else if (re >= bl) { // r >= b > g
+                first_offset = 1;
+                second_offset = 1 + level_square;
+                first_fraction = re;
+                second_fraction = bl;
+                third_fraction = gr;
+            } else { // b > r >= g
+                first_offset = level_square;
+                second_offset = level_square + 1;
+                first_fraction = bl;
+                second_fraction = re;
+                third_fraction = gr;
+            }
+        } else if (re >= bl) { // g > r >= b
+            first_offset = level;
+            second_offset = level + 1;
+            first_fraction = gr;
+            second_fraction = re;
+            third_fraction = bl;
+        } else if (gr >= bl) { // g >= b > r
+            first_offset = level;
+            second_offset = level + level_square;
+            first_fraction = gr;
+            second_fraction = bl;
+            third_fraction = re;
+        } else { // b > g > r
+            first_offset = level_square;
+            second_offset = level_square + level;
+            first_fraction = bl;
+            second_fraction = gr;
+            third_fraction = re;
+        }
+
+        const unsigned int color = red + green * level + blue * level_square;
+        const std::size_t first_index = color * 4;
+        const std::size_t second_index = (color + first_offset) * 4;
+        const std::size_t third_index = (color + second_offset) * 4;
+        const std::size_t last_index = (color + last_offset) * 4;
+        const float input[3] = {*r, *g, *b};
+
+        for (int channel = 0; channel < 3; ++channel) {
+            const float first = clut_image.data[first_index + channel];
+            const float second = clut_image.data[second_index + channel];
+            const float third = clut_image.data[third_index + channel];
+            const float last = clut_image.data[last_index + channel];
+            const float value =
+                first
+                + first_fraction * (second - first)
+                + second_fraction * (third - second)
+                + third_fraction * (last - third);
+
+            out_rgbx[channel] = intp<float>(strength, value, input[channel]);
+        }
+    }
 }
 
 // ===========================================================================

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -370,16 +370,21 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         }
     }
 
-    if (size < 2 || size > 256 || static_cast<int>(entries.size()) != size * size * size) {
+    if (size < 2 || size > 256) {
+        return false;
+    }
+
+    const std::size_t cube_size = static_cast<std::size_t>(size);
+    const std::size_t total = cube_size * cube_size * cube_size;
+    if (entries.size() != total) {
         return false;
     }
 
     clut_level = size;
 
-    const int total = size * size * size;
     AlignedBuffer<std::uint16_t> image(total * 4 + 4); // +4: getRGB reads one pixel ahead
 
-    for (int i = 0; i < total; ++i) {
+    for (std::size_t i = 0; i < total; ++i) {
         for (int c = 0; c < 3; ++c) {
             const float range = domain_max[c] - domain_min[c];
             float v = (range > 0.f) ? (entries[i][c] - domain_min[c]) / range : 0.f;

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -370,7 +370,7 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         }
     }
 
-    if (size <= 1 || static_cast<int>(entries.size()) != size * size * size) {
+    if (size < 2 || size > 256 || static_cast<int>(entries.size()) != size * size * size) {
         return false;
     }
 

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -364,6 +364,12 @@ bool rtengine::CubeLUT::load(const Glib::ustring& filename)
         }
     }
 
+    for (int c = 0; c < 3; ++c) {
+        if (!(domain_min[c] < domain_max[c])) {
+            return false;
+        }
+    }
+
     if (size <= 1 || static_cast<int>(entries.size()) != size * size * size) {
         return false;
     }

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -1,4 +1,8 @@
 #include <algorithm>
+#include <array>
+#include <fstream>
+#include <sstream>
+#include <vector>
 
 #include <glibmm/fileutils.h>
 #include <glibmm/miscutils.h>
@@ -18,7 +22,44 @@
 namespace
 {
 
-bool loadFile(
+// ---------------------------------------------------------------------------
+// Shared SSE helper used by CLUT3D::getRGB
+// ---------------------------------------------------------------------------
+
+#if defined(__SSE2__) || defined(RT_SIMDE)
+vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
+{
+    const vint v_values = _mm_loadu_si128(reinterpret_cast<const vint*>(clut_image.data + index));
+#ifdef __SSE4_1__
+    return {
+        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(v_values)),
+        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(_mm_srli_si128(v_values, 8)))
+    };
+#else
+    const vint v_mask = _mm_set1_epi32(0x0000FFFF);
+
+    vint v_low = _mm_shuffle_epi32(v_values, _MM_SHUFFLE(1, 0, 1, 0));
+    vint v_high = _mm_shuffle_epi32(v_values, _MM_SHUFFLE(3, 2, 3, 2));
+    v_low = _mm_shufflelo_epi16(v_low, _MM_SHUFFLE(1, 1, 0, 0));
+    v_high = _mm_shufflelo_epi16(v_high, _MM_SHUFFLE(1, 1, 0, 0));
+    v_low = _mm_shufflehi_epi16(v_low, _MM_SHUFFLE(3, 3, 2, 2));
+    v_high = _mm_shufflehi_epi16(v_high, _MM_SHUFFLE(3, 3, 2, 2));
+    v_low = vandm(v_low, v_mask);
+    v_high = vandm(v_high, v_mask);
+
+    return {
+        _mm_cvtepi32_ps(v_low),
+        _mm_cvtepi32_ps(v_high)
+    };
+#endif
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// HaldCLUT loading helper (image-based: PNG / TIFF)
+// ---------------------------------------------------------------------------
+
+bool loadHaldFile(
     const Glib::ustring& filename,
     const Glib::ustring& working_color_space,
     AlignedBuffer<std::uint16_t>& clut_image,
@@ -84,81 +125,28 @@ bool loadFile(
     return res;
 }
 
-#if defined(__SSE2__) || defined(RT_SIMDE)
-vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
-{
-    const vint v_values = _mm_loadu_si128(reinterpret_cast<const vint*>(clut_image.data + index));
-#ifdef __SSE4_1__
-    return {
-        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(v_values)),
-        _mm_cvtepi32_ps(_mm_cvtepu16_epi32(_mm_srli_si128(v_values, 8)))
-    };
-#else
-    const vint v_mask = _mm_set1_epi32(0x0000FFFF);
+} // anonymous namespace
 
-    vint v_low = _mm_shuffle_epi32(v_values, _MM_SHUFFLE(1, 0, 1, 0));
-    vint v_high = _mm_shuffle_epi32(v_values, _MM_SHUFFLE(3, 2, 3, 2));
-    v_low = _mm_shufflelo_epi16(v_low, _MM_SHUFFLE(1, 1, 0, 0));
-    v_high = _mm_shufflelo_epi16(v_high, _MM_SHUFFLE(1, 1, 0, 0));
-    v_low = _mm_shufflehi_epi16(v_low, _MM_SHUFFLE(3, 3, 2, 2));
-    v_high = _mm_shufflehi_epi16(v_high, _MM_SHUFFLE(3, 3, 2, 2));
-    v_low = vandm(v_low, v_mask);
-    v_high = vandm(v_high, v_mask);
+// ===========================================================================
+// CLUT3D — shared base implementation
+// ===========================================================================
 
-    return {
-        _mm_cvtepi32_ps(v_low),
-        _mm_cvtepi32_ps(v_high)
-    };
-#endif
-}
-#endif
-
-}
-
-rtengine::HaldCLUT::HaldCLUT() :
-    clut_level(0),
-    flevel_minus_one(0.0f),
-    flevel_minus_two(0.0f),
-    clut_profile("sRGB")
-{
-}
-
-rtengine::HaldCLUT::~HaldCLUT()
-{
-}
-
-bool rtengine::HaldCLUT::load(const Glib::ustring& filename)
-{
-    if (loadFile(filename, "", clut_image, clut_level)) {
-        Glib::ustring name, ext;
-        splitClutFilename(filename, name, ext, clut_profile);
-
-        clut_filename = filename;
-        clut_level *= clut_level;
-        flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;
-        flevel_minus_two = static_cast<float>(clut_level - 2);
-        return true;
-    }
-
-    return false;
-}
-
-rtengine::HaldCLUT::operator bool() const
+rtengine::CLUT3D::operator bool() const
 {
     return !clut_image.isEmpty();
 }
 
-Glib::ustring rtengine::HaldCLUT::getFilename() const
+Glib::ustring rtengine::CLUT3D::getFilename() const
 {
     return clut_filename;
 }
 
-Glib::ustring rtengine::HaldCLUT::getProfile() const
+Glib::ustring rtengine::CLUT3D::getProfile() const
 {
     return clut_profile;
 }
 
-void rtengine::HaldCLUT::getRGB(
+void rtengine::CLUT3D::getRGB(
     float strength,
     std::size_t line_size,
     const float* r,
@@ -167,8 +155,7 @@ void rtengine::HaldCLUT::getRGB(
     float* out_rgbx
 ) const
 {
-    const unsigned int level = clut_level; // This is important
-
+    const unsigned int level = clut_level;
     const unsigned int level_square = level * level;
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
@@ -270,6 +257,26 @@ void rtengine::HaldCLUT::getRGB(
     }
 }
 
+// ===========================================================================
+// HaldCLUT — image-based (PNG / TIFF) Hald CLUT
+// ===========================================================================
+
+bool rtengine::HaldCLUT::load(const Glib::ustring& filename)
+{
+    if (loadHaldFile(filename, "", clut_image, clut_level)) {
+        Glib::ustring name, ext;
+        splitClutFilename(filename, name, ext, clut_profile);
+
+        clut_filename = filename;
+        clut_level *= clut_level;
+        flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;
+        flevel_minus_two = static_cast<float>(clut_level - 2);
+        return true;
+    }
+
+    return false;
+}
+
 void rtengine::HaldCLUT::splitClutFilename(
     const Glib::ustring& filename,
     Glib::ustring& name,
@@ -295,7 +302,7 @@ void rtengine::HaldCLUT::splitClutFilename(
         if (!name.empty()) {
             for (const auto& working_profile : rtengine::ICCStore::getInstance()->getWorkingProfiles()) {
                 if (
-                    !working_profile.empty() // This isn't strictly needed, but an empty wp name should be skipped anyway
+                    !working_profile.empty()
                     && std::search(name.rbegin(), name.rend(), working_profile.rbegin(), working_profile.rend()) == name.rbegin()
                 ) {
                     profile_name = working_profile;
@@ -307,15 +314,101 @@ void rtengine::HaldCLUT::splitClutFilename(
     }
 }
 
+// ===========================================================================
+// CubeLUT — text-based .cube 3D LUT (Adobe / DaVinci Resolve format)
+// ===========================================================================
+
+bool rtengine::CubeLUT::load(const Glib::ustring& filename)
+{
+    std::ifstream file(filename.c_str());
+    if (!file.is_open()) {
+        return false;
+    }
+
+    int size = 0;
+    float domain_min[3] = {0.f, 0.f, 0.f};
+    float domain_max[3] = {1.f, 1.f, 1.f};
+    std::vector<std::array<float, 3>> entries;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        // Strip Windows-style carriage return
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+
+        if (line.rfind("LUT_3D_SIZE", 0) == 0) {
+            std::istringstream ss(line.substr(11));
+            ss >> size;
+        } else if (line.rfind("DOMAIN_MIN", 0) == 0) {
+            std::istringstream ss(line.substr(10));
+            ss >> domain_min[0] >> domain_min[1] >> domain_min[2];
+        } else if (line.rfind("DOMAIN_MAX", 0) == 0) {
+            std::istringstream ss(line.substr(10));
+            ss >> domain_max[0] >> domain_max[1] >> domain_max[2];
+        } else if (line.rfind("TITLE", 0) == 0
+                   || line.rfind("LUT_1D_SIZE", 0) == 0
+                   || line.rfind("LUT_1D_INPUT_TABLE", 0) == 0
+                   || line.rfind("LUT_3D_INPUT_TABLE", 0) == 0) {
+            // header-only keywords — nothing to do
+        } else {
+            float r, g, b;
+            std::istringstream ss(line);
+            if (ss >> r >> g >> b) {
+                entries.push_back({r, g, b});
+            }
+        }
+    }
+
+    if (size <= 1 || static_cast<int>(entries.size()) != size * size * size) {
+        return false;
+    }
+
+    clut_level = size;
+
+    const int total = size * size * size;
+    AlignedBuffer<std::uint16_t> image(total * 4 + 4); // +4: getRGB reads one pixel ahead
+
+    for (int i = 0; i < total; ++i) {
+        for (int c = 0; c < 3; ++c) {
+            const float range = domain_max[c] - domain_min[c];
+            float v = (range > 0.f) ? (entries[i][c] - domain_min[c]) / range : 0.f;
+            v = std::max(0.f, std::min(1.f, v));
+            image.data[i * 4 + c] = static_cast<std::uint16_t>(v * 65535.f + 0.5f);
+        }
+        image.data[i * 4 + 3] = 0;
+    }
+
+    clut_image.swap(image);
+
+    // Determine colour profile from filename suffix (same convention as HaldCLUT)
+    Glib::ustring name, ext;
+    HaldCLUT::splitClutFilename(filename, name, ext, clut_profile);
+
+    clut_filename = filename;
+    flevel_minus_one = static_cast<float>(clut_level - 1) / 65535.0f;
+    flevel_minus_two = static_cast<float>(clut_level - 2);
+
+    return true;
+}
+
+// ===========================================================================
+// CLUTStore — factory + LRU cache
+// ===========================================================================
+
 rtengine::CLUTStore& rtengine::CLUTStore::getInstance()
 {
     static CLUTStore instance;
     return instance;
 }
 
-std::shared_ptr<rtengine::HaldCLUT> rtengine::CLUTStore::getClut(const Glib::ustring& filename) const
+std::shared_ptr<rtengine::CLUT3D> rtengine::CLUTStore::getClut(const Glib::ustring& filename) const
 {
-    std::shared_ptr<rtengine::HaldCLUT> result;
+    std::shared_ptr<rtengine::CLUT3D> result;
 
     const Glib::ustring full_filename =
         !Glib::path_is_absolute(filename)
@@ -323,7 +416,17 @@ std::shared_ptr<rtengine::HaldCLUT> rtengine::CLUTStore::getClut(const Glib::ust
             : filename;
 
     if (!cache.get(full_filename, result)) {
-        std::unique_ptr<rtengine::HaldCLUT> clut(new rtengine::HaldCLUT);
+        // Choose concrete class from file extension
+        Glib::ustring name, ext, dummy;
+        HaldCLUT::splitClutFilename(full_filename, name, ext, dummy, false);
+        ext = ext.casefold();
+
+        std::unique_ptr<CLUT3D> clut;
+        if (ext == "cube") {
+            clut.reset(new CubeLUT());
+        } else {
+            clut.reset(new HaldCLUT());
+        }
 
         if (clut->load(full_filename)) {
             result = std::move(clut);

--- a/rtengine/clutstore.cc
+++ b/rtengine/clutstore.cc
@@ -23,7 +23,7 @@ namespace
 {
 
 // ---------------------------------------------------------------------------
-// SSE helper used by HaldCLUT::getRGB
+// SSE helpers used by CLUT interpolation
 // ---------------------------------------------------------------------------
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
@@ -51,6 +51,16 @@ vfloat2 getClutValues(const AlignedBuffer<std::uint16_t>& clut_image, size_t ind
         _mm_cvtepi32_ps(v_low),
         _mm_cvtepi32_ps(v_high)
     };
+#endif
+}
+
+vfloat getClutValue(const AlignedBuffer<std::uint16_t>& clut_image, size_t index)
+{
+    const vint v_value = _mm_loadl_epi64(reinterpret_cast<const vint*>(clut_image.data + index));
+#ifdef __SSE4_1__
+    return _mm_cvtepi32_ps(_mm_cvtepu16_epi32(v_value));
+#else
+    return _mm_cvtepi32_ps(_mm_unpacklo_epi16(v_value, _mm_setzero_si128()));
 #endif
 }
 #endif
@@ -434,6 +444,10 @@ void rtengine::CubeLUT::getRGB(
     const unsigned int level_square = level * level;
     const unsigned int last_offset = 1 + level + level_square;
 
+#if defined(__SSE2__) || defined(RT_SIMDE)
+    const vfloat v_strength = F2V(strength);
+#endif
+
     for (std::size_t column = 0; column < line_size; ++column, ++r, ++g, ++b, out_rgbx += 4) {
         const float scaled_red = *r * flevel_minus_one;
         const float scaled_green = *g * flevel_minus_one;
@@ -498,6 +512,8 @@ void rtengine::CubeLUT::getRGB(
         const std::size_t second_index = (color + first_offset) * 4;
         const std::size_t third_index = (color + second_offset) * 4;
         const std::size_t last_index = (color + last_offset) * 4;
+
+#if ! defined(__SSE2__) && ! defined(RT_SIMDE)
         const float input[3] = {*r, *g, *b};
 
         for (int channel = 0; channel < 3; ++channel) {
@@ -513,6 +529,19 @@ void rtengine::CubeLUT::getRGB(
 
             out_rgbx[channel] = intp<float>(strength, value, input[channel]);
         }
+#else
+        const vfloat v_first = getClutValue(clut_image, first_index);
+        const vfloat v_second = getClutValue(clut_image, second_index);
+        const vfloat v_third = getClutValue(clut_image, third_index);
+        const vfloat v_last = getClutValue(clut_image, last_index);
+
+        vfloat v_value = v_first + F2V(first_fraction) * (v_second - v_first);
+        v_value = v_value + F2V(second_fraction) * (v_third - v_second);
+        v_value = v_value + F2V(third_fraction) * (v_last - v_third);
+
+        const vfloat v_input = _mm_set_ps(0.0f, *b, *g, *r);
+        STVF(*out_rgbx, vintpf(v_strength, v_value, v_input));
+#endif
     }
 }
 

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -12,11 +12,6 @@
 namespace rtengine
 {
 
-enum class CLUTTransferFunction {
-    SRGB,
-    FLOG2
-};
-
 /**
  * Abstract base class for 3D colour look-up tables used by Film Simulation.
  *
@@ -36,11 +31,6 @@ public:
 
     Glib::ustring getFilename() const;
     Glib::ustring getProfile() const;
-    Glib::ustring getInputProfile() const;
-    Glib::ustring getOutputProfile() const;
-    CLUTTransferFunction getInputTransferFunction() const;
-    CLUTTransferFunction getOutputTransferFunction() const;
-    bool hasDifferentInputAndOutputColorSpace() const;
 
     virtual void getRGB(
         float strength,
@@ -57,10 +47,7 @@ protected:
     float flevel_minus_one = 0.f;
     float flevel_minus_two = 0.f;
     Glib::ustring clut_filename;
-    Glib::ustring clut_input_profile = "sRGB";
-    Glib::ustring clut_output_profile = "sRGB";
-    CLUTTransferFunction clut_input_transfer_function = CLUTTransferFunction::SRGB;
-    CLUTTransferFunction clut_output_transfer_function = CLUTTransferFunction::SRGB;
+    Glib::ustring clut_profile = "sRGB";
 };
 
 /**
@@ -97,10 +84,8 @@ public:
  * Cube LUT — loads text-based .cube files (Adobe / DaVinci Resolve format)
  * and uses tetrahedral interpolation.
  * Supports LUT_3D_SIZE, DOMAIN_MIN / DOMAIN_MAX and comment lines.
- * The input and output colour profiles default to sRGB; like HaldCLUT, a
- * suffix in the filename can override both (e.g. "MyLUT_ProPhoto.cube").
- * Fujifilm F-Log2 / F-Gamut to BT.709 LUTs are recognized from their vendor
- * comment metadata and use the corresponding input and output transforms.
+ * The colour profile defaults to sRGB; like HaldCLUT, a suffix in the
+ * filename can override it (e.g. "MyLUT_ProPhoto.cube").
  */
 class CubeLUT final :
     public CLUT3D

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -12,6 +12,11 @@
 namespace rtengine
 {
 
+enum class CLUTTransferFunction {
+    SRGB,
+    FLOG2
+};
+
 /**
  * Abstract base class for 3D colour look-up tables used by Film Simulation.
  *
@@ -31,6 +36,11 @@ public:
 
     Glib::ustring getFilename() const;
     Glib::ustring getProfile() const;
+    Glib::ustring getInputProfile() const;
+    Glib::ustring getOutputProfile() const;
+    CLUTTransferFunction getInputTransferFunction() const;
+    CLUTTransferFunction getOutputTransferFunction() const;
+    bool hasDifferentInputAndOutputColorSpace() const;
 
     virtual void getRGB(
         float strength,
@@ -47,7 +57,10 @@ protected:
     float flevel_minus_one = 0.f;
     float flevel_minus_two = 0.f;
     Glib::ustring clut_filename;
-    Glib::ustring clut_profile = "sRGB";
+    Glib::ustring clut_input_profile = "sRGB";
+    Glib::ustring clut_output_profile = "sRGB";
+    CLUTTransferFunction clut_input_transfer_function = CLUTTransferFunction::SRGB;
+    CLUTTransferFunction clut_output_transfer_function = CLUTTransferFunction::SRGB;
 };
 
 /**
@@ -84,8 +97,10 @@ public:
  * Cube LUT — loads text-based .cube files (Adobe / DaVinci Resolve format)
  * and uses tetrahedral interpolation.
  * Supports LUT_3D_SIZE, DOMAIN_MIN / DOMAIN_MAX and comment lines.
- * The colour profile defaults to sRGB; like HaldCLUT, a suffix in the
- * filename can override it (e.g. "MyLUT_ProPhoto.cube").
+ * The input and output colour profiles default to sRGB; like HaldCLUT, a
+ * suffix in the filename can override both (e.g. "MyLUT_ProPhoto.cube").
+ * Fujifilm F-Log2 / F-Gamut to BT.709 LUTs are recognized from their vendor
+ * comment metadata and use the corresponding input and output transforms.
  */
 class CubeLUT final :
     public CLUT3D

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -101,6 +101,10 @@ public:
         const float* b,
         float* out_rgbx
     ) const override;
+
+private:
+    float domain_scale[3] = {};
+    float domain_offset[3] = {};
 };
 
 class CLUTStore final :

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -15,9 +15,9 @@ namespace rtengine
 /**
  * Abstract base class for 3D colour look-up tables used by Film Simulation.
  *
- * Concrete subclasses implement load() for their respective file formats.
- * The shared internal representation (a flat uint16 RGBX buffer indexed as a
- * cubic grid) and the trilinear getRGB() interpolation live here.
+ * Concrete subclasses implement loading and interpolation for their respective
+ * file formats. The internal representation is a flat uint16 RGBX buffer
+ * indexed as a cubic grid.
  */
 class CLUT3D :
     public NonCopyable
@@ -32,14 +32,14 @@ public:
     Glib::ustring getFilename() const;
     Glib::ustring getProfile() const;
 
-    void getRGB(
+    virtual void getRGB(
         float strength,
         std::size_t line_size,
         const float* r,
         const float* g,
         const float* b,
         float* out_rgbx
-    ) const;
+    ) const = 0;
 
 protected:
     AlignedBuffer<std::uint16_t> clut_image;
@@ -52,13 +52,23 @@ protected:
 
 /**
  * Hald CLUT — loads square PNG / TIFF image files where the image dimensions
- * encode the cube size as  width == height == level³.
+ * encode the cube size as width == height == level³, and uses trilinear
+ * interpolation.
  */
 class HaldCLUT final :
     public CLUT3D
 {
 public:
     bool load(const Glib::ustring& filename) override;
+
+    void getRGB(
+        float strength,
+        std::size_t line_size,
+        const float* r,
+        const float* g,
+        const float* b,
+        float* out_rgbx
+    ) const override;
 
     /** Split a CLUT filename into name, extension and optional ICC profile. */
     static void splitClutFilename(
@@ -71,7 +81,8 @@ public:
 };
 
 /**
- * Cube LUT — loads text-based .cube files (Adobe / DaVinci Resolve format).
+ * Cube LUT — loads text-based .cube files (Adobe / DaVinci Resolve format)
+ * and uses tetrahedral interpolation.
  * Supports LUT_3D_SIZE, DOMAIN_MIN / DOMAIN_MAX and comment lines.
  * The colour profile defaults to sRGB; like HaldCLUT, a suffix in the
  * filename can override it (e.g. "MyLUT_ProPhoto.cube").
@@ -81,6 +92,15 @@ class CubeLUT final :
 {
 public:
     bool load(const Glib::ustring& filename) override;
+
+    void getRGB(
+        float strength,
+        std::size_t line_size,
+        const float* r,
+        const float* g,
+        const float* b,
+        float* out_rgbx
+    ) const override;
 };
 
 class CLUTStore final :

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -16,8 +16,7 @@ namespace rtengine
  * Abstract base class for 3D colour look-up tables used by Film Simulation.
  *
  * Concrete subclasses implement loading and interpolation for their respective
- * file formats. The internal representation is a flat uint16 RGBX buffer
- * indexed as a cubic grid.
+ * file formats and own their format-specific storage.
  */
 class CLUT3D :
     public NonCopyable
@@ -42,7 +41,6 @@ public:
     ) const = 0;
 
 protected:
-    AlignedBuffer<std::uint16_t> clut_image;
     unsigned int clut_level = 0;
     float flevel_minus_one = 0.f;
     float flevel_minus_two = 0.f;
@@ -78,6 +76,9 @@ public:
         Glib::ustring& profile_name,
         bool checkProfile = true
     );
+
+private:
+    AlignedBuffer<std::uint16_t> clut_image;
 };
 
 /**
@@ -103,6 +104,7 @@ public:
     ) const override;
 
 private:
+    AlignedBuffer<float> clut_image;
     float domain_scale[3] = {};
     float domain_offset[3] = {};
 };

--- a/rtengine/clutstore.h
+++ b/rtengine/clutstore.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <cstdint>
 
+#include <glibmm/ustring.h>
+
 #include "cache.h"
 #include "alignedbuffer.h"
 #include "noncopyable.h"
@@ -10,14 +12,20 @@
 namespace rtengine
 {
 
-class HaldCLUT final :
+/**
+ * Abstract base class for 3D colour look-up tables used by Film Simulation.
+ *
+ * Concrete subclasses implement load() for their respective file formats.
+ * The shared internal representation (a flat uint16 RGBX buffer indexed as a
+ * cubic grid) and the trilinear getRGB() interpolation live here.
+ */
+class CLUT3D :
     public NonCopyable
 {
 public:
-    HaldCLUT();
-    ~HaldCLUT();
+    virtual ~CLUT3D() = default;
 
-    bool load(const Glib::ustring& filename);
+    virtual bool load(const Glib::ustring& filename) = 0;
 
     explicit operator bool() const;
 
@@ -33,6 +41,26 @@ public:
         float* out_rgbx
     ) const;
 
+protected:
+    AlignedBuffer<std::uint16_t> clut_image;
+    unsigned int clut_level = 0;
+    float flevel_minus_one = 0.f;
+    float flevel_minus_two = 0.f;
+    Glib::ustring clut_filename;
+    Glib::ustring clut_profile = "sRGB";
+};
+
+/**
+ * Hald CLUT — loads square PNG / TIFF image files where the image dimensions
+ * encode the cube size as  width == height == level³.
+ */
+class HaldCLUT final :
+    public CLUT3D
+{
+public:
+    bool load(const Glib::ustring& filename) override;
+
+    /** Split a CLUT filename into name, extension and optional ICC profile. */
     static void splitClutFilename(
         const Glib::ustring& filename,
         Glib::ustring& name,
@@ -40,14 +68,19 @@ public:
         Glib::ustring& profile_name,
         bool checkProfile = true
     );
+};
 
-private:
-    AlignedBuffer<std::uint16_t> clut_image;
-    unsigned int clut_level;
-    float flevel_minus_one;
-    float flevel_minus_two;
-    Glib::ustring clut_filename;
-    Glib::ustring clut_profile;
+/**
+ * Cube LUT — loads text-based .cube files (Adobe / DaVinci Resolve format).
+ * Supports LUT_3D_SIZE, DOMAIN_MIN / DOMAIN_MAX and comment lines.
+ * The colour profile defaults to sRGB; like HaldCLUT, a suffix in the
+ * filename can override it (e.g. "MyLUT_ProPhoto.cube").
+ */
+class CubeLUT final :
+    public CLUT3D
+{
+public:
+    bool load(const Glib::ustring& filename) override;
 };
 
 class CLUTStore final :
@@ -56,14 +89,17 @@ class CLUTStore final :
 public:
     static CLUTStore& getInstance();
 
-    std::shared_ptr<HaldCLUT> getClut(const Glib::ustring& filename) const;
+    /** Returns a CLUT3D for the given filename, creating and caching it on
+     *  first access.  The concrete type (HaldCLUT or CubeLUT) is chosen
+     *  automatically from the file extension. */
+    std::shared_ptr<CLUT3D> getClut(const Glib::ustring& filename) const;
 
     void clearCache();
 
 private:
     CLUTStore();
 
-    mutable Cache<Glib::ustring, std::shared_ptr<HaldCLUT>> cache;
+    mutable Cache<Glib::ustring, std::shared_ptr<CLUT3D>> cache;
 };
 
 }

--- a/rtengine/color.cc
+++ b/rtengine/color.cc
@@ -2110,29 +2110,6 @@ float Color::eval_ACEScct_curve(float x, bool forward)
 
 // end code take in ART thanks to Alberto Griggio
 
-// Fujifilm F-Log2 Data Sheet, version 1.1.
-float Color::eval_FLog2_curve(float x, bool forward)
-{
-    constexpr float A = 5.555556f;
-    constexpr float B = 0.064829f;
-    constexpr float C = 0.245281f;
-    constexpr float D = 0.384316f;
-    constexpr float E = 8.799461f;
-    constexpr float F = 0.092864f;
-    constexpr float CUT1 = 0.000889f;
-    constexpr float CUT2 = 0.100686685370811f;
-
-    if (forward) {
-        return x >= CUT1
-            ? C * std::log10(A * x + B) + D
-            : E * x + F;
-    }
-
-    return x >= CUT2
-        ? std::pow(10.f, (x - D) / C) / A - B / A
-        : (x - F) / E;
-}
-
 //functions needs to use ACES
 
 // transpose Matrix

--- a/rtengine/color.cc
+++ b/rtengine/color.cc
@@ -2110,6 +2110,29 @@ float Color::eval_ACEScct_curve(float x, bool forward)
 
 // end code take in ART thanks to Alberto Griggio
 
+// Fujifilm F-Log2 Data Sheet, version 1.1.
+float Color::eval_FLog2_curve(float x, bool forward)
+{
+    constexpr float A = 5.555556f;
+    constexpr float B = 0.064829f;
+    constexpr float C = 0.245281f;
+    constexpr float D = 0.384316f;
+    constexpr float E = 8.799461f;
+    constexpr float F = 0.092864f;
+    constexpr float CUT1 = 0.000889f;
+    constexpr float CUT2 = 0.100686685370811f;
+
+    if (forward) {
+        return x >= CUT1
+            ? C * std::log10(A * x + B) + D
+            : E * x + F;
+    }
+
+    return x >= CUT2
+        ? std::pow(10.f, (x - D) / C) / A - B / A
+        : (x - F) / E;
+}
+
 //functions needs to use ACES
 
 // transpose Matrix

--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -1399,6 +1399,12 @@ static inline void Lab2XYZ(vfloat L, vfloat a, vfloat b, vfloat &x, vfloat &y, v
     {
         return igammatab_srgb[x];
     }
+    static inline float igamma_srgb_extended(float x)
+    {
+        return x >= 0.f && x <= MAXVALF
+            ? igammatab_srgb[x]
+            : static_cast<float>(igamma2(x / MAXVALF) * MAXVALF);
+    }
     //static inline float  gamma_srgb       (double x) { return gammatab_srgb[x]; }
     //static inline float  gamma            (double x) { return gammatab[x]; }
     //static inline float  igamma_srgb      (double x) { return igammatab_srgb[x]; }

--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -1415,9 +1415,6 @@ static inline void Lab2XYZ(vfloat L, vfloat a, vfloat b, vfloat &x, vfloat &y, v
 
     static float eval_ACEScct_curve(float x, bool inverse);
 
-    /** Fujifilm F-Log2 opto-electronic transfer function and its inverse. */
-    static float eval_FLog2_curve(float x, bool forward);
-
     static void xyz2oklab(float X, float Y, float Z, float &L, float &a, float &b);
     static void oklab2xyz(float L, float a, float b, float &X, float &Y, float &Z);
 

--- a/rtengine/color.h
+++ b/rtengine/color.h
@@ -1415,6 +1415,9 @@ static inline void Lab2XYZ(vfloat L, vfloat a, vfloat b, vfloat &x, vfloat &y, v
 
     static float eval_ACEScct_curve(float x, bool inverse);
 
+    /** Fujifilm F-Log2 opto-electronic transfer function and its inverse. */
+    static float eval_FLog2_curve(float x, bool forward);
+
     static void xyz2oklab(float X, float Y, float Z, float &L, float &a, float &b);
     static void oklab2xyz(float L, float a, float b, float &X, float &Y, float &Z);
 

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -3189,9 +3189,9 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                             float &sourceB = clutb[tj];
 
                             // Apply inverse gamma sRGB
-                            sourceR = Color::igamma_srgb(out_rgbx[tj * 4 + 0]);
-                            sourceG = Color::igamma_srgb(out_rgbx[tj * 4 + 1]);
-                            sourceB = Color::igamma_srgb(out_rgbx[tj * 4 + 2]);
+                            sourceR = Color::igamma_srgb_extended(out_rgbx[tj * 4 + 0]);
+                            sourceG = Color::igamma_srgb_extended(out_rgbx[tj * 4 + 1]);
+                            sourceB = Color::igamma_srgb_extended(out_rgbx[tj * 4 + 2]);
                         }
 
                         if (!clutAndWorkingProfilesAreSame) {

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2178,7 +2178,7 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
         }
     }
 
-    std::shared_ptr<HaldCLUT> hald_clut;
+    std::shared_ptr<CLUT3D> hald_clut;
     bool clutAndWorkingProfilesAreSame = false;
     TMatrix xyz2clut = {}, clut2xyz = {};
 #if defined(__SSE2__) || defined(RT_SIMDE)

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2179,7 +2179,11 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
     }
 
     std::shared_ptr<CLUT3D> hald_clut;
-    bool clutAndWorkingProfilesAreSame = false;
+    bool clutInputAndWorkingProfilesAreSame = false;
+    bool clutOutputAndWorkingProfilesAreSame = false;
+    bool clutHasDifferentInputAndOutputColorSpace = false;
+    bool clutInputIsFLog2 = false;
+    bool clutOutputIsFLog2 = false;
     TMatrix xyz2clut = {}, clut2xyz = {};
 #if defined(__SSE2__) || defined(RT_SIMDE)
     vfloat v_work2xyz[3][3] ALIGNED16;
@@ -2192,11 +2196,14 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
         hald_clut = CLUTStore::getInstance().getClut(params->filmSimulation.clutFilename);
 
         if (hald_clut) {
-            clutAndWorkingProfilesAreSame = hald_clut->getProfile() == params->icm.workingProfile;
+            clutInputAndWorkingProfilesAreSame = hald_clut->getInputProfile() == params->icm.workingProfile;
+            clutOutputAndWorkingProfilesAreSame = hald_clut->getOutputProfile() == params->icm.workingProfile;
+            clutHasDifferentInputAndOutputColorSpace = hald_clut->hasDifferentInputAndOutputColorSpace();
+            clutInputIsFLog2 = hald_clut->getInputTransferFunction() == CLUTTransferFunction::FLOG2;
+            clutOutputIsFLog2 = hald_clut->getOutputTransferFunction() == CLUTTransferFunction::FLOG2;
 
-            if (!clutAndWorkingProfilesAreSame) {
-                xyz2clut = ICCStore::getInstance()->workingSpaceInverseMatrix(hald_clut->getProfile());
-                clut2xyz = ICCStore::getInstance()->workingSpaceMatrix(hald_clut->getProfile());
+            if (!clutInputAndWorkingProfilesAreSame) {
+                xyz2clut = ICCStore::getInstance()->workingSpaceInverseMatrix(hald_clut->getInputProfile());
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
 
@@ -2204,6 +2211,19 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                     for (int j = 0; j < 3; ++j) {
                         v_work2xyz[i][j] = F2V(wprof[i][j]);
                         v_xyz2clut[i][j] = F2V(xyz2clut[i][j]);
+                    }
+                }
+
+#endif
+            }
+
+            if (!clutOutputAndWorkingProfilesAreSame) {
+                clut2xyz = ICCStore::getInstance()->workingSpaceMatrix(hald_clut->getOutputProfile());
+
+#if defined(__SSE2__) || defined(RT_SIMDE)
+
+                for (int i = 0; i < 3; ++i) {
+                    for (int j = 0; j < 3; ++j) {
                         v_xyz2work[i][j] = F2V(wiprof[i][j]);
                         v_clut2xyz[i][j] = F2V(clut2xyz[i][j]);
                     }
@@ -3123,7 +3143,7 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                 if (hald_clut) {
 
                     for (int i = istart, ti = 0; i < tH; i++, ti++) {
-                        if (!clutAndWorkingProfilesAreSame) {
+                        if (!clutInputAndWorkingProfilesAreSame) {
                             // Convert from working to clut profile
                             int j = jstart;
                             int tj = 0;
@@ -3168,14 +3188,21 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                             float &sourceG = clutg[tj];
                             float &sourceB = clutb[tj];
 
-                            // Apply gamma sRGB (default RT)
-                            sourceR = Color::gamma_srgbclipped(sourceR);
-                            sourceG = Color::gamma_srgbclipped(sourceG);
-                            sourceB = Color::gamma_srgbclipped(sourceB);
+                            if (clutInputIsFLog2) {
+                                constexpr float MAXVAL = 65535.f;
+                                sourceR = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceR / MAXVAL, true));
+                                sourceG = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceG / MAXVAL, true));
+                                sourceB = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceB / MAXVAL, true));
+                            } else {
+                                // Apply gamma sRGB (default RT)
+                                sourceR = Color::gamma_srgbclipped(sourceR);
+                                sourceG = Color::gamma_srgbclipped(sourceG);
+                                sourceB = Color::gamma_srgbclipped(sourceB);
+                            }
                         }
 
                         hald_clut->getRGB(
-                            film_simulation_strength,
+                            clutHasDifferentInputAndOutputColorSpace ? 1.f : film_simulation_strength,
                             std::min(TS, tW - jstart),
                             clutr,
                             clutg,
@@ -3188,13 +3215,20 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                             float &sourceG = clutg[tj];
                             float &sourceB = clutb[tj];
 
-                            // Apply inverse gamma sRGB
-                            sourceR = Color::igamma_srgb(out_rgbx[tj * 4 + 0]);
-                            sourceG = Color::igamma_srgb(out_rgbx[tj * 4 + 1]);
-                            sourceB = Color::igamma_srgb(out_rgbx[tj * 4 + 2]);
+                            if (clutOutputIsFLog2) {
+                                constexpr float MAXVAL = 65535.f;
+                                sourceR = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 0] / MAXVAL, false);
+                                sourceG = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 1] / MAXVAL, false);
+                                sourceB = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 2] / MAXVAL, false);
+                            } else {
+                                // Apply inverse gamma sRGB
+                                sourceR = Color::igamma_srgb(out_rgbx[tj * 4 + 0]);
+                                sourceG = Color::igamma_srgb(out_rgbx[tj * 4 + 1]);
+                                sourceB = Color::igamma_srgb(out_rgbx[tj * 4 + 2]);
+                            }
                         }
 
-                        if (!clutAndWorkingProfilesAreSame) {
+                        if (!clutOutputAndWorkingProfilesAreSame) {
                             // Convert from clut to working profile
                             int j = jstart;
                             int tj = 0;
@@ -3231,6 +3265,12 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                         }
 
                         for (int j = jstart, tj = 0; j < tW; j++, tj++) {
+                            if (clutHasDifferentInputAndOutputColorSpace) {
+                                clutr[tj] = intp<float>(film_simulation_strength, clutr[tj], rtemp[ti * TS + tj]);
+                                clutg[tj] = intp<float>(film_simulation_strength, clutg[tj], gtemp[ti * TS + tj]);
+                                clutb[tj] = intp<float>(film_simulation_strength, clutb[tj], btemp[ti * TS + tj]);
+                            }
+
                             setUnlessOOG(rtemp[ti * TS + tj], gtemp[ti * TS + tj], btemp[ti * TS + tj], clutr[tj], clutg[tj], clutb[tj]);
                         }
                     }

--- a/rtengine/improcfun.cc
+++ b/rtengine/improcfun.cc
@@ -2179,11 +2179,7 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
     }
 
     std::shared_ptr<CLUT3D> hald_clut;
-    bool clutInputAndWorkingProfilesAreSame = false;
-    bool clutOutputAndWorkingProfilesAreSame = false;
-    bool clutHasDifferentInputAndOutputColorSpace = false;
-    bool clutInputIsFLog2 = false;
-    bool clutOutputIsFLog2 = false;
+    bool clutAndWorkingProfilesAreSame = false;
     TMatrix xyz2clut = {}, clut2xyz = {};
 #if defined(__SSE2__) || defined(RT_SIMDE)
     vfloat v_work2xyz[3][3] ALIGNED16;
@@ -2196,14 +2192,11 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
         hald_clut = CLUTStore::getInstance().getClut(params->filmSimulation.clutFilename);
 
         if (hald_clut) {
-            clutInputAndWorkingProfilesAreSame = hald_clut->getInputProfile() == params->icm.workingProfile;
-            clutOutputAndWorkingProfilesAreSame = hald_clut->getOutputProfile() == params->icm.workingProfile;
-            clutHasDifferentInputAndOutputColorSpace = hald_clut->hasDifferentInputAndOutputColorSpace();
-            clutInputIsFLog2 = hald_clut->getInputTransferFunction() == CLUTTransferFunction::FLOG2;
-            clutOutputIsFLog2 = hald_clut->getOutputTransferFunction() == CLUTTransferFunction::FLOG2;
+            clutAndWorkingProfilesAreSame = hald_clut->getProfile() == params->icm.workingProfile;
 
-            if (!clutInputAndWorkingProfilesAreSame) {
-                xyz2clut = ICCStore::getInstance()->workingSpaceInverseMatrix(hald_clut->getInputProfile());
+            if (!clutAndWorkingProfilesAreSame) {
+                xyz2clut = ICCStore::getInstance()->workingSpaceInverseMatrix(hald_clut->getProfile());
+                clut2xyz = ICCStore::getInstance()->workingSpaceMatrix(hald_clut->getProfile());
 
 #if defined(__SSE2__) || defined(RT_SIMDE)
 
@@ -2211,19 +2204,6 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                     for (int j = 0; j < 3; ++j) {
                         v_work2xyz[i][j] = F2V(wprof[i][j]);
                         v_xyz2clut[i][j] = F2V(xyz2clut[i][j]);
-                    }
-                }
-
-#endif
-            }
-
-            if (!clutOutputAndWorkingProfilesAreSame) {
-                clut2xyz = ICCStore::getInstance()->workingSpaceMatrix(hald_clut->getOutputProfile());
-
-#if defined(__SSE2__) || defined(RT_SIMDE)
-
-                for (int i = 0; i < 3; ++i) {
-                    for (int j = 0; j < 3; ++j) {
                         v_xyz2work[i][j] = F2V(wiprof[i][j]);
                         v_clut2xyz[i][j] = F2V(clut2xyz[i][j]);
                     }
@@ -3143,7 +3123,7 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                 if (hald_clut) {
 
                     for (int i = istart, ti = 0; i < tH; i++, ti++) {
-                        if (!clutInputAndWorkingProfilesAreSame) {
+                        if (!clutAndWorkingProfilesAreSame) {
                             // Convert from working to clut profile
                             int j = jstart;
                             int tj = 0;
@@ -3188,21 +3168,14 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                             float &sourceG = clutg[tj];
                             float &sourceB = clutb[tj];
 
-                            if (clutInputIsFLog2) {
-                                constexpr float MAXVAL = 65535.f;
-                                sourceR = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceR / MAXVAL, true));
-                                sourceG = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceG / MAXVAL, true));
-                                sourceB = MAXVAL * LIM01(Color::eval_FLog2_curve(sourceB / MAXVAL, true));
-                            } else {
-                                // Apply gamma sRGB (default RT)
-                                sourceR = Color::gamma_srgbclipped(sourceR);
-                                sourceG = Color::gamma_srgbclipped(sourceG);
-                                sourceB = Color::gamma_srgbclipped(sourceB);
-                            }
+                            // Apply gamma sRGB (default RT)
+                            sourceR = Color::gamma_srgbclipped(sourceR);
+                            sourceG = Color::gamma_srgbclipped(sourceG);
+                            sourceB = Color::gamma_srgbclipped(sourceB);
                         }
 
                         hald_clut->getRGB(
-                            clutHasDifferentInputAndOutputColorSpace ? 1.f : film_simulation_strength,
+                            film_simulation_strength,
                             std::min(TS, tW - jstart),
                             clutr,
                             clutg,
@@ -3215,20 +3188,13 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                             float &sourceG = clutg[tj];
                             float &sourceB = clutb[tj];
 
-                            if (clutOutputIsFLog2) {
-                                constexpr float MAXVAL = 65535.f;
-                                sourceR = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 0] / MAXVAL, false);
-                                sourceG = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 1] / MAXVAL, false);
-                                sourceB = MAXVAL * Color::eval_FLog2_curve(out_rgbx[tj * 4 + 2] / MAXVAL, false);
-                            } else {
-                                // Apply inverse gamma sRGB
-                                sourceR = Color::igamma_srgb(out_rgbx[tj * 4 + 0]);
-                                sourceG = Color::igamma_srgb(out_rgbx[tj * 4 + 1]);
-                                sourceB = Color::igamma_srgb(out_rgbx[tj * 4 + 2]);
-                            }
+                            // Apply inverse gamma sRGB
+                            sourceR = Color::igamma_srgb(out_rgbx[tj * 4 + 0]);
+                            sourceG = Color::igamma_srgb(out_rgbx[tj * 4 + 1]);
+                            sourceB = Color::igamma_srgb(out_rgbx[tj * 4 + 2]);
                         }
 
-                        if (!clutOutputAndWorkingProfilesAreSame) {
+                        if (!clutAndWorkingProfilesAreSame) {
                             // Convert from clut to working profile
                             int j = jstart;
                             int tj = 0;
@@ -3265,12 +3231,6 @@ void ImProcFunctions::rgbProc(Imagefloat* working, LabImage* lab, PipetteBuffer 
                         }
 
                         for (int j = jstart, tj = 0; j < tW; j++, tj++) {
-                            if (clutHasDifferentInputAndOutputColorSpace) {
-                                clutr[tj] = intp<float>(film_simulation_strength, clutr[tj], rtemp[ti * TS + tj]);
-                                clutg[tj] = intp<float>(film_simulation_strength, clutg[tj], gtemp[ti * TS + tj]);
-                                clutb[tj] = intp<float>(film_simulation_strength, clutb[tj], btemp[ti * TS + tj]);
-                            }
-
                             setUnlessOOG(rtemp[ti * TS + tj], gtemp[ti * TS + tj], btemp[ti * TS + tj], clutr[tj], clutg[tj], clutb[tj]);
                         }
                     }

--- a/rtgui/tools/filmsimulation.cc
+++ b/rtgui/tools/filmsimulation.cc
@@ -398,7 +398,7 @@ int ClutComboBox::ClutModel::parseDir(const Glib::ustring& path)
             HaldCLUT::splitClutFilename (entry, name, extension, profileName, false);
 
             extension = extension.casefold();
-            if (extension != "png" && extension != "tif") {
+            if (extension != "png" && extension != "tif" && extension != "cube") {
                 continue;
             }
 

--- a/tools/bake_cube_lut-README.md
+++ b/tools/bake_cube_lut-README.md
@@ -79,10 +79,17 @@ Run the following command for the complete command-line reference:
 python3 bake_cube_lut.py --help
 ```
 
-## Output limitations
+## Input and output range
 
 The generated LUT targets RawTherapee's Rec.2020 Film Simulation profile and
 therefore must retain the `_Rec2020.cube` filename suffix. It represents
-non-negative linear input values from 0 to 1. Values outside that range are
-subject to the same clipping limitations as RawTherapee's existing Film
-Simulation processing.
+non-negative linear input values from 0 to 1; source-LUT input coordinates are
+clamped to the source `DOMAIN_MIN` and `DOMAIN_MAX` while baking. Input values
+outside the generated range remain subject to RawTherapee Film Simulation's
+input clipping.
+
+Source LUT results and the subsequent output transforms are not clamped. The
+generated Cube can therefore contain finite encoded output values below 0 or
+above 1. RawTherapee preserves those extended Cube outputs through its inverse
+sRGB transfer and working-profile conversion, although later processing or
+final export can still clip them.

--- a/tools/bake_cube_lut-README.md
+++ b/tools/bake_cube_lut-README.md
@@ -1,0 +1,88 @@
+# Cube LUT baking tool
+
+`bake_cube_lut.py` converts a technical 3D Cube LUT into a LUT that can be
+used by RawTherapee's Film Simulation tool.
+
+Technical LUTs commonly expect and produce values in a vendor-specific colour
+gamut and transfer function, such as Fujifilm F-Gamut and F-Log2. RawTherapee
+instead associates a Film Simulation LUT with an RGB profile through the
+profile suffix in its filename. The baking tool composes the required transfer
+function and gamut conversions into a new LUT following RawTherapee's
+`_Rec2020.cube` convention.
+
+The tool requires Python 3 but uses only the Python standard library. Python is
+not required to run RawTherapee or to use LUTs that have already been baked.
+
+## Usage
+
+Run the tool with an input Cube file and an output filename ending in
+`_Rec2020.cube`:
+
+```text
+python3 bake_cube_lut.py INPUT.cube OUTPUT_Rec2020.cube
+```
+
+For example, the Fujifilm Reala Ace LUT can be converted with:
+
+```text
+python3 bake_cube_lut.py \
+    FLog2_to_REALA-ACE_65grid_V.1.00.cube \
+    Fujifilm_REALA-ACE_Rec2020.cube
+```
+
+The default `auto` preset reads Fujifilm's `Gamma` and `Gamut` comments and
+recognizes F-Log2/F-Gamut LUTs that output ITU-R BT.709. The output grid is
+65 x 65 x 65 by default.
+
+Use `--size` to select another output grid size:
+
+```text
+python3 bake_cube_lut.py INPUT.cube OUTPUT_Rec2020.cube --size 33
+```
+
+`--size` controls the side length of the generated cube independently of the
+source cube's `LUT_3D_SIZE`. For every point in the generated grid, the tool
+applies the input gamut and transfer conversions and then samples the source
+cube at the resulting coordinate. If that coordinate falls between source
+samples, the tool uses tetrahedral interpolation. It then applies the output
+conversions and writes the result into the generated cube. Consequently, a
+smaller output size downsamples the composed transform, while a larger output
+size upsamples it; increasing the size cannot recover detail that is absent
+from the source LUT.
+
+This interpolation follows the *Adobe Cube LUT Specification 1.0*. Section
+7.1, "The Three-Dimensional Table", states that 3D table values shall be set
+so tetrahedral interpolation generates the correct output. Section 8,
+"Application Requirements", says that readers should use tetrahedral
+interpolation for three-dimensional tables when an input lies between stored
+sample points.
+
+For a source LUT whose transforms cannot be inferred from metadata, specify
+them explicitly:
+
+```text
+python3 bake_cube_lut.py INPUT.cube OUTPUT_Rec2020.cube \
+    --preset none \
+    --input-gamut rec2020 \
+    --input-transfer flog2 \
+    --output-gamut bt709 \
+    --output-transfer srgb
+```
+
+Supported gamut names are `srgb`, `bt709`, `rec2020`, `fgamut`, and
+`f-gamut`. Supported transfer functions are `srgb`, `flog2`, and `f-log2`.
+F-Gamut is treated as Rec.2020, while BT.709 uses the same primaries as sRGB.
+
+Run the following command for the complete command-line reference:
+
+```text
+python3 bake_cube_lut.py --help
+```
+
+## Output limitations
+
+The generated LUT targets RawTherapee's Rec.2020 Film Simulation profile and
+therefore must retain the `_Rec2020.cube` filename suffix. It represents
+non-negative linear input values from 0 to 1. Values outside that range are
+subject to the same clipping limitations as RawTherapee's existing Film
+Simulation processing.

--- a/tools/bake_cube_lut.py
+++ b/tools/bake_cube_lut.py
@@ -154,6 +154,8 @@ class CubeLUT:
     title: str | None = None
 
     def sample(self, rgb: RGB) -> RGB:
+        # Adobe Cube LUT Specification 1.0, sections 7.1 and 8, specifies
+        # tetrahedral interpolation for values between 3D table samples.
         fractions = []
         bases = []
 

--- a/tools/bake_cube_lut.py
+++ b/tools/bake_cube_lut.py
@@ -8,9 +8,9 @@ the sRGB transfer function, and converts back to the working profile.
 
 This tool composes a source LUT's input/output colour transforms into that
 convention. Generated LUTs target Rec.2020 and must end in ``_Rec2020.cube``.
-Like RawTherapee's ordinary Film Simulation path, the result is limited to
-non-negative linear values in the range 0..1 and uses encoded-space strength
-blending.
+Their input grid remains limited to encoded values in the range 0..1, but
+finite output values below 0 or above 1 are preserved. Film Simulation
+strength blending remains encoded-space.
 """
 
 from __future__ import annotations
@@ -90,14 +90,12 @@ def convert_gamut(rgb: RGB, source: str, destination: str) -> RGB:
 
 
 def srgb_encode(value: float) -> float:
-    value = clamp01(value)
     if value <= 0.003040:
         return 12.92310 * value
     return 1.055 * math.pow(value, 1.0 / 2.4) - 0.055
 
 
 def srgb_decode(value: float) -> float:
-    value = clamp01(value)
     if value <= 0.039286:
         return value / 12.92310
     return math.pow((value + 0.055) / 1.055, 2.4)
@@ -231,9 +229,12 @@ def parse_three_floats(arguments: Sequence[str], keyword: str, line_number: int)
     if len(arguments) != 3:
         raise ValueError(f"line {line_number}: {keyword} requires three values")
     try:
-        return tuple(float(value) for value in arguments)  # type: ignore[return-value]
+        values = tuple(float(value) for value in arguments)
     except ValueError as exc:
         raise ValueError(f"line {line_number}: invalid {keyword} value") from exc
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"line {line_number}: non-finite {keyword} value")
+    return values  # type: ignore[return-value]
 
 
 def read_cube(path: Path) -> CubeLUT:
@@ -358,7 +359,11 @@ def transform_sample(lut: CubeLUT, encoded_rec2020: RGB, spec: TransformSpec) ->
     linear_input = convert_gamut(linear_rec2020, "rec2020", spec.input_gamut)
     encoded_input = map_channels(ENCODERS[spec.input_transfer], linear_input)
 
-    encoded_output = tuple(clamp01(value) for value in lut.sample(encoded_input))  # type: ignore[assignment]
+    # CubeLUT.sample() clamps only the source LUT's input coordinates, as
+    # required by its DOMAIN_MIN/MAX. Output samples and the extended sRGB
+    # wrapper remain unclamped so the baked Cube can preserve finite values
+    # below 0 and above 1.
+    encoded_output = lut.sample(encoded_input)
     linear_output = map_channels(DECODERS[spec.output_transfer], encoded_output)
     linear_rec2020_output = convert_gamut(linear_output, spec.output_gamut, "rec2020")
     return map_channels(srgb_encode, linear_rec2020_output)
@@ -396,10 +401,13 @@ def write_cube(
         output.write(f"# Source gamut: {source_gamut}\n")
         output.write("# RawTherapee profile: Rec2020\n")
         output.write("# Linear input range represented: 0.0 to 1.0\n")
+        output.write("# Output values may be outside 0.0 to 1.0\n")
         output.write(f"LUT_3D_SIZE {size}\n")
         output.write("DOMAIN_MIN 0.0 0.0 0.0\n")
         output.write("DOMAIN_MAX 1.0 1.0 1.0\n\n")
         for red, green, blue in values:
+            if not all(math.isfinite(value) for value in (red, green, blue)):
+                raise ValueError("generated LUT contains a non-finite output value")
             output.write(f"{red:.10f} {green:.10f} {blue:.10f}\n")
 
 

--- a/tools/bake_cube_lut.py
+++ b/tools/bake_cube_lut.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Bake a technical 3D Cube LUT for RawTherapee Film Simulation.
+
+RawTherapee associates a Film Simulation LUT with an RGB profile through the
+profile name at the end of the filename. It converts linear working RGB to
+that profile, applies the sRGB transfer function, evaluates the LUT, removes
+the sRGB transfer function, and converts back to the working profile.
+
+This tool composes a source LUT's input/output colour transforms into that
+convention. Generated LUTs target Rec.2020 and must end in ``_Rec2020.cube``.
+Like RawTherapee's ordinary Film Simulation path, the result is limited to
+non-negative linear values in the range 0..1 and uses encoded-space strength
+blending.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Iterator, List, Sequence, Tuple
+
+
+RGB = Tuple[float, float, float]
+Matrix3 = Tuple[RGB, RGB, RGB]
+
+
+SRGB_TO_XYZ: Matrix3 = (
+    (0.4124564, 0.3575761, 0.1804375),
+    (0.2126729, 0.7151522, 0.0721750),
+    (0.0193339, 0.1191920, 0.9503041),
+)
+
+XYZ_TO_SRGB: Matrix3 = (
+    (3.2404542, -1.5371385, -0.4985314),
+    (-0.9692660, 1.8760108, 0.0415560),
+    (0.0556434, -0.2040259, 1.0572252),
+)
+
+REC2020_TO_XYZ: Matrix3 = (
+    (0.6369580483, 0.1446169036, 0.1688809752),
+    (0.2627002120, 0.6779980715, 0.0593017165),
+    (0.0000000000, 0.0280726930, 1.0609850577),
+)
+
+XYZ_TO_REC2020: Matrix3 = (
+    (1.7166511880, -0.3556707838, -0.2533662814),
+    (-0.6666843518, 1.6164812366, 0.0157685458),
+    (0.0176398574, -0.0427706133, 0.9421031212),
+)
+
+
+GAMUT_ALIASES = {
+    "srgb": "srgb",
+    "bt709": "srgb",
+    "rec2020": "rec2020",
+    "fgamut": "rec2020",
+    "f-gamut": "rec2020",
+}
+
+TRANSFER_ALIASES = {
+    "srgb": "srgb",
+    "flog2": "flog2",
+    "f-log2": "flog2",
+}
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def matrix_vector(matrix: Matrix3, vector: RGB) -> RGB:
+    return tuple(
+        sum(matrix[row][column] * vector[column] for column in range(3))
+        for row in range(3)
+    )  # type: ignore[return-value]
+
+
+def convert_gamut(rgb: RGB, source: str, destination: str) -> RGB:
+    source = normalize_gamut(source)
+    destination = normalize_gamut(destination)
+
+    if source == destination:
+        return rgb
+
+    source_to_xyz = SRGB_TO_XYZ if source == "srgb" else REC2020_TO_XYZ
+    xyz_to_destination = XYZ_TO_SRGB if destination == "srgb" else XYZ_TO_REC2020
+    return matrix_vector(xyz_to_destination, matrix_vector(source_to_xyz, rgb))
+
+
+def srgb_encode(value: float) -> float:
+    value = clamp01(value)
+    if value <= 0.003040:
+        return 12.92310 * value
+    return 1.055 * math.pow(value, 1.0 / 2.4) - 0.055
+
+
+def srgb_decode(value: float) -> float:
+    value = clamp01(value)
+    if value <= 0.039286:
+        return value / 12.92310
+    return math.pow((value + 0.055) / 1.055, 2.4)
+
+
+def flog2_encode(value: float) -> float:
+    if value >= 0.000889:
+        return 0.245281 * math.log10(5.555556 * value + 0.064829) + 0.384316
+    return 8.799461 * value + 0.092864
+
+
+def flog2_decode(value: float) -> float:
+    if value >= 0.100686685370811:
+        return math.pow(10.0, (value - 0.384316) / 0.245281) / 5.555556 - 0.064829 / 5.555556
+    return (value - 0.092864) / 8.799461
+
+
+ENCODERS: Dict[str, Callable[[float], float]] = {
+    "srgb": srgb_encode,
+    "flog2": flog2_encode,
+}
+
+DECODERS: Dict[str, Callable[[float], float]] = {
+    "srgb": srgb_decode,
+    "flog2": flog2_decode,
+}
+
+
+def normalize_gamut(value: str) -> str:
+    try:
+        return GAMUT_ALIASES[value.lower()]
+    except KeyError as exc:
+        raise ValueError(f"unsupported gamut: {value}") from exc
+
+
+def normalize_transfer(value: str) -> str:
+    try:
+        return TRANSFER_ALIASES[value.lower()]
+    except KeyError as exc:
+        raise ValueError(f"unsupported transfer function: {value}") from exc
+
+
+def map_channels(function: Callable[[float], float], rgb: RGB) -> RGB:
+    return function(rgb[0]), function(rgb[1]), function(rgb[2])
+
+
+@dataclass(frozen=True)
+class CubeLUT:
+    size: int
+    values: Sequence[RGB]
+    domain_min: RGB = (0.0, 0.0, 0.0)
+    domain_max: RGB = (1.0, 1.0, 1.0)
+    metadata: Dict[str, str] | None = None
+    title: str | None = None
+
+    def sample(self, rgb: RGB) -> RGB:
+        fractions = []
+        bases = []
+
+        for channel in range(3):
+            normalized = (
+                (rgb[channel] - self.domain_min[channel])
+                / (self.domain_max[channel] - self.domain_min[channel])
+            )
+            scaled = clamp01(normalized) * (self.size - 1)
+            base = min(self.size - 2, int(math.floor(scaled)))
+            bases.append(base)
+            fractions.append(scaled - base)
+
+        red, green, blue = bases
+        red_fraction, green_fraction, blue_fraction = fractions
+        level = self.size
+        level_square = level * level
+        base_index = red + green * level + blue * level_square
+
+        if red_fraction >= green_fraction:
+            if green_fraction >= blue_fraction:
+                offsets = (1, 1 + level)
+                ordered_fractions = (red_fraction, green_fraction, blue_fraction)
+            elif red_fraction >= blue_fraction:
+                offsets = (1, 1 + level_square)
+                ordered_fractions = (red_fraction, blue_fraction, green_fraction)
+            else:
+                offsets = (level_square, level_square + 1)
+                ordered_fractions = (blue_fraction, red_fraction, green_fraction)
+        elif red_fraction >= blue_fraction:
+            offsets = (level, level + 1)
+            ordered_fractions = (green_fraction, red_fraction, blue_fraction)
+        elif green_fraction >= blue_fraction:
+            offsets = (level, level + level_square)
+            ordered_fractions = (green_fraction, blue_fraction, red_fraction)
+        else:
+            offsets = (level_square, level_square + level)
+            ordered_fractions = (blue_fraction, green_fraction, red_fraction)
+
+        vertices = (
+            self.values[base_index],
+            self.values[base_index + offsets[0]],
+            self.values[base_index + offsets[1]],
+            self.values[base_index + 1 + level + level_square],
+        )
+
+        result = []
+        for channel in range(3):
+            c0, c1, c2, c3 = (vertex[channel] for vertex in vertices)
+            f1, f2, f3 = ordered_fractions
+            result.append(c0 + f1 * (c1 - c0) + f2 * (c2 - c1) + f3 * (c3 - c2))
+
+        return tuple(result)  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class TransformSpec:
+    input_gamut: str
+    input_transfer: str
+    output_gamut: str
+    output_transfer: str
+
+    def normalized(self) -> "TransformSpec":
+        return TransformSpec(
+            normalize_gamut(self.input_gamut),
+            normalize_transfer(self.input_transfer),
+            normalize_gamut(self.output_gamut),
+            normalize_transfer(self.output_transfer),
+        )
+
+
+def parse_three_floats(arguments: Sequence[str], keyword: str, line_number: int) -> RGB:
+    if len(arguments) != 3:
+        raise ValueError(f"line {line_number}: {keyword} requires three values")
+    try:
+        return tuple(float(value) for value in arguments)  # type: ignore[return-value]
+    except ValueError as exc:
+        raise ValueError(f"line {line_number}: invalid {keyword} value") from exc
+
+
+def read_cube(path: Path) -> CubeLUT:
+    size: int | None = None
+    domain_min: RGB = (0.0, 0.0, 0.0)
+    domain_max: RGB = (1.0, 1.0, 1.0)
+    values: List[RGB] = []
+    metadata: Dict[str, str] = {}
+    title: str | None = None
+
+    with path.open("r", encoding="utf-8-sig") as source:
+        for line_number, raw_line in enumerate(source, 1):
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("#"):
+                comment = line[1:].strip()
+                if ":" in comment:
+                    key, value = comment.split(":", 1)
+                    metadata[key.strip().lower()] = value.strip()
+                continue
+
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+
+            fields = line.split()
+            keyword = fields[0].upper()
+            arguments = fields[1:]
+
+            if keyword == "TITLE":
+                title = line[len(fields[0]):].strip().strip('"')
+            elif keyword == "LUT_3D_SIZE":
+                if len(arguments) != 1:
+                    raise ValueError(f"line {line_number}: LUT_3D_SIZE requires one value")
+                try:
+                    size = int(arguments[0])
+                except ValueError as exc:
+                    raise ValueError(f"line {line_number}: invalid LUT_3D_SIZE") from exc
+                if not 2 <= size <= 256:
+                    raise ValueError(f"line {line_number}: LUT_3D_SIZE must be between 2 and 256")
+            elif keyword == "DOMAIN_MIN":
+                domain_min = parse_three_floats(arguments, keyword, line_number)
+            elif keyword == "DOMAIN_MAX":
+                domain_max = parse_three_floats(arguments, keyword, line_number)
+            elif keyword.startswith("LUT_1D"):
+                raise ValueError(f"line {line_number}: 1D/shaper LUTs are not supported")
+            elif keyword in {"LUT_3D_INPUT_RANGE", "LUT_3D_INPUT_TABLE"}:
+                raise ValueError(f"line {line_number}: {keyword} is not supported")
+            else:
+                if size is None:
+                    raise ValueError(f"line {line_number}: LUT data precedes LUT_3D_SIZE")
+                values.append(parse_three_floats(fields, "LUT entry", line_number))
+                if len(values) > size * size * size:
+                    raise ValueError(f"line {line_number}: too many LUT entries")
+
+    if size is None:
+        raise ValueError("missing LUT_3D_SIZE")
+    if any(domain_min[channel] >= domain_max[channel] for channel in range(3)):
+        raise ValueError("DOMAIN_MIN must be lower than DOMAIN_MAX for every channel")
+    expected_entries = size * size * size
+    if len(values) != expected_entries:
+        raise ValueError(f"expected {expected_entries} LUT entries, found {len(values)}")
+
+    return CubeLUT(size, values, domain_min, domain_max, metadata, title)
+
+
+def infer_fujifilm_spec(lut: CubeLUT) -> TransformSpec | None:
+    metadata = lut.metadata or {}
+    gamma = metadata.get("gamma", "")
+    gamut = metadata.get("gamut", "")
+
+    if not gamma.startswith("F-Log2 to ") or gamut != "F-Gamut to ITU-R BT.709":
+        return None
+
+    output_transfer = "flog2" if gamma == "F-Log2 to F-Log2" else "srgb"
+    return TransformSpec("rec2020", "flog2", "srgb", output_transfer)
+
+
+def resolve_transform_spec(
+    lut: CubeLUT,
+    preset: str,
+    input_gamut: str | None,
+    input_transfer: str | None,
+    output_gamut: str | None,
+    output_transfer: str | None,
+) -> TransformSpec:
+    inferred: TransformSpec | None = None
+    if preset in {"auto", "fujifilm-flog2-bt709"}:
+        inferred = infer_fujifilm_spec(lut)
+        if preset == "fujifilm-flog2-bt709" and inferred is None:
+            metadata = lut.metadata or {}
+            gamma = metadata.get("gamma", "F-Log2 to ETERNA")
+            inferred = TransformSpec(
+                "rec2020",
+                "flog2",
+                "srgb",
+                "flog2" if gamma == "F-Log2 to F-Log2" else "srgb",
+            )
+
+    values = {
+        "input_gamut": input_gamut or (inferred.input_gamut if inferred else None),
+        "input_transfer": input_transfer or (inferred.input_transfer if inferred else None),
+        "output_gamut": output_gamut or (inferred.output_gamut if inferred else None),
+        "output_transfer": output_transfer or (inferred.output_transfer if inferred else None),
+    }
+    missing = [name.replace("_", "-") for name, value in values.items() if value is None]
+    if missing:
+        raise ValueError(
+            "could not infer the source transform; specify "
+            + ", ".join(f"--{name}" for name in missing)
+        )
+
+    return TransformSpec(**values).normalized()  # type: ignore[arg-type]
+
+
+def transform_sample(lut: CubeLUT, encoded_rec2020: RGB, spec: TransformSpec) -> RGB:
+    spec = spec.normalized()
+
+    linear_rec2020 = map_channels(srgb_decode, encoded_rec2020)
+    linear_input = convert_gamut(linear_rec2020, "rec2020", spec.input_gamut)
+    encoded_input = map_channels(ENCODERS[spec.input_transfer], linear_input)
+
+    encoded_output = tuple(clamp01(value) for value in lut.sample(encoded_input))  # type: ignore[assignment]
+    linear_output = map_channels(DECODERS[spec.output_transfer], encoded_output)
+    linear_rec2020_output = convert_gamut(linear_output, spec.output_gamut, "rec2020")
+    return map_channels(srgb_encode, linear_rec2020_output)
+
+
+def iter_baked_values(lut: CubeLUT, spec: TransformSpec, size: int) -> Iterator[RGB]:
+    denominator = float(size - 1)
+    for blue in range(size):
+        for green in range(size):
+            for red in range(size):
+                yield transform_sample(
+                    lut,
+                    (red / denominator, green / denominator, blue / denominator),
+                    spec,
+                )
+
+
+def write_cube(
+    path: Path,
+    source_path: Path,
+    source: CubeLUT,
+    spec: TransformSpec,
+    size: int,
+    values: Iterable[RGB],
+) -> None:
+    metadata = source.metadata or {}
+    source_gamma = metadata.get("gamma", spec.input_transfer)
+    source_gamut = metadata.get("gamut", f"{spec.input_gamut} to {spec.output_gamut}")
+
+    with path.open("w", encoding="utf-8", newline="\n") as output:
+        output.write(f'TITLE "{source.title or source_path.stem} - RawTherapee Rec2020"\n')
+        output.write("# Generated by tools/bake_cube_lut.py\n")
+        output.write(f"# Source: {source_path.name}\n")
+        output.write(f"# Source gamma: {source_gamma}\n")
+        output.write(f"# Source gamut: {source_gamut}\n")
+        output.write("# RawTherapee profile: Rec2020\n")
+        output.write("# Linear input range represented: 0.0 to 1.0\n")
+        output.write(f"LUT_3D_SIZE {size}\n")
+        output.write("DOMAIN_MIN 0.0 0.0 0.0\n")
+        output.write("DOMAIN_MAX 1.0 1.0 1.0\n\n")
+        for red, green, blue in values:
+            output.write(f"{red:.10f} {green:.10f} {blue:.10f}\n")
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="source 3D .cube LUT")
+    parser.add_argument("output", type=Path, help="output path ending in _Rec2020.cube")
+    parser.add_argument(
+        "--preset",
+        choices=("auto", "none", "fujifilm-flog2-bt709"),
+        default="auto",
+        help="source transform preset (default: infer from metadata)",
+    )
+    parser.add_argument("--size", type=int, default=65, help="generated cube size (default: 65)")
+    parser.add_argument("--input-gamut", choices=tuple(GAMUT_ALIASES))
+    parser.add_argument("--input-transfer", choices=tuple(TRANSFER_ALIASES))
+    parser.add_argument("--output-gamut", choices=tuple(GAMUT_ALIASES))
+    parser.add_argument("--output-transfer", choices=tuple(TRANSFER_ALIASES))
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    parser = create_argument_parser()
+    options = parser.parse_args(arguments)
+
+    if not 2 <= options.size <= 256:
+        parser.error("--size must be between 2 and 256")
+    if options.output.suffix.lower() != ".cube" or not options.output.stem.endswith("_Rec2020"):
+        parser.error("output filename must end in _Rec2020.cube")
+
+    try:
+        source = read_cube(options.input)
+        spec = resolve_transform_spec(
+            source,
+            options.preset,
+            options.input_gamut,
+            options.input_transfer,
+            options.output_gamut,
+            options.output_transfer,
+        )
+        write_cube(
+            options.output,
+            options.input,
+            source,
+            spec,
+            options.size,
+            iter_baked_values(source, spec, options.size),
+        )
+    except (OSError, ValueError) as exc:
+        parser.error(str(exc))
+
+    print(f"Wrote {options.size}x{options.size}x{options.size} Rec2020 LUT to {options.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_bake_cube_lut.py
+++ b/tools/tests/test_bake_cube_lut.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import bake_cube_lut as baker
+
+
+def cube_text(values, domain_min=(0, 0, 0), domain_max=(1, 1, 1), comments=""):
+    lines = [comments, "LUT_3D_SIZE 2"]
+    lines.append("DOMAIN_MIN " + " ".join(str(value) for value in domain_min))
+    lines.append("DOMAIN_MAX " + " ".join(str(value) for value in domain_max))
+    lines.extend(" ".join(str(channel) for channel in value) for value in values)
+    return "\n".join(lines) + "\n"
+
+
+class CubeParsingTest(unittest.TestCase):
+    def read(self, contents):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "test.cube"
+            path.write_text(contents, encoding="utf-8")
+            return baker.read_cube(path)
+
+    def test_domain_is_applied_to_input_coordinates(self):
+        values = [
+            (0, 0, 0), (1, 0, 0),
+            (0, 1, 0), (1, 1, 0),
+            (0, 0, 1), (1, 0, 1),
+            (0, 1, 1), (1, 1, 1),
+        ]
+        lut = self.read(cube_text(values, (-1, -2, -3), (1, 2, 3)))
+        self.assertEqual(lut.sample((-1, -2, -3)), (0.0, 0.0, 0.0))
+        self.assertEqual(lut.sample((1, 2, 3)), (1.0, 1.0, 1.0))
+        self.assertEqual(lut.sample((0, 0, 0)), (0.5, 0.5, 0.5))
+
+    def test_rejects_reversed_domain(self):
+        values = [(0, 0, 0)] * 8
+        with self.assertRaisesRegex(ValueError, "DOMAIN_MIN"):
+            self.read(cube_text(values, (1, 0, 0), (0, 1, 1)))
+
+    def test_rejects_wrong_entry_count(self):
+        with self.assertRaisesRegex(ValueError, "expected 8"):
+            self.read(cube_text([(0, 0, 0)] * 7))
+
+
+class TetrahedralInterpolationTest(unittest.TestCase):
+    VALUES = (
+        (0.02, 0.02, 0.02),
+        (0.11, 0.11, 0.11),
+        (0.23, 0.23, 0.23),
+        (0.37, 0.37, 0.37),
+        (0.41, 0.41, 0.41),
+        (0.59, 0.59, 0.59),
+        (0.61, 0.61, 0.61),
+        (0.83, 0.83, 0.83),
+    )
+
+    def setUp(self):
+        self.lut = baker.CubeLUT(2, self.VALUES)
+
+    def expected(self, red, green, blue):
+        c000, c100, c010, c110, c001, c101, c011, c111 = (
+            value[0] for value in self.VALUES
+        )
+        if red >= green >= blue:
+            return c000 + red * (c100 - c000) + green * (c110 - c100) + blue * (c111 - c110)
+        if red >= blue > green:
+            return c000 + red * (c100 - c000) + blue * (c101 - c100) + green * (c111 - c101)
+        if blue > red >= green:
+            return c000 + blue * (c001 - c000) + red * (c101 - c001) + green * (c111 - c101)
+        if green > red >= blue:
+            return c000 + green * (c010 - c000) + red * (c110 - c010) + blue * (c111 - c110)
+        if green >= blue > red:
+            return c000 + green * (c010 - c000) + blue * (c011 - c010) + red * (c111 - c011)
+        return c000 + blue * (c001 - c000) + green * (c011 - c001) + red * (c111 - c011)
+
+    def test_all_six_fraction_orderings(self):
+        points = (
+            (0.75, 0.50, 0.25),
+            (0.75, 0.25, 0.50),
+            (0.50, 0.25, 0.75),
+            (0.50, 0.75, 0.25),
+            (0.25, 0.75, 0.50),
+            (0.25, 0.50, 0.75),
+        )
+        for point in points:
+            with self.subTest(point=point):
+                expected = self.expected(*point)
+                self.assertAlmostEqual(self.lut.sample(point)[0], expected, places=14)
+
+    def test_equal_boundaries_and_endpoints(self):
+        self.assertEqual(self.lut.sample((0, 0, 0)), self.VALUES[0])
+        self.assertEqual(self.lut.sample((1, 1, 1)), self.VALUES[7])
+        expected = self.expected(0.5, 0.5, 0.5)
+        self.assertAlmostEqual(self.lut.sample((0.5, 0.5, 0.5))[0], expected, places=14)
+
+
+class TransferFunctionTest(unittest.TestCase):
+    def test_flog2_cut_points(self):
+        self.assertAlmostEqual(baker.flog2_encode(0.000889), 0.100686685370811, places=14)
+        self.assertAlmostEqual(baker.flog2_decode(0.100686685370811), 0.000889, places=14)
+
+    def test_flog2_round_trip(self):
+        for value in (-0.01, 0.0, 0.000889, 0.18, 1.0, 5.0, 10.0):
+            with self.subTest(value=value):
+                self.assertAlmostEqual(baker.flog2_decode(baker.flog2_encode(value)), value, places=12)
+
+
+class TransformTest(unittest.TestCase):
+    def test_fujifilm_metadata_detection(self):
+        lut = baker.CubeLUT(
+            2,
+            [(0, 0, 0)] * 8,
+            metadata={
+                "gamma": "F-Log2 to ETERNA BLEACH BYPASS",
+                "gamut": "F-Gamut to ITU-R BT.709",
+            },
+        )
+        self.assertEqual(
+            baker.infer_fujifilm_spec(lut),
+            baker.TransformSpec("rec2020", "flog2", "srgb", "srgb"),
+        )
+
+    def test_flog2_preserving_metadata_detection(self):
+        lut = baker.CubeLUT(
+            2,
+            [(0, 0, 0)] * 8,
+            metadata={
+                "gamma": "F-Log2 to F-Log2",
+                "gamut": "F-Gamut to ITU-R BT.709",
+            },
+        )
+        self.assertEqual(baker.infer_fujifilm_spec(lut).output_transfer, "flog2")
+
+    def test_explicit_transform_without_preset(self):
+        lut = baker.CubeLUT(2, [(0, 0, 0)] * 8)
+        spec = baker.resolve_transform_spec(
+            lut,
+            "none",
+            "f-gamut",
+            "f-log2",
+            "bt709",
+            "srgb",
+        )
+        self.assertEqual(spec, baker.TransformSpec("rec2020", "flog2", "srgb", "srgb"))
+
+    def test_identity_composition(self):
+        identity = baker.CubeLUT(
+            2,
+            [
+                (0, 0, 0), (1, 0, 0),
+                (0, 1, 0), (1, 1, 0),
+                (0, 0, 1), (1, 0, 1),
+                (0, 1, 1), (1, 1, 1),
+            ],
+        )
+        spec = baker.TransformSpec("rec2020", "srgb", "rec2020", "srgb")
+        values = list(baker.iter_baked_values(identity, spec, 3))
+        for blue in range(3):
+            for green in range(3):
+                for red in range(3):
+                    index = red + green * 3 + blue * 9
+                    expected = (red / 2, green / 2, blue / 2)
+                    for actual_channel, expected_channel in zip(values[index], expected):
+                        self.assertAlmostEqual(actual_channel, expected_channel, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_bake_cube_lut.py
+++ b/tools/tests/test_bake_cube_lut.py
@@ -47,6 +47,11 @@ class CubeParsingTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "expected 8"):
             self.read(cube_text([(0, 0, 0)] * 7))
 
+    def test_rejects_non_finite_values(self):
+        values = [(0, 0, 0)] * 7 + [(float("inf"), 0, 0)]
+        with self.assertRaisesRegex(ValueError, "non-finite LUT entry"):
+            self.read(cube_text(values))
+
 
 class TetrahedralInterpolationTest(unittest.TestCase):
     VALUES = (
@@ -101,6 +106,15 @@ class TetrahedralInterpolationTest(unittest.TestCase):
 
 
 class TransferFunctionTest(unittest.TestCase):
+    def test_extended_srgb_round_trip(self):
+        for value in (-0.25, 0.0, 0.5, 1.0, 1.5, 2.0):
+            with self.subTest(value=value):
+                self.assertAlmostEqual(
+                    baker.srgb_encode(baker.srgb_decode(value)),
+                    value,
+                    places=12,
+                )
+
     def test_flog2_cut_points(self):
         self.assertAlmostEqual(baker.flog2_encode(0.000889), 0.100686685370811, places=14)
         self.assertAlmostEqual(baker.flog2_decode(0.100686685370811), 0.000889, places=14)
@@ -168,6 +182,38 @@ class TransformTest(unittest.TestCase):
                     expected = (red / 2, green / 2, blue / 2)
                     for actual_channel, expected_channel in zip(values[index], expected):
                         self.assertAlmostEqual(actual_channel, expected_channel, places=12)
+
+    def test_extended_source_output_is_not_clamped(self):
+        extended = (-0.25, 1.5, 2.0)
+        lut = baker.CubeLUT(2, [extended] * 8)
+        spec = baker.TransformSpec("rec2020", "srgb", "rec2020", "srgb")
+
+        actual = baker.transform_sample(lut, (0.25, 0.5, 0.75), spec)
+
+        for actual_channel, expected_channel in zip(actual, extended):
+            self.assertAlmostEqual(actual_channel, expected_channel, places=12)
+
+    def test_extended_values_are_written_to_cube(self):
+        extended = (-0.25, 1.5, 2.0)
+        source = baker.CubeLUT(2, [extended] * 8)
+        spec = baker.TransformSpec("rec2020", "srgb", "rec2020", "srgb")
+
+        with tempfile.TemporaryDirectory() as directory:
+            directory_path = Path(directory)
+            output_path = directory_path / "extended_Rec2020.cube"
+            baker.write_cube(
+                output_path,
+                directory_path / "source.cube",
+                source,
+                spec,
+                2,
+                [extended] * 8,
+            )
+            written = baker.read_cube(output_path)
+            contents = output_path.read_text(encoding="utf-8")
+
+        self.assertEqual(written.values, [extended] * 8)
+        self.assertIn("# Output values may be outside 0.0 to 1.0", contents)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds 3D Adobe/DaVinci Resolve `.cube` LUT support to Film Simulation alongside the existing Hald CLUT formats, addressing #5704.

This work builds on the original implementation by Nicolò Santamaria (@NicoNex) in #7675. His original commit and authorship are preserved in this branch. The implementation has subsequently been extended to follow Cube semantics more closely, preserve valid intermediate colour values, and support technical LUTs whose transfer function or gamut does not directly match RawTherapee’s Film Simulation pipeline.

## Why Cube LUTs use float storage

Cube outputs are not restricted to `[0,1]`. Negative values and values above 1 are valid intermediate results used for gamut conversion, log transforms, and highlight headroom. Clamping them while loading changes the transform before RawTherapee can convert the result back into its working profile.

For example, a baked Fujifilm 65³ F-Log2-to-F-Log2 LUT contains 50 negative channel samples and 65,195 samples above 1, reaching 1.595. Reala Ace, ETERNA, and WDR remain within `[0,1]`, so retaining extended values does not alter those ordinary creative LUTs.

Cube vertices are therefore stored as aligned RGBX floats. Values inside `[0,1]` retain the existing inverse-sRGB table path; extended values use the corresponding analytic inverse transfer. Profile conversion remains unclipped, allowing intermediate values to return to the displayable range later in the pipeline.

The memory cost is approximately 0.55 MiB for a 33³ LUT and 4.2 MiB for a 65³ LUT; the specification maximum of 256³ requires about 256 MiB. Hald CLUTs remain on their original `uint16_t` path and produce unchanged output.

## Changes beyond the original implementation

- Applies `DOMAIN_MIN/MAX` to input coordinates and validates finite, ordered bounds.
- Enforces the 2–256 grid-size range with overflow-safe allocation and bounded parsing.
- Accepts leading whitespace on keyword lines.
- Uses Adobe-compatible tetrahedral interpolation for Cube LUTs while retaining Hald’s trilinear interpolation.
- Provides matching scalar and SSE2/SIMDe Cube interpolation paths.
- Preserves finite Cube outputs below 0 and above 1 through strength blending, inverse transfer, and profile conversion.
- Includes and installs `bake_cube_lut.py`, a standard-library Python tool for adapting technical LUTs to RawTherapee’s Film Simulation pipeline.
- The baker converts the source transfer function and gamut into RawTherapee’s `_Rec2020.cube` convention and tetrahedrally resamples the source LUT to the requested grid size. This allows LUTs designed for inputs such as Fujifilm F-Log2/F-Gamut to be used without adding vendor-specific transforms to the runtime processing pipeline.
- Supports automatic Fujifilm metadata recognition and explicit input/output gamut and transfer options for LUTs from other vendors.
- Includes usage documentation and standard-library tests for the baking workflow.

## Validation

Tested native, generic SSE2, and SIMDe builds. Synthetic LUTs cover all six tetrahedra, boundaries, endpoints, domains, extended values, and 0%, 50%, and 100% strength. Identity Cube output and 0% Film Simulation match their references, while existing Hald output remains pixel-identical.

The baker tests parsing, domains, transfer-function round trips, metadata recognition, tetrahedral interpolation, identity composition, resampling, and extended output. Representative Fujifilm Reala Ace, ETERNA, WDR, and F-Log2-preserving LUTs were also baked and processed through `rawtherapee-cli`.

Film Simulation input remains limited to `[0,1]`; 1D/shaper LUTs, tone mapping, and final-export clipping policy remain outside this PR.

---

AI assistance: This work was developed with assistance from OpenAI Codex / ChatGPT.
